### PR TITLE
Moved forecasting to official folder

### DIFF
--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -1,1423 +1,1065 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title"
-   },
-   "source": [
-    "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-    "      Open in Google Cloud Notebooks\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:automl"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "\n",
-    "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:covid,forecast"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:automl,training,batch_prediction"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Create a Vertex `Dataset` resource.\n",
-    "- Train the model.\n",
-    "- View the model evaluation.\n",
-    "- Make a batch prediction.\n",
-    "\n",
-    "There is one key difference between using batch prediction and using online prediction:\n",
-    "\n",
-    "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
-    "\n",
-    "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
-    "\n",
-    "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
-    "\n",
-    "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_tensorflow"
-   },
-   "outputs": [],
-   "source": [
-    "if os.environ[\"IS_TESTING\"]:\n",
-    "    ! pip3 install --upgrade tensorflow $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "# PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-    "\n",
-    "PROJECT_ID = \"python-docs-samples-tests\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Updated property [core/project].\n"
-     ]
-    }
-   ],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: GOOGLE_APPLICATION_CREDENTIALS=''\n"
-     ]
-    }
-   ],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}\n",
-    "\n",
-    "BUCKET_NAME = \"gs://ivanmkc-test2\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating gs://ivanmkc-test2/...\n",
-      "ServiceException: 409 A Cloud Storage bucket named 'ivanmkc-test2' already exists. Try another name. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization.\n"
-     ]
-    }
-   ],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      2073  2021-05-07T17:20:31Z  gs://ivanmkc-test2/aiplatform-2021-05-07-13:20:30.406-aiplatform_custom_trainer_script-0.1.tar.gz#1620408031014708  metageneration=1\n",
-      "      2085  2021-05-11T01:39:31Z  gs://ivanmkc-test2/aiplatform-2021-05-10-21:39:30.859-aiplatform_custom_trainer_script-0.1.tar.gz#1620697171325511  metageneration=1\n",
-      "      3165  2021-05-18T01:01:54Z  gs://ivanmkc-test2/aiplatform-2021-05-17-21:01:54.120-aiplatform_custom_trainer_script-0.1.tar.gz#1621299714675620  metageneration=1\n",
-      "      3188  2021-05-18T18:00:44Z  gs://ivanmkc-test2/aiplatform-2021-05-18-14:00:43.706-aiplatform_custom_trainer_script-0.1.tar.gz#1621360844345827  metageneration=1\n",
-      "      3174  2021-05-18T19:22:16Z  gs://ivanmkc-test2/aiplatform-2021-05-18-15:22:15.934-aiplatform_custom_trainer_script-0.1.tar.gz#1621365736630406  metageneration=1\n",
-      "      3182  2021-05-18T19:22:56Z  gs://ivanmkc-test2/aiplatform-2021-05-18-15:22:56.161-aiplatform_custom_trainer_script-0.1.tar.gz#1621365776739206  metageneration=1\n",
-      "      3191  2021-05-18T20:07:06Z  gs://ivanmkc-test2/aiplatform-2021-05-18-16:07:06.396-aiplatform_custom_trainer_script-0.1.tar.gz#1621368426945134  metageneration=1\n",
-      "      3166  2021-05-19T18:04:06Z  gs://ivanmkc-test2/aiplatform-2021-05-19-14:04:06.497-aiplatform_custom_trainer_script-0.1.tar.gz#1621447446989129  metageneration=1\n",
-      "      3170  2021-05-19T18:16:38Z  gs://ivanmkc-test2/aiplatform-2021-05-19-14:16:37.024-aiplatform_custom_trainer_script-0.1.tar.gz#1621448198742738  metageneration=1\n",
-      "      3199  2021-05-19T18:59:26Z  gs://ivanmkc-test2/aiplatform-2021-05-19-14:59:26.179-aiplatform_custom_trainer_script-0.1.tar.gz#1621450766704526  metageneration=1\n",
-      "      3193  2021-05-19T20:21:12Z  gs://ivanmkc-test2/aiplatform-2021-05-19-16:21:12.053-aiplatform_custom_trainer_script-0.1.tar.gz#1621455672552438  metageneration=1\n",
-      "      3191  2021-05-19T21:14:09Z  gs://ivanmkc-test2/aiplatform-2021-05-19-17:14:09.280-aiplatform_custom_trainer_script-0.1.tar.gz#1621458849768372  metageneration=1\n",
-      "      3177  2021-05-20T21:32:39Z  gs://ivanmkc-test2/aiplatform-2021-05-20-17:32:38.831-aiplatform_custom_trainer_script-0.1.tar.gz#1621546359429463  metageneration=1\n",
-      "      3180  2021-05-20T22:30:31Z  gs://ivanmkc-test2/aiplatform-2021-05-20-18:30:30.945-aiplatform_custom_trainer_script-0.1.tar.gz#1621549831483237  metageneration=1\n",
-      "      3161  2021-05-20T23:31:44Z  gs://ivanmkc-test2/aiplatform-2021-05-20-19:31:43.683-aiplatform_custom_trainer_script-0.1.tar.gz#1621553504272652  metageneration=1\n",
-      "      3146  2021-05-21T00:06:26Z  gs://ivanmkc-test2/aiplatform-2021-05-20-20:06:25.680-aiplatform_custom_trainer_script-0.1.tar.gz#1621555586066225  metageneration=1\n",
-      "      3191  2021-05-21T00:38:42Z  gs://ivanmkc-test2/aiplatform-2021-05-20-20:38:42.378-aiplatform_custom_trainer_script-0.1.tar.gz#1621557522775908  metageneration=1\n",
-      "      3159  2021-05-21T18:20:13Z  gs://ivanmkc-test2/aiplatform-2021-05-21-14:20:12.502-aiplatform_custom_trainer_script-0.1.tar.gz#1621621213059496  metageneration=1\n",
-      "      3159  2021-05-21T19:00:36Z  gs://ivanmkc-test2/aiplatform-2021-05-21-15:00:35.747-aiplatform_custom_trainer_script-0.1.tar.gz#1621623636250345  metageneration=1\n",
-      "      3172  2021-05-21T19:40:03Z  gs://ivanmkc-test2/aiplatform-2021-05-21-15:40:02.606-aiplatform_custom_trainer_script-0.1.tar.gz#1621626003043729  metageneration=1\n",
-      "      3213  2021-05-21T20:36:21Z  gs://ivanmkc-test2/aiplatform-2021-05-21-16:36:20.587-aiplatform_custom_trainer_script-0.1.tar.gz#1621629381181091  metageneration=1\n",
-      "      3224  2021-05-21T23:47:07Z  gs://ivanmkc-test2/aiplatform-2021-05-21-19:47:06.495-aiplatform_custom_trainer_script-0.1.tar.gz#1621640827040854  metageneration=1\n",
-      "      3272  2021-05-22T00:25:45Z  gs://ivanmkc-test2/aiplatform-2021-05-21-20:25:44.914-aiplatform_custom_trainer_script-0.1.tar.gz#1621643145442395  metageneration=1\n",
-      "      3287  2021-05-22T01:38:32Z  gs://ivanmkc-test2/aiplatform-2021-05-21-21:38:32.387-aiplatform_custom_trainer_script-0.1.tar.gz#1621647512885045  metageneration=1\n",
-      "      3265  2021-05-24T16:00:11Z  gs://ivanmkc-test2/aiplatform-2021-05-24-12:00:10.954-aiplatform_custom_trainer_script-0.1.tar.gz#1621872011543155  metageneration=1\n",
-      "      3089  2021-05-24T20:57:13Z  gs://ivanmkc-test2/aiplatform-2021-05-24-16:57:12.583-aiplatform_custom_trainer_script-0.1.tar.gz#1621889833155994  metageneration=1\n",
-      "      3052  2021-05-28T16:29:53Z  gs://ivanmkc-test2/aiplatform-2021-05-28-12:29:52.632-aiplatform_custom_trainer_script-0.1.tar.gz#1622219393114120  metageneration=1\n",
-      "      3048  2021-05-28T16:47:26Z  gs://ivanmkc-test2/aiplatform-2021-05-28-12:47:25.868-aiplatform_custom_trainer_script-0.1.tar.gz#1622220446321981  metageneration=1\n",
-      "      3047  2021-05-28T17:03:00Z  gs://ivanmkc-test2/aiplatform-2021-05-28-13:03:00.476-aiplatform_custom_trainer_script-0.1.tar.gz#1622221380958831  metageneration=1\n",
-      "      3034  2021-05-28T17:11:24Z  gs://ivanmkc-test2/aiplatform-2021-05-28-13:11:23.766-aiplatform_custom_trainer_script-0.1.tar.gz#1622221884244794  metageneration=1\n",
-      "      3032  2021-05-28T17:57:41Z  gs://ivanmkc-test2/aiplatform-2021-05-28-13:57:40.649-aiplatform_custom_trainer_script-0.1.tar.gz#1622224661093085  metageneration=1\n",
-      "      3039  2021-05-28T18:20:45Z  gs://ivanmkc-test2/aiplatform-2021-05-28-14:20:45.562-aiplatform_custom_trainer_script-0.1.tar.gz#1622226045927498  metageneration=1\n",
-      "      2980  2021-05-28T16:40:49Z  gs://ivanmkc-test2/aiplatform-2021-05-28-16:40:49.672-aiplatform_custom_trainer_script-0.1.tar.gz#1622220049755693  metageneration=1\n",
-      "      3024  2021-06-01T17:18:15Z  gs://ivanmkc-test2/aiplatform-2021-06-01-13:18:14.630-aiplatform_custom_trainer_script-0.1.tar.gz#1622567895125402  metageneration=1\n",
-      "      3545  2021-06-01T17:59:28Z  gs://ivanmkc-test2/aiplatform-2021-06-01-13:59:28.229-aiplatform_custom_trainer_script-0.1.tar.gz#1622570368704609  metageneration=1\n",
-      "      3540  2021-06-01T18:33:11Z  gs://ivanmkc-test2/aiplatform-2021-06-01-14:33:11.172-aiplatform_custom_trainer_script-0.1.tar.gz#1622572391651243  metageneration=1\n",
-      "      3573  2021-06-01T19:40:31Z  gs://ivanmkc-test2/aiplatform-2021-06-01-15:40:30.907-aiplatform_custom_trainer_script-0.1.tar.gz#1622576431859672  metageneration=1\n",
-      "      3624  2021-06-01T20:31:42Z  gs://ivanmkc-test2/aiplatform-2021-06-01-16:31:41.567-aiplatform_custom_trainer_script-0.1.tar.gz#1622579502078080  metageneration=1\n",
-      "      3640  2021-06-01T21:37:20Z  gs://ivanmkc-test2/aiplatform-2021-06-01-17:37:20.488-aiplatform_custom_trainer_script-0.1.tar.gz#1622583440980424  metageneration=1\n",
-      "      3632  2021-06-02T00:08:16Z  gs://ivanmkc-test2/aiplatform-2021-06-01-20:08:15.701-aiplatform_custom_trainer_script-0.1.tar.gz#1622592496091322  metageneration=1\n",
-      "      3628  2021-06-02T01:32:41Z  gs://ivanmkc-test2/aiplatform-2021-06-01-21:32:40.695-aiplatform_custom_trainer_script-0.1.tar.gz#1622597561163990  metageneration=1\n",
-      "      3632  2021-06-02T01:56:56Z  gs://ivanmkc-test2/aiplatform-2021-06-01-21:56:56.473-aiplatform_custom_trainer_script-0.1.tar.gz#1622599016978016  metageneration=1\n",
-      "      3621  2021-06-02T02:11:24Z  gs://ivanmkc-test2/aiplatform-2021-06-01-22:11:23.911-aiplatform_custom_trainer_script-0.1.tar.gz#1622599884367514  metageneration=1\n",
-      "      3625  2021-06-02T02:19:50Z  gs://ivanmkc-test2/aiplatform-2021-06-01-22:19:50.384-aiplatform_custom_trainer_script-0.1.tar.gz#1622600390800752  metageneration=1\n",
-      "      3614  2021-06-02T03:04:43Z  gs://ivanmkc-test2/aiplatform-2021-06-01-23:04:43.071-aiplatform_custom_trainer_script-0.1.tar.gz#1622603083406290  metageneration=1\n",
-      "      3625  2021-06-02T04:07:08Z  gs://ivanmkc-test2/aiplatform-2021-06-02-00:07:08.086-aiplatform_custom_trainer_script-0.1.tar.gz#1622606828498448  metageneration=1\n",
-      "      3630  2021-06-02T15:26:08Z  gs://ivanmkc-test2/aiplatform-2021-06-02-11:26:08.476-aiplatform_custom_trainer_script-0.1.tar.gz#1622647568917873  metageneration=1\n",
-      "      4101  2021-06-02T22:41:58Z  gs://ivanmkc-test2/aiplatform-2021-06-02-18:41:57.632-aiplatform_custom_trainer_script-0.1.tar.gz#1622673718024533  metageneration=1\n",
-      "      4093  2021-06-02T23:11:39Z  gs://ivanmkc-test2/aiplatform-2021-06-02-19:11:39.011-aiplatform_custom_trainer_script-0.1.tar.gz#1622675499489089  metageneration=1\n",
-      "      4440  2021-06-03T00:17:59Z  gs://ivanmkc-test2/aiplatform-2021-06-02-20:17:59.417-aiplatform_custom_trainer_script-0.1.tar.gz#1622679479939511  metageneration=1\n",
-      "      4412  2021-06-03T00:52:03Z  gs://ivanmkc-test2/aiplatform-2021-06-02-20:52:02.747-aiplatform_custom_trainer_script-0.1.tar.gz#1622681523242749  metageneration=1\n",
-      "      4422  2021-06-03T14:00:43Z  gs://ivanmkc-test2/aiplatform-2021-06-03-10:00:43.496-aiplatform_custom_trainer_script-0.1.tar.gz#1622728843923195  metageneration=1\n",
-      "      4428  2021-06-03T15:39:32Z  gs://ivanmkc-test2/aiplatform-2021-06-03-11:39:31.637-aiplatform_custom_trainer_script-0.1.tar.gz#1622734772182576  metageneration=1\n",
-      "      4425  2021-06-03T17:58:23Z  gs://ivanmkc-test2/aiplatform-2021-06-03-13:58:23.361-aiplatform_custom_trainer_script-0.1.tar.gz#1622743103871466  metageneration=1\n",
-      "      4464  2021-06-03T19:52:00Z  gs://ivanmkc-test2/aiplatform-2021-06-03-15:52:00.431-aiplatform_custom_trainer_script-0.1.tar.gz#1622749920939026  metageneration=1\n",
-      "      4386  2021-06-03T23:19:04Z  gs://ivanmkc-test2/aiplatform-2021-06-03-19:19:04.384-aiplatform_custom_trainer_script-0.1.tar.gz#1622762344899425  metageneration=1\n",
-      "      4418  2021-06-04T00:01:30Z  gs://ivanmkc-test2/aiplatform-2021-06-03-20:01:29.518-aiplatform_custom_trainer_script-0.1.tar.gz#1622764890013782  metageneration=1\n",
-      "      4423  2021-06-04T23:13:20Z  gs://ivanmkc-test2/aiplatform-2021-06-04-19:13:19.899-aiplatform_custom_trainer_script-0.1.tar.gz#1622848400420717  metageneration=1\n",
-      "      4374  2021-06-05T01:44:29Z  gs://ivanmkc-test2/aiplatform-2021-06-04-21:44:29.038-aiplatform_custom_trainer_script-0.1.tar.gz#1622857469478397  metageneration=1\n",
-      "      4352  2021-06-04T23:16:57Z  gs://ivanmkc-test2/aiplatform-2021-06-04-23:16:57.596-aiplatform_custom_trainer_script-0.1.tar.gz#1622848617677052  metageneration=1\n",
-      "      4372  2021-06-07T19:26:12Z  gs://ivanmkc-test2/aiplatform-2021-06-07-15:26:11.765-aiplatform_custom_trainer_script-0.1.tar.gz#1623093972165874  metageneration=1\n",
-      "      4382  2021-06-07T22:55:17Z  gs://ivanmkc-test2/aiplatform-2021-06-07-18:55:16.961-aiplatform_custom_trainer_script-0.1.tar.gz#1623106517370141  metageneration=1\n",
-      "      4387  2021-06-07T23:59:44Z  gs://ivanmkc-test2/aiplatform-2021-06-07-19:59:43.853-aiplatform_custom_trainer_script-0.1.tar.gz#1623110384333039  metageneration=1\n",
-      "      4369  2021-06-08T00:57:53Z  gs://ivanmkc-test2/aiplatform-2021-06-07-20:57:52.921-aiplatform_custom_trainer_script-0.1.tar.gz#1623113873466108  metageneration=1\n",
-      "      4421  2021-06-08T02:09:34Z  gs://ivanmkc-test2/aiplatform-2021-06-07-22:09:33.865-aiplatform_custom_trainer_script-0.1.tar.gz#1623118174336015  metageneration=1\n",
-      "      4417  2021-06-08T05:13:29Z  gs://ivanmkc-test2/aiplatform-2021-06-08-01:13:28.810-aiplatform_custom_trainer_script-0.1.tar.gz#1623129209289510  metageneration=1\n",
-      "      4414  2021-06-09T16:34:14Z  gs://ivanmkc-test2/aiplatform-2021-06-09-12:34:13.709-aiplatform_custom_trainer_script-0.1.tar.gz#1623256454161825  metageneration=1\n",
-      "      4370  2021-06-09T17:18:52Z  gs://ivanmkc-test2/aiplatform-2021-06-09-13:18:51.720-aiplatform_custom_trainer_script-0.1.tar.gz#1623259132185318  metageneration=1\n",
-      "      4398  2021-06-09T18:29:46Z  gs://ivanmkc-test2/aiplatform-2021-06-09-14:29:46.275-aiplatform_custom_trainer_script-0.1.tar.gz#1623263386712302  metageneration=1\n",
-      "      4499  2021-06-09T20:52:30Z  gs://ivanmkc-test2/aiplatform-2021-06-09-16:52:29.780-aiplatform_custom_trainer_script-0.1.tar.gz#1623271950266058  metageneration=1\n",
-      "      4394  2021-06-09T21:19:01Z  gs://ivanmkc-test2/aiplatform-2021-06-09-17:19:00.779-aiplatform_custom_trainer_script-0.1.tar.gz#1623273541292747  metageneration=1\n",
-      "      4434  2021-06-09T22:03:33Z  gs://ivanmkc-test2/aiplatform-2021-06-09-18:03:32.546-aiplatform_custom_trainer_script-0.1.tar.gz#1623276213031402  metageneration=1\n",
-      "      4543  2021-06-10T01:00:27Z  gs://ivanmkc-test2/aiplatform-2021-06-09-21:00:27.118-aiplatform_custom_trainer_script-0.1.tar.gz#1623286827711145  metageneration=1\n",
-      "      4563  2021-06-10T16:05:58Z  gs://ivanmkc-test2/aiplatform-2021-06-10-12:05:58.066-aiplatform_custom_trainer_script-0.1.tar.gz#1623341158516195  metageneration=1\n",
-      "      4570  2021-06-10T19:12:23Z  gs://ivanmkc-test2/aiplatform-2021-06-10-15:12:22.693-aiplatform_custom_trainer_script-0.1.tar.gz#1623352343699661  metageneration=1\n",
-      "      4569  2021-06-10T20:45:07Z  gs://ivanmkc-test2/aiplatform-2021-06-10-16:45:06.379-aiplatform_custom_trainer_script-0.1.tar.gz#1623357907612822  metageneration=1\n",
-      "      4577  2021-06-10T21:22:02Z  gs://ivanmkc-test2/aiplatform-2021-06-10-17:22:02.412-aiplatform_custom_trainer_script-0.1.tar.gz#1623360122913336  metageneration=1\n",
-      "      4180  2021-06-10T19:56:10Z  gs://ivanmkc-test2/aiplatform-2021-06-10-19:56:10.068-aiplatform_custom_trainer_script-0.1.tar.gz#1623354970160766  metageneration=1\n",
-      "      4171  2021-06-10T21:02:45Z  gs://ivanmkc-test2/aiplatform-2021-06-10-21:02:45.462-aiplatform_custom_trainer_script-0.1.tar.gz#1623358965561193  metageneration=1\n",
-      "      4419  2021-06-11T03:59:35Z  gs://ivanmkc-test2/aiplatform-2021-06-10-23:59:35.280-aiplatform_custom_trainer_script-0.1.tar.gz#1623383975709393  metageneration=1\n",
-      "      4368  2021-06-11T02:51:03Z  gs://ivanmkc-test2/aiplatform-2021-06-11-02:51:03.445-aiplatform_custom_trainer_script-0.1.tar.gz#1623379863584974  metageneration=1\n",
-      "      4174  2021-06-11T02:53:59Z  gs://ivanmkc-test2/aiplatform-2021-06-11-02:53:59.753-aiplatform_custom_trainer_script-0.1.tar.gz#1623380039821880  metageneration=1\n",
-      "      4174  2021-06-11T02:55:43Z  gs://ivanmkc-test2/aiplatform-2021-06-11-02:55:43.636-aiplatform_custom_trainer_script-0.1.tar.gz#1623380143732884  metageneration=1\n",
-      "      4364  2021-06-11T15:54:50Z  gs://ivanmkc-test2/aiplatform-2021-06-11-15:54:49.928-aiplatform_custom_trainer_script-0.1.tar.gz#1623426890033146  metageneration=1\n",
-      "      4174  2021-06-11T15:55:54Z  gs://ivanmkc-test2/aiplatform-2021-06-11-15:55:54.863-aiplatform_custom_trainer_script-0.1.tar.gz#1623426954945872  metageneration=1\n",
-      "      4177  2021-06-11T21:44:31Z  gs://ivanmkc-test2/aiplatform-2021-06-11-21:44:31.164-aiplatform_custom_trainer_script-0.1.tar.gz#1623447871251848  metageneration=1\n",
-      "      4371  2021-06-12T00:24:21Z  gs://ivanmkc-test2/aiplatform-2021-06-12-00:24:21.150-aiplatform_custom_trainer_script-0.1.tar.gz#1623457461228775  metageneration=1\n",
-      "      4174  2021-06-12T00:25:04Z  gs://ivanmkc-test2/aiplatform-2021-06-12-00:25:04.853-aiplatform_custom_trainer_script-0.1.tar.gz#1623457504927369  metageneration=1\n",
-      "      4542  2021-06-14T18:18:49Z  gs://ivanmkc-test2/aiplatform-2021-06-14-14:18:49.306-aiplatform_custom_trainer_script-0.1.tar.gz#1623694729656688  metageneration=1\n",
-      "      4497  2021-06-14T18:51:53Z  gs://ivanmkc-test2/aiplatform-2021-06-14-14:51:53.281-aiplatform_custom_trainer_script-0.1.tar.gz#1623696713748372  metageneration=1\n",
-      "      4518  2021-06-14T19:21:25Z  gs://ivanmkc-test2/aiplatform-2021-06-14-15:21:25.265-aiplatform_custom_trainer_script-0.1.tar.gz#1623698485729153  metageneration=1\n",
-      "      4370  2021-06-14T16:18:49Z  gs://ivanmkc-test2/aiplatform-2021-06-14-16:18:49.870-aiplatform_custom_trainer_script-0.1.tar.gz#1623687529960720  metageneration=1\n",
-      "      4173  2021-06-14T16:20:50Z  gs://ivanmkc-test2/aiplatform-2021-06-14-16:20:50.528-aiplatform_custom_trainer_script-0.1.tar.gz#1623687650603991  metageneration=1\n",
-      "      4495  2021-06-14T22:19:31Z  gs://ivanmkc-test2/aiplatform-2021-06-14-18:19:31.421-aiplatform_custom_trainer_script-0.1.tar.gz#1623709171971703  metageneration=1\n",
-      "      4500  2021-06-14T23:03:50Z  gs://ivanmkc-test2/aiplatform-2021-06-14-19:03:50.124-aiplatform_custom_trainer_script-0.1.tar.gz#1623711830658234  metageneration=1\n",
-      "      4482  2021-06-14T23:36:37Z  gs://ivanmkc-test2/aiplatform-2021-06-14-19:36:36.691-aiplatform_custom_trainer_script-0.1.tar.gz#1623713797207622  metageneration=1\n",
-      "      4363  2021-06-15T23:28:45Z  gs://ivanmkc-test2/aiplatform-2021-06-15-23:28:45.335-aiplatform_custom_trainer_script-0.1.tar.gz#1623799725435678  metageneration=1\n",
-      "      4175  2021-06-15T23:29:35Z  gs://ivanmkc-test2/aiplatform-2021-06-15-23:29:34.903-aiplatform_custom_trainer_script-0.1.tar.gz#1623799775014476  metageneration=1\n",
-      "       297  2021-06-15T23:29:32Z  gs://ivanmkc-test2/mean_and_std.json#1623799772321868  metageneration=1\n",
-      "     72467  2021-05-07T22:38:47Z  gs://ivanmkc-test2/rossman_train.csv#1620427127449479  metageneration=1\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-07-13:20:30.758/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-10-21:39:31.212/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-18-16:07:06.791/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-24-16:57:13.090/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-12:29:52.977/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-12:47:26.210/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-13:03:00.832/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-13:11:24.121/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-16:40:49.786/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-02-11:26:08.836/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-03-15:52:00.866/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-03-20:01:29.907/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-04-19:13:20.241/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-04-23:16:57.699/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-09-12:34:14.067/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-09-18:03:32.931/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-12:05:58.474/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-15:12:23.142/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-17:22:02.812/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-19:56:10.189/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-21:02:45.589/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-23:59:35.663/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-02:51:03.614/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-02:53:59.834/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-02:55:43.764/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-15:54:50.054/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-15:55:54.968/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-21:44:31.279/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-12-00:24:21.240/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-12-00:25:04.936/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-14:18:49.653/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-15:21:25.622/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-16:18:49.982/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-16:20:50.626/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-18:19:31.788/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-19:03:50.499/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-19:36:37.064/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-15-23:28:45.461/\n",
-      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-15-23:29:35.037/\n",
-      "                                 gs://ivanmkc-test2/artifacts/\n",
-      "                                 gs://ivanmkc-test2/cloudbuild-test/\n",
-      "                                 gs://ivanmkc-test2/code_archives/\n",
-      "                                 gs://ivanmkc-test2/data/\n",
-      "                                 gs://ivanmkc-test2/executed_notebooks/\n",
-      "                                 gs://ivanmkc-test2/keras-job-dir/\n",
-      "                                 gs://ivanmkc-test2/notebook-testing/\n",
-      "                                 gs://ivanmkc-test2/notebooks/\n",
-      "                                 gs://ivanmkc-test2/pipeline_root/\n",
-      "                                 gs://ivanmkc-test2/pipeline_staging/\n",
-      "TOTAL: 100 objects, 447899 bytes (437.4 KiB)\n"
-     ]
-    }
-   ],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aiplatform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex SDK for Python\n",
-    "\n",
-    "Initialize the Vertex SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "tutorial_start:automl"
-   },
-   "source": [
-    "# Tutorial\n",
-    "\n",
-    "Now you are ready to start creating your own AutoML tabular forecasting model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "import_file:u_dataset,csv"
-   },
-   "source": [
-    "#### Location of BigQuery training data.\n",
-    "\n",
-    "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "id": "import_file:covid,csv,forecast"
-   },
-   "outputs": [],
-   "source": [
-    "TRAINING_DATASET_BQ_PATH = (\n",
-    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_dataset:tabular,forecast"
-   },
-   "source": [
-    "### Create the Dataset\n",
-    "\n",
-    "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
-    "\n",
-    "- `display_name`: The human readable name for the `Dataset` resource.\n",
-    "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
-    "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
-    "\n",
-    "This operation may take several minutes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "id": "create_dataset:tabular,forecast"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.datasets.dataset:Creating TimeSeriesDataset\n",
-      "INFO:google.cloud.aiplatform.datasets.dataset:Create TimeSeriesDataset backing LRO: projects/1012616486416/locations/us-central1/datasets/5754817471500517376/operations/4979492517847236608\n",
-      "INFO:google.cloud.aiplatform.datasets.dataset:TimeSeriesDataset created. Resource name: projects/1012616486416/locations/us-central1/datasets/5754817471500517376\n",
-      "INFO:google.cloud.aiplatform.datasets.dataset:To use this TimeSeriesDataset in another session:\n",
-      "INFO:google.cloud.aiplatform.datasets.dataset:ds = aiplatform.TimeSeriesDataset('projects/1012616486416/locations/us-central1/datasets/5754817471500517376')\n",
-      "projects/1012616486416/locations/us-central1/datasets/5754817471500517376\n"
-     ]
-    }
-   ],
-   "source": [
-    "dataset = aiplatform.TimeSeriesDataset.create(\n",
-    "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
-    "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
-    ")\n",
-    "\n",
-    "time_column = \"date\"\n",
-    "time_series_identifier_column = \"store_name\"\n",
-    "target_column = \"sale_dollars\"\n",
-    "\n",
-    "print(dataset.resource_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "id": "f3575e7f7823"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'5754817471500517376'"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
       ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dataset.name"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "id": "set_transformations:covid"
-   },
-   "outputs": [],
-   "source": [
-    "# COLUMN_SPECS = {\n",
-    "#     time_column: \"timestamp\",\n",
-    "#     target_column: \"numeric\",\n",
-    "#     \"city\": \"categorical\",\n",
-    "#     \"zip_code\": \"categorical\",\n",
-    "#     \"county\": \"categorical\",\n",
-    "# }\n",
-    "\n",
-    "COLUMN_TRANSFORMATIONS = [\n",
-    "    {\"timestamp\": {\"column_name\": time_column}},\n",
-    "    {\"numeric\": {\"column_name\": target_column}},\n",
-    "    {\"categorical\": {\"column_name\": \"city\"}},\n",
-    "    {\"categorical\": {\"column_name\": \"zip_code\"}},\n",
-    "    {\"categorical\": {\"column_name\": \"county\"}},\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_automl_pipeline:tabular,forecast"
-   },
-   "source": [
-    "### Create and run training job\n",
-    "\n",
-    "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
-    "\n",
-    "#### Create training job\n",
-    "\n",
-    "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
-    "\n",
-    "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
-    "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
-    "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
-    "    - `minimize-rmse`\n",
-    "    - `minimize-mae`\n",
-    "    - `minimize-rmsle`\n",
-    "\n",
-    "The instantiated object is the job for the training pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "id": "create_automl_pipeline:tabular,forecast"
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
-    "\n",
-    "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
-    "    display_name=MODEL_DISPLAY_NAME,\n",
-    "    optimization_objective=\"minimize-rmse\",\n",
-    "    #     column_specs=COLUMN_SPECS,\n",
-    "    column_transformations=COLUMN_TRANSFORMATIONS,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_automl_pipeline:forecast"
-   },
-   "source": [
-    "#### Run the training pipeline\n",
-    "\n",
-    "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
-    "\n",
-    "- `dataset`: The `Dataset` resource to train the model.\n",
-    "- `model_display_name`: The human readable name for the trained model.\n",
-    "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
-    "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
-    "- `target_column`: The name of the column to train as the label.\n",
-    "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
-    "- `time_column`:\n",
-    "- `time_series_identifier_column`:\n",
-    "\n",
-    "The `run` method when completed returns the `Model` resource.\n",
-    "\n",
-    "The execution of the training pipeline will take up to 20 minutes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "id": "run_automl_pipeline:forecast"
-   },
-   "outputs": [
+    },
     {
-     "ename": "RuntimeError",
-     "evalue": "AutoML Forecasting Training has already run.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-30-9221afa26bde>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m model = training_job.run(\n\u001b[0m\u001b[1;32m      2\u001b[0m     \u001b[0mdataset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mtarget_column\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtarget_column\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m     \u001b[0mtime_column\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtime_column\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0mtime_series_identifier_column\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtime_series_identifier_column\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/aiplatform/training_jobs.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, dataset, target_column, time_column, time_series_identifier_column, unavailable_at_forecast_columns, available_at_forecast_columns, forecast_horizon, data_granularity_unit, data_granularity_count, predefined_split_column_name, weight_column, time_series_attribute_columns, context_window, export_evaluated_data_items, export_evaluated_data_items_bigquery_destination_uri, export_evaluated_data_items_override_destination, quantiles, validation_options, budget_milli_node_hours, model_display_name, sync)\u001b[0m\n\u001b[1;32m   3235\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3236\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_has_run\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3237\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mRuntimeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"AutoML Forecasting Training has already run.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3238\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3239\u001b[0m         return self._run(\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: AutoML Forecasting Training has already run."
-     ]
-    }
-   ],
-   "source": [
-    "model = training_job.run(\n",
-    "    dataset=dataset,\n",
-    "    target_column=target_column,\n",
-    "    time_column=time_column,\n",
-    "    time_series_identifier_column=time_series_identifier_column,\n",
-    "    available_at_forecast_columns=[time_column],\n",
-    "    unavailable_at_forecast_columns=[target_column],\n",
-    "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
-    "    forecast_horizon=30,\n",
-    "    context_window=30,\n",
-    "    data_granularity_unit=\"day\",\n",
-    "    data_granularity_count=1,\n",
-    "    weight_column=None,\n",
-    "    budget_milli_node_hours=1000,\n",
-    "    model_display_name=MODEL_DISPLAY_NAME,\n",
-    "    predefined_split_column_name=None,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "evaluate_the_model:mbsdk"
-   },
-   "source": [
-    "## Review model evaluation scores\n",
-    "After your model has finished training, you can review the evaluation scores for it.\n",
-    "\n",
-    "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "metadata": {
-    "id": "evaluate_the_model:mbsdk"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title"
+      },
+      "source": [
+        "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      Open in Google Cloud Notebooks\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "name: \"projects/1012616486416/locations/us-central1/models/5877624124230074368/evaluations/2405091353327963614\"\n",
-      "metrics_schema_uri: \"gs://google-cloud-aiplatform/schema/modelevaluation/forecasting_metrics_1.0.0.yaml\"\n",
-      "metrics {\n",
-      "  struct_value {\n",
-      "    fields {\n",
-      "      key: \"meanAbsoluteError\"\n",
-      "      value {\n",
-      "        number_value: 3915.58\n",
-      "      }\n",
-      "    }\n",
-      "    fields {\n",
-      "      key: \"meanAbsolutePercentageError\"\n",
-      "      value {\n",
-      "        number_value: 377.37677\n",
-      "      }\n",
-      "    }\n",
-      "    fields {\n",
-      "      key: \"rSquared\"\n",
-      "      value {\n",
-      "        number_value: 0.5439744\n",
-      "      }\n",
-      "    }\n",
-      "    fields {\n",
-      "      key: \"rootMeanSquaredError\"\n",
-      "      value {\n",
-      "        number_value: 8925.371\n",
-      "      }\n",
-      "    }\n",
-      "    fields {\n",
-      "      key: \"rootMeanSquaredLogError\"\n",
-      "      value {\n",
-      "        number_value: 0.934609\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      "create_time {\n",
-      "  seconds: 1636488192\n",
-      "  nanos: 183194000\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Get model resource ID\n",
-    "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
-    "model = models[0]\n",
-    "\n",
-    "# Get a reference to the Model Service client\n",
-    "client_options = aiplatform.initializer.global_config.get_client_options()\n",
-    "model_service_client = aiplatform.gapic.ModelServiceClient(client_options=client_options)\n",
-    "\n",
-    "model_evaluations = model_service_client.list_model_evaluations(\n",
-    "    parent=model.resource_name\n",
-    ")\n",
-    "model_evaluation = list(model_evaluations)[0]\n",
-    "print(model_evaluation)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "make_prediction"
-   },
-   "source": [
-    "## Send a batch prediction request\n",
-    "\n",
-    "Send a batch prediction to your deployed model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "batch_request:mbsdk,both_csv"
-   },
-   "source": [
-    "### Make the batch prediction request\n",
-    "\n",
-    "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
-    "\n",
-    "- `job_display_name`: The human readable name for the batch prediction job.\n",
-    "- `gcs_source`: A list of one or more batch request input files.\n",
-    "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
-    "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-    "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-    "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
-   "metadata": {
-    "id": "2c9d935c6ab9"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:automl"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "\n",
+        "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
+      ]
+    },
     {
-     "ename": "Conflict",
-     "evalue": "409 POST https://bigquery.googleapis.com/bigquery/v2/projects/python-docs-samples-tests/datasets?prettyPrint=false: Already Exists: Dataset python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mConflict\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-48-749ba24eacd2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0mdataset_region\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"US\"\u001b[0m  \u001b[0;31m# @param {type : \"string\"}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlocation\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdataset_region\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m \u001b[0mdataset\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreate_dataset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     18\u001b[0m print(\n\u001b[1;32m     19\u001b[0m     \"Created bigquery dataset {} in {}\".format(\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36mcreate_dataset\u001b[0;34m(self, dataset, exists_ok, retry, timeout)\u001b[0m\n\u001b[1;32m    598\u001b[0m             \u001b[0mspan_attributes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m\"path\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    599\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 600\u001b[0;31m             api_response = self._call_api(\n\u001b[0m\u001b[1;32m    601\u001b[0m                 \u001b[0mretry\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    602\u001b[0m                 \u001b[0mspan_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"BigQuery.createDataset\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36m_call_api\u001b[0;34m(self, retry, span_name, span_attributes, job_ref, **kwargs)\u001b[0m\n\u001b[1;32m    738\u001b[0m                 \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mattributes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_attributes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjob_ref\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mjob_ref\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    739\u001b[0m             ):\n\u001b[0;32m--> 740\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    741\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    742\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_wrapped_func\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    283\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_initial\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_maximum\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiplier\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_multiplier\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    284\u001b[0m             )\n\u001b[0;32m--> 285\u001b[0;31m             return retry_target(\n\u001b[0m\u001b[1;32m    286\u001b[0m                 \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    287\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_predicate\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_target\u001b[0;34m(target, predicate, sleep_generator, deadline, on_error)\u001b[0m\n\u001b[1;32m    186\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0msleep\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msleep_generator\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 188\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    189\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0;31m# pylint: disable=broad-except\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/_http.py\u001b[0m in \u001b[0;36mapi_request\u001b[0;34m(self, method, path, query_params, data, content_type, headers, api_base_url, api_version, expect_json, _target_object, timeout)\u001b[0m\n\u001b[1;32m    481\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    482\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;36m200\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m300\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 483\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_http_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    484\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    485\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mexpect_json\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mConflict\u001b[0m: 409 POST https://bigquery.googleapis.com/bigquery/v2/projects/python-docs-samples-tests/datasets?prettyPrint=false: Already Exists: Dataset python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "\n",
-    "from google.cloud import bigquery\n",
-    "\n",
-    "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
-    "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
-    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-    ")\n",
-    "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
-    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-    ")\n",
-    "# Must be the same region as batch_predict_bq_input_uri\n",
-    "client = bigquery.Client()\n",
-    "dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
-    "dataset_region = \"US\"  # @param {type : \"string\"}\n",
-    "dataset.location = dataset_region\n",
-    "dataset = client.create_dataset(dataset)\n",
-    "print(\n",
-    "    \"Created bigquery dataset {} in {}\".format(\n",
-    "        batch_predict_bq_output_dataset_path, dataset_region\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {
-    "id": "batch_request:mbsdk,both_csv"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:covid,forecast"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.jobs:Creating BatchPredictionJob\n",
-      "<google.cloud.aiplatform.jobs.BatchPredictionJob object at 0x14bc40280> is waiting for upstream dependencies to complete.\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob created. Resource name: projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224\n",
-      "INFO:google.cloud.aiplatform.jobs:To use this BatchPredictionJob in another session:\n",
-      "INFO:google.cloud.aiplatform.jobs:bpj = aiplatform.BatchPredictionJob('projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224')\n",
-      "INFO:google.cloud.aiplatform.jobs:View Batch Prediction Job:\n",
-      "https://console.cloud.google.com/ai/platform/locations/us-central1/batch-predictions/1776122496207028224?project=1012616486416\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n"
-     ]
-    }
-   ],
-   "source": [
-    "PREDICTION_DATASET_BQ_PATH = (\n",
-    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-    ")\n",
-    "\n",
-    "batch_prediction_job = model.batch_predict(\n",
-    "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
-    "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
-    "    instances_format=\"bigquery\",\n",
-    "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
-    "    predictions_format=\"bigquery\",\n",
-    "    sync=False,\n",
-    ")\n",
-    "\n",
-    "print(batch_prediction_job)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "batch_request_wait:mbsdk"
-   },
-   "source": [
-    "### Wait for completion of batch prediction job\n",
-    "\n",
-    "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {
-    "id": "batch_request_wait:mbsdk"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:automl,training,batch_prediction"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a Vertex `Dataset` resource.\n",
+        "- Train the model.\n",
+        "- View the model evaluation.\n",
+        "- Make a batch prediction.\n",
+        "\n",
+        "There is one key difference between using batch prediction and using online prediction:\n",
+        "\n",
+        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
+        "\n",
+        "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_RUNNING\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
-      "JobState.JOB_STATE_SUCCEEDED\n",
-      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob run completed. Resource name: projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224\n"
-     ]
-    }
-   ],
-   "source": [
-    "batch_prediction_job.wait()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "get_batch_prediction:mbsdk,forecast"
-   },
-   "source": [
-    "### Get the predictions\n",
-    "\n",
-    "Next, get the results from the completed batch prediction job.\n",
-    "\n",
-    "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
-    "\n",
-    "- CSV header + predicted_label\n",
-    "- CSV row + prediction, per prediction request"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {
-    "id": "get_batch_prediction:mbsdk,forecast"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
     {
-     "ename": "NotFound",
-     "evalue": "404 GET https://bigquery.googleapis.com/bigquery/v2/projects/1012616486416/datasets/iowa_liquor_sales_predictions_20211109124705/tables/predictions?prettyPrint=false: Not found: Table python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705.predictions",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNotFound\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-51-dd878a8e21fa>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtensorflow\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mtf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mbp_iter_outputs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbatch_prediction_job\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_outputs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mprediction_results\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/aiplatform/jobs.py\u001b[0m in \u001b[0;36miter_outputs\u001b[0;34m(self, bq_max_results)\u001b[0m\n\u001b[1;32m    821\u001b[0m             \u001b[0m_\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbq_dataset_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbq_dataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\".\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    822\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 823\u001b[0;31m             row_iterator = bq_client.list_rows(\n\u001b[0m\u001b[1;32m    824\u001b[0m                 \u001b[0mtable\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34mf\"{bq_dataset_id}.predictions\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmax_results\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mbq_max_results\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    825\u001b[0m             )\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36mlist_rows\u001b[0;34m(self, table, selected_fields, max_results, page_token, start_index, page_size, retry, timeout)\u001b[0m\n\u001b[1;32m   3579\u001b[0m         \u001b[0;31m# columns, so get the table resource for them rather than failing.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3580\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mschema\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3581\u001b[0;31m             \u001b[0mtable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_table\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreference\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mretry\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mretry\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3582\u001b[0m             \u001b[0mschema\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mschema\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3583\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36mget_table\u001b[0;34m(self, table, retry, timeout)\u001b[0m\n\u001b[1;32m    991\u001b[0m         \u001b[0mpath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtable_ref\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    992\u001b[0m         \u001b[0mspan_attributes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m\"path\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 993\u001b[0;31m         api_response = self._call_api(\n\u001b[0m\u001b[1;32m    994\u001b[0m             \u001b[0mretry\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    995\u001b[0m             \u001b[0mspan_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"BigQuery.getTable\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36m_call_api\u001b[0;34m(self, retry, span_name, span_attributes, job_ref, **kwargs)\u001b[0m\n\u001b[1;32m    738\u001b[0m                 \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mattributes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_attributes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjob_ref\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mjob_ref\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    739\u001b[0m             ):\n\u001b[0;32m--> 740\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    741\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    742\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_wrapped_func\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    283\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_initial\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_maximum\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiplier\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_multiplier\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    284\u001b[0m             )\n\u001b[0;32m--> 285\u001b[0;31m             return retry_target(\n\u001b[0m\u001b[1;32m    286\u001b[0m                 \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    287\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_predicate\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_target\u001b[0;34m(target, predicate, sleep_generator, deadline, on_error)\u001b[0m\n\u001b[1;32m    186\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0msleep\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msleep_generator\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 188\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    189\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0;31m# pylint: disable=broad-except\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/_http.py\u001b[0m in \u001b[0;36mapi_request\u001b[0;34m(self, method, path, query_params, data, content_type, headers, api_base_url, api_version, expect_json, _target_object, timeout)\u001b[0m\n\u001b[1;32m    481\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    482\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;36m200\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m300\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 483\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_http_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    484\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    485\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mexpect_json\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNotFound\u001b[0m: 404 GET https://bigquery.googleapis.com/bigquery/v2/projects/1012616486416/datasets/iowa_liquor_sales_predictions_20211109124705/tables/predictions?prettyPrint=false: Not found: Table python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705.predictions"
-     ]
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
+        "\n",
+        "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
+        "\n",
+        "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_tensorflow"
+      },
+      "outputs": [],
+      "source": [
+        "if os.environ[\"IS_TESTING\"]:\n",
+        "    ! pip3 install --upgrade tensorflow $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"[your-region]\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aiplatform"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex SDK for Python\n",
+        "\n",
+        "Initialize the Vertex SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tutorial_start:automl"
+      },
+      "source": [
+        "# Tutorial\n",
+        "\n",
+        "Now you are ready to start creating your own AutoML tabular forecasting model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "import_file:u_dataset,csv"
+      },
+      "source": [
+        "#### Location of BigQuery training data.\n",
+        "\n",
+        "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_file:covid,csv,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "TRAINING_DATASET_BQ_PATH = (\n",
+        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_dataset:tabular,forecast"
+      },
+      "source": [
+        "### Create the Dataset\n",
+        "\n",
+        "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
+        "\n",
+        "- `display_name`: The human readable name for the `Dataset` resource.\n",
+        "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
+        "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
+        "\n",
+        "This operation may take several minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_dataset:tabular,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "dataset = aiplatform.TimeSeriesDataset.create(\n",
+        "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
+        "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
+        ")\n",
+        "\n",
+        "time_column = \"date\"\n",
+        "time_series_identifier_column = \"store_name\"\n",
+        "target_column = \"sale_dollars\"\n",
+        "\n",
+        "print(dataset.resource_name)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_transformations:covid"
+      },
+      "outputs": [],
+      "source": [
+        "COLUMN_SPECS = {\n",
+        "    time_column: \"timestamp\",\n",
+        "    target_column: \"numeric\",\n",
+        "    \"city\": \"categorical\",\n",
+        "    \"zip_code\": \"categorical\",\n",
+        "    \"county\": \"categorical\",\n",
+        "}\n",
+        "\n",
+        "# COLUMN_TRANSFORMATIONS = [\n",
+        "#     {\"timestamp\": {\"column_name\": time_column}},\n",
+        "#     {\"numeric\": {\"column_name\": target_column}},\n",
+        "#     {\"categorical\": {\"column_name\": \"city\"}},\n",
+        "#     {\"categorical\": {\"column_name\": \"zip_code\"}},\n",
+        "#     {\"categorical\": {\"column_name\": \"county\"}},\n",
+        "# ]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_automl_pipeline:tabular,forecast"
+      },
+      "source": [
+        "### Create and run training job\n",
+        "\n",
+        "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
+        "\n",
+        "#### Create training job\n",
+        "\n",
+        "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
+        "\n",
+        "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
+        "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
+        "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
+        "    - `minimize-rmse`\n",
+        "    - `minimize-mae`\n",
+        "    - `minimize-rmsle`\n",
+        "\n",
+        "The instantiated object is the job for the training pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_automl_pipeline:tabular,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
+        "\n",
+        "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
+        "    display_name=MODEL_DISPLAY_NAME,\n",
+        "    optimization_objective=\"minimize-rmse\",\n",
+        "    #     column_specs=COLUMN_SPECS,\n",
+        "    column_transformations=COLUMN_TRANSFORMATIONS,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_automl_pipeline:forecast"
+      },
+      "source": [
+        "#### Run the training pipeline\n",
+        "\n",
+        "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
+        "\n",
+        "- `dataset`: The `Dataset` resource to train the model.\n",
+        "- `model_display_name`: The human readable name for the trained model.\n",
+        "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
+        "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
+        "- `target_column`: The name of the column to train as the label.\n",
+        "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
+        "- `time_column`:\n",
+        "- `time_series_identifier_column`:\n",
+        "\n",
+        "The `run` method when completed returns the `Model` resource.\n",
+        "\n",
+        "The execution of the training pipeline will take up to 20 minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_automl_pipeline:forecast"
+      },
+      "outputs": [],
+      "source": [
+        "model = training_job.run(\n",
+        "    dataset=dataset,\n",
+        "    target_column=target_column,\n",
+        "    time_column=time_column,\n",
+        "    time_series_identifier_column=time_series_identifier_column,\n",
+        "    available_at_forecast_columns=[time_column],\n",
+        "    unavailable_at_forecast_columns=[target_column],\n",
+        "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
+        "    forecast_horizon=30,\n",
+        "    context_window=30,\n",
+        "    data_granularity_unit=\"day\",\n",
+        "    data_granularity_count=1,\n",
+        "    weight_column=None,\n",
+        "    budget_milli_node_hours=1000,\n",
+        "    model_display_name=MODEL_DISPLAY_NAME,\n",
+        "    predefined_split_column_name=None,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "evaluate_the_model:mbsdk"
+      },
+      "source": [
+        "## Review model evaluation scores\n",
+        "After your model has finished training, you can review the evaluation scores for it.\n",
+        "\n",
+        "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "evaluate_the_model:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "# Get model resource ID\n",
+        "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
+        "model = models[0]\n",
+        "\n",
+        "# Get a reference to the Model Service client\n",
+        "client_options = aiplatform.initializer.global_config.get_client_options()\n",
+        "model_service_client = aiplatform.gapic.ModelServiceClient(\n",
+        "    client_options=client_options\n",
+        ")\n",
+        "\n",
+        "model_evaluations = model_service_client.list_model_evaluations(\n",
+        "    parent=model.resource_name\n",
+        ")\n",
+        "model_evaluation = list(model_evaluations)[0]\n",
+        "print(model_evaluation)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "make_prediction"
+      },
+      "source": [
+        "## Send a batch prediction request\n",
+        "\n",
+        "Send a batch prediction to your deployed model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "batch_request:mbsdk,both_csv"
+      },
+      "source": [
+        "### Make the batch prediction request\n",
+        "\n",
+        "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
+        "\n",
+        "- `job_display_name`: The human readable name for the batch prediction job.\n",
+        "- `gcs_source`: A list of one or more batch request input files.\n",
+        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
+        "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+        "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2c9d935c6ab9"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "from google.cloud import bigquery\n",
+        "\n",
+        "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
+        "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
+        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+        ")\n",
+        "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
+        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+        ")\n",
+        "# Must be the same region as batch_predict_bq_input_uri\n",
+        "client = bigquery.Client()\n",
+        "dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
+        "dataset_region = \"US\"  # @param {type : \"string\"}\n",
+        "dataset.location = dataset_region\n",
+        "dataset = client.create_dataset(dataset)\n",
+        "print(\n",
+        "    \"Created bigquery dataset {} in {}\".format(\n",
+        "        batch_predict_bq_output_dataset_path, dataset_region\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "batch_request:mbsdk,both_csv"
+      },
+      "outputs": [],
+      "source": [
+        "PREDICTION_DATASET_BQ_PATH = (\n",
+        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+        ")\n",
+        "\n",
+        "batch_prediction_job = model.batch_predict(\n",
+        "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
+        "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
+        "    instances_format=\"bigquery\",\n",
+        "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
+        "    predictions_format=\"bigquery\",\n",
+        "    sync=False,\n",
+        ")\n",
+        "\n",
+        "print(batch_prediction_job)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "batch_request_wait:mbsdk"
+      },
+      "source": [
+        "### Wait for completion of batch prediction job\n",
+        "\n",
+        "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "batch_request_wait:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "batch_prediction_job.wait()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "get_batch_prediction:mbsdk,forecast"
+      },
+      "source": [
+        "### Get the predictions\n",
+        "\n",
+        "Next, get the results from the completed batch prediction job.\n",
+        "\n",
+        "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
+        "\n",
+        "- CSV header + predicted_label\n",
+        "- CSV row + prediction, per prediction request"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "get_batch_prediction:mbsdk,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
+        "\n",
+        "prediction_results = list()\n",
+        "for blob in bp_iter_outputs:\n",
+        "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
+        "        prediction_results.append(blob.name)\n",
+        "\n",
+        "tags = list()\n",
+        "for prediction_result in prediction_results:\n",
+        "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
+        "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
+        "        for line in gfile.readlines():\n",
+        "            print(line)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "78080aa9088e"
+      },
+      "source": [
+        "### Visualize the forecasts\n",
+        "\n",
+        "Lastly, follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
+        "The code block included in this section dynamically generates a Data Studio link that specifies the template, the location of the forecasts, and the query to generate the chart. The data is populated from the forecasts generated earlier.\n",
+        "\n",
+        "You can inspect the used template at https://datastudio.google.com/c/u/0/reporting/067f70d2-8cd6-4a4c-a099-292acd1053e8. This was created by Google specifically to view forecasting predictions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f82f00be2160"
+      },
+      "outputs": [],
+      "source": [
+        "import urllib\n",
+        "\n",
+        "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
+        "\n",
+        "prediction_table_id = \"\"\n",
+        "for table in tables:\n",
+        "    if (\n",
+        "        table.table_id.startswith(\"predictions_\")\n",
+        "        and table.table_id > prediction_table_id\n",
+        "    ):\n",
+        "        prediction_table_id = table.table_id\n",
+        "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
+        "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
+        ")\n",
+        "\n",
+        "\n",
+        "def _sanitize_bq_uri(bq_uri):\n",
+        "    if bq_uri.startswith(\"bq://\"):\n",
+        "        bq_uri = bq_uri[5:]\n",
+        "    return bq_uri.replace(\":\", \".\")\n",
+        "\n",
+        "\n",
+        "def get_data_studio_link(\n",
+        "    batch_prediction_bq_input_uri,\n",
+        "    batch_prediction_bq_output_uri,\n",
+        "    time_column,\n",
+        "    time_series_identifier_column,\n",
+        "    target_column,\n",
+        "):\n",
+        "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
+        "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
+        "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
+        "    query = (\n",
+        "        \"SELECT \\\\n\"\n",
+        "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
+        "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
+        "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
+        "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
+        "        \" * \\\\n\"\n",
+        "        \"FROM `{}` input\\\\n\"\n",
+        "        \"LEFT JOIN `{}` output\\\\n\"\n",
+        "        \"ON\\\\n\"\n",
+        "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
+        "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
+        "    )\n",
+        "    query = query.format(\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        target_column,\n",
+        "        target_column,\n",
+        "        batch_prediction_bq_input_uri,\n",
+        "        batch_prediction_bq_output_uri,\n",
+        "        time_column,\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        time_series_identifier_column,\n",
+        "    )\n",
+        "    params = {\n",
+        "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
+        "        \"ds0.connector\": \"BIG_QUERY\",\n",
+        "        \"ds0.projectId\": PROJECT_ID,\n",
+        "        \"ds0.billingProjectId\": PROJECT_ID,\n",
+        "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
+        "        \"ds0.sql\": query,\n",
+        "    }\n",
+        "    params_str_parts = []\n",
+        "    for k, v in params.items():\n",
+        "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
+        "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
+        "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
+        "\n",
+        "\n",
+        "print(\n",
+        "    get_data_studio_link(\n",
+        "        PREDICTION_DATASET_BQ_PATH,\n",
+        "        batch_predict_bq_output_uri,\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        target_column,\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:mbsdk"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- AutoML Training Job\n",
+        "- Model\n",
+        "- Batch Prediction Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "# Delete dataset\n",
+        "dataset.delete()\n",
+        "\n",
+        "# Training job\n",
+        "training_job.delete()\n",
+        "\n",
+        "# Delete model\n",
+        "model.delete()\n",
+        "\n",
+        "# Delete batch prediction job\n",
+        "batch_prediction_job.delete()\n",
+        "\n",
+        "if os.getenv(\"IS_TESTING\"):\n",
+        "    ! gsutil rm -r $BUCKET_URI"
+      ]
     }
-   ],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
-    "\n",
-    "prediction_results = list()\n",
-    "for blob in bp_iter_outputs:\n",
-    "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
-    "        prediction_results.append(blob.name)\n",
-    "\n",
-    "tags = list()\n",
-    "for prediction_result in prediction_results:\n",
-    "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
-    "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
-    "        for line in gfile.readlines():\n",
-    "            print(line)"
-   ]
+  ],
+  "metadata": {
+    "colab": {
+      "name": "sdk_automl_tabular_forecasting_batch.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "f82f00be2160"
-   },
-   "outputs": [],
-   "source": [
-    "# @title # Visualize the Forecasts\n",
-    "# @markdown Follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
-    "\n",
-    "import urllib\n",
-    "\n",
-    "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
-    "\n",
-    "prediction_table_id = \"\"\n",
-    "for table in tables:\n",
-    "    if (\n",
-    "        table.table_id.startswith(\"predictions_\")\n",
-    "        and table.table_id > prediction_table_id\n",
-    "    ):\n",
-    "        prediction_table_id = table.table_id\n",
-    "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
-    "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
-    ")\n",
-    "\n",
-    "\n",
-    "def _sanitize_bq_uri(bq_uri):\n",
-    "    if bq_uri.startswith(\"bq://\"):\n",
-    "        bq_uri = bq_uri[5:]\n",
-    "    return bq_uri.replace(\":\", \".\")\n",
-    "\n",
-    "\n",
-    "def get_data_studio_link(\n",
-    "    batch_prediction_bq_input_uri,\n",
-    "    batch_prediction_bq_output_uri,\n",
-    "    time_column,\n",
-    "    time_series_identifier_column,\n",
-    "    target_column,\n",
-    "):\n",
-    "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
-    "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
-    "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
-    "    query = (\n",
-    "        \"SELECT \\\\n\"\n",
-    "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
-    "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
-    "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
-    "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
-    "        \" * \\\\n\"\n",
-    "        \"FROM `{}` input\\\\n\"\n",
-    "        \"LEFT JOIN `{}` output\\\\n\"\n",
-    "        \"ON\\\\n\"\n",
-    "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
-    "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
-    "    )\n",
-    "    query = query.format(\n",
-    "        time_column,\n",
-    "        time_series_identifier_column,\n",
-    "        target_column,\n",
-    "        target_column,\n",
-    "        batch_prediction_bq_input_uri,\n",
-    "        batch_prediction_bq_output_uri,\n",
-    "        time_column,\n",
-    "        time_column,\n",
-    "        time_series_identifier_column,\n",
-    "        time_series_identifier_column,\n",
-    "    )\n",
-    "    params = {\n",
-    "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
-    "        \"ds0.connector\": \"BIG_QUERY\",\n",
-    "        \"ds0.projectId\": PROJECT_ID,\n",
-    "        \"ds0.billingProjectId\": PROJECT_ID,\n",
-    "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
-    "        \"ds0.sql\": query,\n",
-    "    }\n",
-    "    params_str_parts = []\n",
-    "    for k, v in params.items():\n",
-    "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
-    "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
-    "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
-    "\n",
-    "\n",
-    "print(\n",
-    "    get_data_studio_link(\n",
-    "        PREDICTION_DATASET_BQ_PATH,\n",
-    "        batch_predict_bq_output_uri,\n",
-    "        time_column,\n",
-    "        time_series_identifier_column,\n",
-    "        target_column,\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:mbsdk"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- AutoML Training Job\n",
-    "- Model\n",
-    "- Batch Prediction Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "# Delete dataset\n",
-    "dataset.delete()\n",
-    "\n",
-    "# Training job\n",
-    "training_job.delete()\n",
-    "\n",
-    "# Delete model\n",
-    "model.delete()\n",
-    "\n",
-    "# Delete batch prediction job\n",
-    "batch_prediction_job.delete()\n",
-    "\n",
-    "if os.getenv(\"IS_TESTING\"):\n",
-    "    ! gsutil rm -r $BUCKET_URI"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "sdk_automl_tabular_forecasting_batch.ipynb",
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -670,7 +670,7 @@
         "\n",
         "The `run` method when completed returns the `Model` resource.\n",
         "\n",
-        "The execution of the training pipeline will take up to 20 minutes."
+        "The execution of the training pipeline will take up to one hour."
       ]
     },
     {

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -1037,7 +1037,7 @@
         "batch_prediction_job.delete()\n",
         "\n",
         "if os.getenv(\"IS_TESTING\"):\n",
-        "    ! gsutil rm -r $BUCKET_URI"
+        "    ! gsutil rm -r $BUCKET_NAME"
       ]
     }
   ],

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -1,1066 +1,1423 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title"
-      },
-      "source": [
-        "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-        "      Open in Google Cloud Notebooks\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:automl"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "\n",
-        "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:covid,forecast"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:automl,training,batch_prediction"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Create a Vertex `Dataset` resource.\n",
-        "- Train the model.\n",
-        "- View the model evaluation.\n",
-        "- Make a batch prediction.\n",
-        "\n",
-        "There is one key difference between using batch prediction and using online prediction:\n",
-        "\n",
-        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
-        "\n",
-        "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
-        "\n",
-        "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
-        "\n",
-        "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_tensorflow"
-      },
-      "outputs": [],
-      "source": [
-        "if os.environ[\"IS_TESTING\"]:\n",
-        "    ! pip3 install --upgrade tensorflow $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "# PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-        "\n",
-        "PROJECT_ID = \"python-docs-samples-tests\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}\n",
-        "\n",
-        "BUCKET_NAME = \"gs://ivanmkc-test2\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex SDK for Python\n",
-        "\n",
-        "Initialize the Vertex SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tutorial_start:automl"
-      },
-      "source": [
-        "# Tutorial\n",
-        "\n",
-        "Now you are ready to start creating your own AutoML tabular forecasting model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "import_file:u_dataset,csv"
-      },
-      "source": [
-        "#### Location of BigQuery training data.\n",
-        "\n",
-        "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_file:covid,csv,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "TRAINING_DATASET_BQ_PATH = (\n",
-        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_dataset:tabular,forecast"
-      },
-      "source": [
-        "### Create the Dataset\n",
-        "\n",
-        "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
-        "\n",
-        "- `display_name`: The human readable name for the `Dataset` resource.\n",
-        "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
-        "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
-        "\n",
-        "This operation may take several minutes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_dataset:tabular,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "dataset = aip.TimeSeriesDataset.create(\n",
-        "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
-        "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
-        ")\n",
-        "\n",
-        "time_column = \"date\"\n",
-        "time_series_identifier_column = \"store_name\"\n",
-        "target_column = \"sale_dollars\"\n",
-        "\n",
-        "print(dataset.resource_name)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f3575e7f7823"
-      },
-      "outputs": [],
-      "source": [
-        "dataset.name"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_transformations:covid"
-      },
-      "outputs": [],
-      "source": [
-        "# COLUMN_SPECS = {\n",
-        "#     time_column: \"timestamp\",\n",
-        "#     target_column: \"numeric\",\n",
-        "#     \"city\": \"categorical\",\n",
-        "#     \"zip_code\": \"categorical\",\n",
-        "#     \"county\": \"categorical\",\n",
-        "# }\n",
-        "\n",
-        "COLUMN_TRANSFORMATIONS = [\n",
-        "    {\"timestamp\": {\"column_name\": time_column}},\n",
-        "    {\"numeric\": {\"column_name\": target_column}},\n",
-        "    {\"categorical\": {\"column_name\": \"city\"}},\n",
-        "    {\"categorical\": {\"column_name\": \"zip_code\"}},\n",
-        "    {\"categorical\": {\"column_name\": \"county\"}},\n",
-        "]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_automl_pipeline:tabular,forecast"
-      },
-      "source": [
-        "### Create and run training job\n",
-        "\n",
-        "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
-        "\n",
-        "#### Create training job\n",
-        "\n",
-        "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
-        "\n",
-        "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
-        "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
-        "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
-        "    - `minimize-rmse`\n",
-        "    - `minimize-mae`\n",
-        "    - `minimize-rmsle`\n",
-        "\n",
-        "The instantiated object is the job for the training pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_automl_pipeline:tabular,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
-        "\n",
-        "training_job = aip.AutoMLForecastingTrainingJob(\n",
-        "    display_name=MODEL_DISPLAY_NAME,\n",
-        "    optimization_objective=\"minimize-rmse\",\n",
-        "    #     column_specs=COLUMN_SPECS,\n",
-        "    column_transformations=COLUMN_TRANSFORMATIONS,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_automl_pipeline:forecast"
-      },
-      "source": [
-        "#### Run the training pipeline\n",
-        "\n",
-        "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
-        "\n",
-        "- `dataset`: The `Dataset` resource to train the model.\n",
-        "- `model_display_name`: The human readable name for the trained model.\n",
-        "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
-        "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
-        "- `target_column`: The name of the column to train as the label.\n",
-        "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
-        "- `time_column`:\n",
-        "- `time_series_identifier_column`:\n",
-        "\n",
-        "The `run` method when completed returns the `Model` resource.\n",
-        "\n",
-        "The execution of the training pipeline will take up to 20 minutes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_automl_pipeline:forecast"
-      },
-      "outputs": [],
-      "source": [
-        "model = training_job.run(\n",
-        "    dataset=dataset,\n",
-        "    target_column=target_column,\n",
-        "    time_column=time_column,\n",
-        "    time_series_identifier_column=time_series_identifier_column,\n",
-        "    available_at_forecast_columns=[time_column],\n",
-        "    unavailable_at_forecast_columns=[target_column],\n",
-        "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
-        "    forecast_horizon=30,\n",
-        "    context_window=30,\n",
-        "    data_granularity_unit=\"day\",\n",
-        "    data_granularity_count=1,\n",
-        "    weight_column=None,\n",
-        "    budget_milli_node_hours=1000,\n",
-        "    model_display_name=\"iowa-liquor-sales-forecast-model\",\n",
-        "    predefined_split_column_name=None,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "evaluate_the_model:mbsdk"
-      },
-      "source": [
-        "## Review model evaluation scores\n",
-        "After your model has finished training, you can review the evaluation scores for it.\n",
-        "\n",
-        "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "evaluate_the_model:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "# Get model resource ID\n",
-        "models = aip.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
-        "\n",
-        "# Get a reference to the Model Service client\n",
-        "client_options = {\"api_endpoint\": f\"{REGION}-aiplatform.googleapis.com\"}\n",
-        "model_service_client = aip.gapic.ModelServiceClient(client_options=client_options)\n",
-        "\n",
-        "model_evaluations = model_service_client.list_model_evaluations(\n",
-        "    parent=models[0].resource_name\n",
-        ")\n",
-        "model_evaluation = list(model_evaluations)[0]\n",
-        "print(model_evaluation)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "make_prediction"
-      },
-      "source": [
-        "## Send a batch prediction request\n",
-        "\n",
-        "Send a batch prediction to your deployed model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "batch_request:mbsdk,both_csv"
-      },
-      "source": [
-        "### Make the batch prediction request\n",
-        "\n",
-        "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
-        "\n",
-        "- `job_display_name`: The human readable name for the batch prediction job.\n",
-        "- `gcs_source`: A list of one or more batch request input files.\n",
-        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
-        "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-        "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2c9d935c6ab9"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "from google.cloud import bigquery\n",
-        "\n",
-        "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
-        "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
-        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-        ")\n",
-        "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
-        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-        ")\n",
-        "# Must be the same region as batch_predict_bq_input_uri\n",
-        "client = bigquery.Client()\n",
-        "dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
-        "dataset_region = \"US\"  # @param {type : \"string\"}\n",
-        "dataset.location = dataset_region\n",
-        "dataset = client.create_dataset(dataset)\n",
-        "print(\n",
-        "    \"Created bigquery dataset {} in {}\".format(\n",
-        "        batch_predict_bq_output_dataset_path, dataset_region\n",
-        "    )\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "batch_request:mbsdk,both_csv"
-      },
-      "outputs": [],
-      "source": [
-        "PREDICTION_DATASET_BQ_PATH = (\n",
-        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-        ")\n",
-        "\n",
-        "batch_prediction_job = model.batch_predict(\n",
-        "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
-        "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
-        "    instances_format=\"bigquery\",\n",
-        "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
-        "    predictions_format=\"bigquery\",\n",
-        "    sync=False,\n",
-        ")\n",
-        "\n",
-        "print(batch_prediction_job)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "batch_request_wait:mbsdk"
-      },
-      "source": [
-        "### Wait for completion of batch prediction job\n",
-        "\n",
-        "Next, wait for the batch job to complete. Alternatively, one can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "batch_request_wait:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "batch_prediction_job.wait()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "get_batch_prediction:mbsdk,forecast"
-      },
-      "source": [
-        "._gca_resource.output_info### Get the predictions\n",
-        "\n",
-        "Next, get the results from the completed batch prediction job.\n",
-        "\n",
-        "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
-        "\n",
-        "- CSV header + predicted_label\n",
-        "- CSV row + prediction, per prediction request"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "get_batch_prediction:mbsdk,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "import tensorflow as tf\n",
-        "\n",
-        "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
-        "\n",
-        "prediction_results = list()\n",
-        "for blob in bp_iter_outputs:\n",
-        "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
-        "        prediction_results.append(blob.name)\n",
-        "\n",
-        "tags = list()\n",
-        "for prediction_result in prediction_results:\n",
-        "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
-        "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
-        "        for line in gfile.readlines():\n",
-        "            print(line)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f82f00be2160"
-      },
-      "outputs": [],
-      "source": [
-        "# @title # Visualize the Forecasts\n",
-        "# @markdown Follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
-        "\n",
-        "import urllib\n",
-        "\n",
-        "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
-        "\n",
-        "prediction_table_id = \"\"\n",
-        "for table in tables:\n",
-        "    if (\n",
-        "        table.table_id.startswith(\"predictions_\")\n",
-        "        and table.table_id > prediction_table_id\n",
-        "    ):\n",
-        "        prediction_table_id = table.table_id\n",
-        "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
-        "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
-        ")\n",
-        "\n",
-        "\n",
-        "def _sanitize_bq_uri(bq_uri):\n",
-        "    if bq_uri.startswith(\"bq://\"):\n",
-        "        bq_uri = bq_uri[5:]\n",
-        "    return bq_uri.replace(\":\", \".\")\n",
-        "\n",
-        "\n",
-        "def get_data_studio_link(\n",
-        "    batch_prediction_bq_input_uri,\n",
-        "    batch_prediction_bq_output_uri,\n",
-        "    time_column,\n",
-        "    time_series_identifier_column,\n",
-        "    target_column,\n",
-        "):\n",
-        "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
-        "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
-        "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
-        "    query = (\n",
-        "        \"SELECT \\\\n\"\n",
-        "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
-        "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
-        "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
-        "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
-        "        \" * \\\\n\"\n",
-        "        \"FROM `{}` input\\\\n\"\n",
-        "        \"LEFT JOIN `{}` output\\\\n\"\n",
-        "        \"ON\\\\n\"\n",
-        "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
-        "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
-        "    )\n",
-        "    query = query.format(\n",
-        "        time_column,\n",
-        "        time_series_identifier_column,\n",
-        "        target_column,\n",
-        "        target_column,\n",
-        "        batch_prediction_bq_input_uri,\n",
-        "        batch_prediction_bq_output_uri,\n",
-        "        time_column,\n",
-        "        time_column,\n",
-        "        time_series_identifier_column,\n",
-        "        time_series_identifier_column,\n",
-        "    )\n",
-        "    params = {\n",
-        "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
-        "        \"ds0.connector\": \"BIG_QUERY\",\n",
-        "        \"ds0.projectId\": PROJECT_ID,\n",
-        "        \"ds0.billingProjectId\": PROJECT_ID,\n",
-        "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
-        "        \"ds0.sql\": query,\n",
-        "    }\n",
-        "    params_str_parts = []\n",
-        "    for k, v in params.items():\n",
-        "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
-        "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
-        "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
-        "\n",
-        "\n",
-        "print(\n",
-        "    get_data_studio_link(\n",
-        "        PREDICTION_DATASET_BQ_PATH,\n",
-        "        batch_predict_bq_output_uri,\n",
-        "        time_column,\n",
-        "        time_series_identifier_column,\n",
-        "        target_column,\n",
-        "    )\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:mbsdk"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- AutoML Training Job\n",
-        "- Model\n",
-        "- Batch Prediction Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "# Delete dataset\n",
-        "dataset.delete()\n",
-        "\n",
-        "# Training job\n",
-        "training_job.delete()\n",
-        "\n",
-        "# Delete model\n",
-        "model.delete()\n",
-        "\n",
-        "# Delete batch prediction job\n",
-        "batch_prediction_job.delete()\n",
-        "\n",
-        "if os.getenv(\"IS_TESTING\"):\n",
-        "    ! gsutil rm -r $BUCKET_URI"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "sdk_automl_tabular_forecasting_batch.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title"
+   },
+   "source": [
+    "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+    "      Open in Google Cloud Notebooks\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:automl"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "\n",
+    "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:covid,forecast"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:automl,training,batch_prediction"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Create a Vertex `Dataset` resource.\n",
+    "- Train the model.\n",
+    "- View the model evaluation.\n",
+    "- Make a batch prediction.\n",
+    "\n",
+    "There is one key difference between using batch prediction and using online prediction:\n",
+    "\n",
+    "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
+    "\n",
+    "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
+    "\n",
+    "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
+    "\n",
+    "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_tensorflow"
+   },
+   "outputs": [],
+   "source": [
+    "if os.environ[\"IS_TESTING\"]:\n",
+    "    ! pip3 install --upgrade tensorflow $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "# PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "\n",
+    "PROJECT_ID = \"python-docs-samples-tests\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Updated property [core/project].\n"
+     ]
+    }
+   ],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: GOOGLE_APPLICATION_CREDENTIALS=''\n"
+     ]
+    }
+   ],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}\n",
+    "\n",
+    "BUCKET_NAME = \"gs://ivanmkc-test2\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating gs://ivanmkc-test2/...\n",
+      "ServiceException: 409 A Cloud Storage bucket named 'ivanmkc-test2' already exists. Try another name. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization.\n"
+     ]
+    }
+   ],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      2073  2021-05-07T17:20:31Z  gs://ivanmkc-test2/aiplatform-2021-05-07-13:20:30.406-aiplatform_custom_trainer_script-0.1.tar.gz#1620408031014708  metageneration=1\n",
+      "      2085  2021-05-11T01:39:31Z  gs://ivanmkc-test2/aiplatform-2021-05-10-21:39:30.859-aiplatform_custom_trainer_script-0.1.tar.gz#1620697171325511  metageneration=1\n",
+      "      3165  2021-05-18T01:01:54Z  gs://ivanmkc-test2/aiplatform-2021-05-17-21:01:54.120-aiplatform_custom_trainer_script-0.1.tar.gz#1621299714675620  metageneration=1\n",
+      "      3188  2021-05-18T18:00:44Z  gs://ivanmkc-test2/aiplatform-2021-05-18-14:00:43.706-aiplatform_custom_trainer_script-0.1.tar.gz#1621360844345827  metageneration=1\n",
+      "      3174  2021-05-18T19:22:16Z  gs://ivanmkc-test2/aiplatform-2021-05-18-15:22:15.934-aiplatform_custom_trainer_script-0.1.tar.gz#1621365736630406  metageneration=1\n",
+      "      3182  2021-05-18T19:22:56Z  gs://ivanmkc-test2/aiplatform-2021-05-18-15:22:56.161-aiplatform_custom_trainer_script-0.1.tar.gz#1621365776739206  metageneration=1\n",
+      "      3191  2021-05-18T20:07:06Z  gs://ivanmkc-test2/aiplatform-2021-05-18-16:07:06.396-aiplatform_custom_trainer_script-0.1.tar.gz#1621368426945134  metageneration=1\n",
+      "      3166  2021-05-19T18:04:06Z  gs://ivanmkc-test2/aiplatform-2021-05-19-14:04:06.497-aiplatform_custom_trainer_script-0.1.tar.gz#1621447446989129  metageneration=1\n",
+      "      3170  2021-05-19T18:16:38Z  gs://ivanmkc-test2/aiplatform-2021-05-19-14:16:37.024-aiplatform_custom_trainer_script-0.1.tar.gz#1621448198742738  metageneration=1\n",
+      "      3199  2021-05-19T18:59:26Z  gs://ivanmkc-test2/aiplatform-2021-05-19-14:59:26.179-aiplatform_custom_trainer_script-0.1.tar.gz#1621450766704526  metageneration=1\n",
+      "      3193  2021-05-19T20:21:12Z  gs://ivanmkc-test2/aiplatform-2021-05-19-16:21:12.053-aiplatform_custom_trainer_script-0.1.tar.gz#1621455672552438  metageneration=1\n",
+      "      3191  2021-05-19T21:14:09Z  gs://ivanmkc-test2/aiplatform-2021-05-19-17:14:09.280-aiplatform_custom_trainer_script-0.1.tar.gz#1621458849768372  metageneration=1\n",
+      "      3177  2021-05-20T21:32:39Z  gs://ivanmkc-test2/aiplatform-2021-05-20-17:32:38.831-aiplatform_custom_trainer_script-0.1.tar.gz#1621546359429463  metageneration=1\n",
+      "      3180  2021-05-20T22:30:31Z  gs://ivanmkc-test2/aiplatform-2021-05-20-18:30:30.945-aiplatform_custom_trainer_script-0.1.tar.gz#1621549831483237  metageneration=1\n",
+      "      3161  2021-05-20T23:31:44Z  gs://ivanmkc-test2/aiplatform-2021-05-20-19:31:43.683-aiplatform_custom_trainer_script-0.1.tar.gz#1621553504272652  metageneration=1\n",
+      "      3146  2021-05-21T00:06:26Z  gs://ivanmkc-test2/aiplatform-2021-05-20-20:06:25.680-aiplatform_custom_trainer_script-0.1.tar.gz#1621555586066225  metageneration=1\n",
+      "      3191  2021-05-21T00:38:42Z  gs://ivanmkc-test2/aiplatform-2021-05-20-20:38:42.378-aiplatform_custom_trainer_script-0.1.tar.gz#1621557522775908  metageneration=1\n",
+      "      3159  2021-05-21T18:20:13Z  gs://ivanmkc-test2/aiplatform-2021-05-21-14:20:12.502-aiplatform_custom_trainer_script-0.1.tar.gz#1621621213059496  metageneration=1\n",
+      "      3159  2021-05-21T19:00:36Z  gs://ivanmkc-test2/aiplatform-2021-05-21-15:00:35.747-aiplatform_custom_trainer_script-0.1.tar.gz#1621623636250345  metageneration=1\n",
+      "      3172  2021-05-21T19:40:03Z  gs://ivanmkc-test2/aiplatform-2021-05-21-15:40:02.606-aiplatform_custom_trainer_script-0.1.tar.gz#1621626003043729  metageneration=1\n",
+      "      3213  2021-05-21T20:36:21Z  gs://ivanmkc-test2/aiplatform-2021-05-21-16:36:20.587-aiplatform_custom_trainer_script-0.1.tar.gz#1621629381181091  metageneration=1\n",
+      "      3224  2021-05-21T23:47:07Z  gs://ivanmkc-test2/aiplatform-2021-05-21-19:47:06.495-aiplatform_custom_trainer_script-0.1.tar.gz#1621640827040854  metageneration=1\n",
+      "      3272  2021-05-22T00:25:45Z  gs://ivanmkc-test2/aiplatform-2021-05-21-20:25:44.914-aiplatform_custom_trainer_script-0.1.tar.gz#1621643145442395  metageneration=1\n",
+      "      3287  2021-05-22T01:38:32Z  gs://ivanmkc-test2/aiplatform-2021-05-21-21:38:32.387-aiplatform_custom_trainer_script-0.1.tar.gz#1621647512885045  metageneration=1\n",
+      "      3265  2021-05-24T16:00:11Z  gs://ivanmkc-test2/aiplatform-2021-05-24-12:00:10.954-aiplatform_custom_trainer_script-0.1.tar.gz#1621872011543155  metageneration=1\n",
+      "      3089  2021-05-24T20:57:13Z  gs://ivanmkc-test2/aiplatform-2021-05-24-16:57:12.583-aiplatform_custom_trainer_script-0.1.tar.gz#1621889833155994  metageneration=1\n",
+      "      3052  2021-05-28T16:29:53Z  gs://ivanmkc-test2/aiplatform-2021-05-28-12:29:52.632-aiplatform_custom_trainer_script-0.1.tar.gz#1622219393114120  metageneration=1\n",
+      "      3048  2021-05-28T16:47:26Z  gs://ivanmkc-test2/aiplatform-2021-05-28-12:47:25.868-aiplatform_custom_trainer_script-0.1.tar.gz#1622220446321981  metageneration=1\n",
+      "      3047  2021-05-28T17:03:00Z  gs://ivanmkc-test2/aiplatform-2021-05-28-13:03:00.476-aiplatform_custom_trainer_script-0.1.tar.gz#1622221380958831  metageneration=1\n",
+      "      3034  2021-05-28T17:11:24Z  gs://ivanmkc-test2/aiplatform-2021-05-28-13:11:23.766-aiplatform_custom_trainer_script-0.1.tar.gz#1622221884244794  metageneration=1\n",
+      "      3032  2021-05-28T17:57:41Z  gs://ivanmkc-test2/aiplatform-2021-05-28-13:57:40.649-aiplatform_custom_trainer_script-0.1.tar.gz#1622224661093085  metageneration=1\n",
+      "      3039  2021-05-28T18:20:45Z  gs://ivanmkc-test2/aiplatform-2021-05-28-14:20:45.562-aiplatform_custom_trainer_script-0.1.tar.gz#1622226045927498  metageneration=1\n",
+      "      2980  2021-05-28T16:40:49Z  gs://ivanmkc-test2/aiplatform-2021-05-28-16:40:49.672-aiplatform_custom_trainer_script-0.1.tar.gz#1622220049755693  metageneration=1\n",
+      "      3024  2021-06-01T17:18:15Z  gs://ivanmkc-test2/aiplatform-2021-06-01-13:18:14.630-aiplatform_custom_trainer_script-0.1.tar.gz#1622567895125402  metageneration=1\n",
+      "      3545  2021-06-01T17:59:28Z  gs://ivanmkc-test2/aiplatform-2021-06-01-13:59:28.229-aiplatform_custom_trainer_script-0.1.tar.gz#1622570368704609  metageneration=1\n",
+      "      3540  2021-06-01T18:33:11Z  gs://ivanmkc-test2/aiplatform-2021-06-01-14:33:11.172-aiplatform_custom_trainer_script-0.1.tar.gz#1622572391651243  metageneration=1\n",
+      "      3573  2021-06-01T19:40:31Z  gs://ivanmkc-test2/aiplatform-2021-06-01-15:40:30.907-aiplatform_custom_trainer_script-0.1.tar.gz#1622576431859672  metageneration=1\n",
+      "      3624  2021-06-01T20:31:42Z  gs://ivanmkc-test2/aiplatform-2021-06-01-16:31:41.567-aiplatform_custom_trainer_script-0.1.tar.gz#1622579502078080  metageneration=1\n",
+      "      3640  2021-06-01T21:37:20Z  gs://ivanmkc-test2/aiplatform-2021-06-01-17:37:20.488-aiplatform_custom_trainer_script-0.1.tar.gz#1622583440980424  metageneration=1\n",
+      "      3632  2021-06-02T00:08:16Z  gs://ivanmkc-test2/aiplatform-2021-06-01-20:08:15.701-aiplatform_custom_trainer_script-0.1.tar.gz#1622592496091322  metageneration=1\n",
+      "      3628  2021-06-02T01:32:41Z  gs://ivanmkc-test2/aiplatform-2021-06-01-21:32:40.695-aiplatform_custom_trainer_script-0.1.tar.gz#1622597561163990  metageneration=1\n",
+      "      3632  2021-06-02T01:56:56Z  gs://ivanmkc-test2/aiplatform-2021-06-01-21:56:56.473-aiplatform_custom_trainer_script-0.1.tar.gz#1622599016978016  metageneration=1\n",
+      "      3621  2021-06-02T02:11:24Z  gs://ivanmkc-test2/aiplatform-2021-06-01-22:11:23.911-aiplatform_custom_trainer_script-0.1.tar.gz#1622599884367514  metageneration=1\n",
+      "      3625  2021-06-02T02:19:50Z  gs://ivanmkc-test2/aiplatform-2021-06-01-22:19:50.384-aiplatform_custom_trainer_script-0.1.tar.gz#1622600390800752  metageneration=1\n",
+      "      3614  2021-06-02T03:04:43Z  gs://ivanmkc-test2/aiplatform-2021-06-01-23:04:43.071-aiplatform_custom_trainer_script-0.1.tar.gz#1622603083406290  metageneration=1\n",
+      "      3625  2021-06-02T04:07:08Z  gs://ivanmkc-test2/aiplatform-2021-06-02-00:07:08.086-aiplatform_custom_trainer_script-0.1.tar.gz#1622606828498448  metageneration=1\n",
+      "      3630  2021-06-02T15:26:08Z  gs://ivanmkc-test2/aiplatform-2021-06-02-11:26:08.476-aiplatform_custom_trainer_script-0.1.tar.gz#1622647568917873  metageneration=1\n",
+      "      4101  2021-06-02T22:41:58Z  gs://ivanmkc-test2/aiplatform-2021-06-02-18:41:57.632-aiplatform_custom_trainer_script-0.1.tar.gz#1622673718024533  metageneration=1\n",
+      "      4093  2021-06-02T23:11:39Z  gs://ivanmkc-test2/aiplatform-2021-06-02-19:11:39.011-aiplatform_custom_trainer_script-0.1.tar.gz#1622675499489089  metageneration=1\n",
+      "      4440  2021-06-03T00:17:59Z  gs://ivanmkc-test2/aiplatform-2021-06-02-20:17:59.417-aiplatform_custom_trainer_script-0.1.tar.gz#1622679479939511  metageneration=1\n",
+      "      4412  2021-06-03T00:52:03Z  gs://ivanmkc-test2/aiplatform-2021-06-02-20:52:02.747-aiplatform_custom_trainer_script-0.1.tar.gz#1622681523242749  metageneration=1\n",
+      "      4422  2021-06-03T14:00:43Z  gs://ivanmkc-test2/aiplatform-2021-06-03-10:00:43.496-aiplatform_custom_trainer_script-0.1.tar.gz#1622728843923195  metageneration=1\n",
+      "      4428  2021-06-03T15:39:32Z  gs://ivanmkc-test2/aiplatform-2021-06-03-11:39:31.637-aiplatform_custom_trainer_script-0.1.tar.gz#1622734772182576  metageneration=1\n",
+      "      4425  2021-06-03T17:58:23Z  gs://ivanmkc-test2/aiplatform-2021-06-03-13:58:23.361-aiplatform_custom_trainer_script-0.1.tar.gz#1622743103871466  metageneration=1\n",
+      "      4464  2021-06-03T19:52:00Z  gs://ivanmkc-test2/aiplatform-2021-06-03-15:52:00.431-aiplatform_custom_trainer_script-0.1.tar.gz#1622749920939026  metageneration=1\n",
+      "      4386  2021-06-03T23:19:04Z  gs://ivanmkc-test2/aiplatform-2021-06-03-19:19:04.384-aiplatform_custom_trainer_script-0.1.tar.gz#1622762344899425  metageneration=1\n",
+      "      4418  2021-06-04T00:01:30Z  gs://ivanmkc-test2/aiplatform-2021-06-03-20:01:29.518-aiplatform_custom_trainer_script-0.1.tar.gz#1622764890013782  metageneration=1\n",
+      "      4423  2021-06-04T23:13:20Z  gs://ivanmkc-test2/aiplatform-2021-06-04-19:13:19.899-aiplatform_custom_trainer_script-0.1.tar.gz#1622848400420717  metageneration=1\n",
+      "      4374  2021-06-05T01:44:29Z  gs://ivanmkc-test2/aiplatform-2021-06-04-21:44:29.038-aiplatform_custom_trainer_script-0.1.tar.gz#1622857469478397  metageneration=1\n",
+      "      4352  2021-06-04T23:16:57Z  gs://ivanmkc-test2/aiplatform-2021-06-04-23:16:57.596-aiplatform_custom_trainer_script-0.1.tar.gz#1622848617677052  metageneration=1\n",
+      "      4372  2021-06-07T19:26:12Z  gs://ivanmkc-test2/aiplatform-2021-06-07-15:26:11.765-aiplatform_custom_trainer_script-0.1.tar.gz#1623093972165874  metageneration=1\n",
+      "      4382  2021-06-07T22:55:17Z  gs://ivanmkc-test2/aiplatform-2021-06-07-18:55:16.961-aiplatform_custom_trainer_script-0.1.tar.gz#1623106517370141  metageneration=1\n",
+      "      4387  2021-06-07T23:59:44Z  gs://ivanmkc-test2/aiplatform-2021-06-07-19:59:43.853-aiplatform_custom_trainer_script-0.1.tar.gz#1623110384333039  metageneration=1\n",
+      "      4369  2021-06-08T00:57:53Z  gs://ivanmkc-test2/aiplatform-2021-06-07-20:57:52.921-aiplatform_custom_trainer_script-0.1.tar.gz#1623113873466108  metageneration=1\n",
+      "      4421  2021-06-08T02:09:34Z  gs://ivanmkc-test2/aiplatform-2021-06-07-22:09:33.865-aiplatform_custom_trainer_script-0.1.tar.gz#1623118174336015  metageneration=1\n",
+      "      4417  2021-06-08T05:13:29Z  gs://ivanmkc-test2/aiplatform-2021-06-08-01:13:28.810-aiplatform_custom_trainer_script-0.1.tar.gz#1623129209289510  metageneration=1\n",
+      "      4414  2021-06-09T16:34:14Z  gs://ivanmkc-test2/aiplatform-2021-06-09-12:34:13.709-aiplatform_custom_trainer_script-0.1.tar.gz#1623256454161825  metageneration=1\n",
+      "      4370  2021-06-09T17:18:52Z  gs://ivanmkc-test2/aiplatform-2021-06-09-13:18:51.720-aiplatform_custom_trainer_script-0.1.tar.gz#1623259132185318  metageneration=1\n",
+      "      4398  2021-06-09T18:29:46Z  gs://ivanmkc-test2/aiplatform-2021-06-09-14:29:46.275-aiplatform_custom_trainer_script-0.1.tar.gz#1623263386712302  metageneration=1\n",
+      "      4499  2021-06-09T20:52:30Z  gs://ivanmkc-test2/aiplatform-2021-06-09-16:52:29.780-aiplatform_custom_trainer_script-0.1.tar.gz#1623271950266058  metageneration=1\n",
+      "      4394  2021-06-09T21:19:01Z  gs://ivanmkc-test2/aiplatform-2021-06-09-17:19:00.779-aiplatform_custom_trainer_script-0.1.tar.gz#1623273541292747  metageneration=1\n",
+      "      4434  2021-06-09T22:03:33Z  gs://ivanmkc-test2/aiplatform-2021-06-09-18:03:32.546-aiplatform_custom_trainer_script-0.1.tar.gz#1623276213031402  metageneration=1\n",
+      "      4543  2021-06-10T01:00:27Z  gs://ivanmkc-test2/aiplatform-2021-06-09-21:00:27.118-aiplatform_custom_trainer_script-0.1.tar.gz#1623286827711145  metageneration=1\n",
+      "      4563  2021-06-10T16:05:58Z  gs://ivanmkc-test2/aiplatform-2021-06-10-12:05:58.066-aiplatform_custom_trainer_script-0.1.tar.gz#1623341158516195  metageneration=1\n",
+      "      4570  2021-06-10T19:12:23Z  gs://ivanmkc-test2/aiplatform-2021-06-10-15:12:22.693-aiplatform_custom_trainer_script-0.1.tar.gz#1623352343699661  metageneration=1\n",
+      "      4569  2021-06-10T20:45:07Z  gs://ivanmkc-test2/aiplatform-2021-06-10-16:45:06.379-aiplatform_custom_trainer_script-0.1.tar.gz#1623357907612822  metageneration=1\n",
+      "      4577  2021-06-10T21:22:02Z  gs://ivanmkc-test2/aiplatform-2021-06-10-17:22:02.412-aiplatform_custom_trainer_script-0.1.tar.gz#1623360122913336  metageneration=1\n",
+      "      4180  2021-06-10T19:56:10Z  gs://ivanmkc-test2/aiplatform-2021-06-10-19:56:10.068-aiplatform_custom_trainer_script-0.1.tar.gz#1623354970160766  metageneration=1\n",
+      "      4171  2021-06-10T21:02:45Z  gs://ivanmkc-test2/aiplatform-2021-06-10-21:02:45.462-aiplatform_custom_trainer_script-0.1.tar.gz#1623358965561193  metageneration=1\n",
+      "      4419  2021-06-11T03:59:35Z  gs://ivanmkc-test2/aiplatform-2021-06-10-23:59:35.280-aiplatform_custom_trainer_script-0.1.tar.gz#1623383975709393  metageneration=1\n",
+      "      4368  2021-06-11T02:51:03Z  gs://ivanmkc-test2/aiplatform-2021-06-11-02:51:03.445-aiplatform_custom_trainer_script-0.1.tar.gz#1623379863584974  metageneration=1\n",
+      "      4174  2021-06-11T02:53:59Z  gs://ivanmkc-test2/aiplatform-2021-06-11-02:53:59.753-aiplatform_custom_trainer_script-0.1.tar.gz#1623380039821880  metageneration=1\n",
+      "      4174  2021-06-11T02:55:43Z  gs://ivanmkc-test2/aiplatform-2021-06-11-02:55:43.636-aiplatform_custom_trainer_script-0.1.tar.gz#1623380143732884  metageneration=1\n",
+      "      4364  2021-06-11T15:54:50Z  gs://ivanmkc-test2/aiplatform-2021-06-11-15:54:49.928-aiplatform_custom_trainer_script-0.1.tar.gz#1623426890033146  metageneration=1\n",
+      "      4174  2021-06-11T15:55:54Z  gs://ivanmkc-test2/aiplatform-2021-06-11-15:55:54.863-aiplatform_custom_trainer_script-0.1.tar.gz#1623426954945872  metageneration=1\n",
+      "      4177  2021-06-11T21:44:31Z  gs://ivanmkc-test2/aiplatform-2021-06-11-21:44:31.164-aiplatform_custom_trainer_script-0.1.tar.gz#1623447871251848  metageneration=1\n",
+      "      4371  2021-06-12T00:24:21Z  gs://ivanmkc-test2/aiplatform-2021-06-12-00:24:21.150-aiplatform_custom_trainer_script-0.1.tar.gz#1623457461228775  metageneration=1\n",
+      "      4174  2021-06-12T00:25:04Z  gs://ivanmkc-test2/aiplatform-2021-06-12-00:25:04.853-aiplatform_custom_trainer_script-0.1.tar.gz#1623457504927369  metageneration=1\n",
+      "      4542  2021-06-14T18:18:49Z  gs://ivanmkc-test2/aiplatform-2021-06-14-14:18:49.306-aiplatform_custom_trainer_script-0.1.tar.gz#1623694729656688  metageneration=1\n",
+      "      4497  2021-06-14T18:51:53Z  gs://ivanmkc-test2/aiplatform-2021-06-14-14:51:53.281-aiplatform_custom_trainer_script-0.1.tar.gz#1623696713748372  metageneration=1\n",
+      "      4518  2021-06-14T19:21:25Z  gs://ivanmkc-test2/aiplatform-2021-06-14-15:21:25.265-aiplatform_custom_trainer_script-0.1.tar.gz#1623698485729153  metageneration=1\n",
+      "      4370  2021-06-14T16:18:49Z  gs://ivanmkc-test2/aiplatform-2021-06-14-16:18:49.870-aiplatform_custom_trainer_script-0.1.tar.gz#1623687529960720  metageneration=1\n",
+      "      4173  2021-06-14T16:20:50Z  gs://ivanmkc-test2/aiplatform-2021-06-14-16:20:50.528-aiplatform_custom_trainer_script-0.1.tar.gz#1623687650603991  metageneration=1\n",
+      "      4495  2021-06-14T22:19:31Z  gs://ivanmkc-test2/aiplatform-2021-06-14-18:19:31.421-aiplatform_custom_trainer_script-0.1.tar.gz#1623709171971703  metageneration=1\n",
+      "      4500  2021-06-14T23:03:50Z  gs://ivanmkc-test2/aiplatform-2021-06-14-19:03:50.124-aiplatform_custom_trainer_script-0.1.tar.gz#1623711830658234  metageneration=1\n",
+      "      4482  2021-06-14T23:36:37Z  gs://ivanmkc-test2/aiplatform-2021-06-14-19:36:36.691-aiplatform_custom_trainer_script-0.1.tar.gz#1623713797207622  metageneration=1\n",
+      "      4363  2021-06-15T23:28:45Z  gs://ivanmkc-test2/aiplatform-2021-06-15-23:28:45.335-aiplatform_custom_trainer_script-0.1.tar.gz#1623799725435678  metageneration=1\n",
+      "      4175  2021-06-15T23:29:35Z  gs://ivanmkc-test2/aiplatform-2021-06-15-23:29:34.903-aiplatform_custom_trainer_script-0.1.tar.gz#1623799775014476  metageneration=1\n",
+      "       297  2021-06-15T23:29:32Z  gs://ivanmkc-test2/mean_and_std.json#1623799772321868  metageneration=1\n",
+      "     72467  2021-05-07T22:38:47Z  gs://ivanmkc-test2/rossman_train.csv#1620427127449479  metageneration=1\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-07-13:20:30.758/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-10-21:39:31.212/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-18-16:07:06.791/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-24-16:57:13.090/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-12:29:52.977/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-12:47:26.210/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-13:03:00.832/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-13:11:24.121/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-05-28-16:40:49.786/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-02-11:26:08.836/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-03-15:52:00.866/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-03-20:01:29.907/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-04-19:13:20.241/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-04-23:16:57.699/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-09-12:34:14.067/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-09-18:03:32.931/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-12:05:58.474/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-15:12:23.142/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-17:22:02.812/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-19:56:10.189/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-21:02:45.589/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-10-23:59:35.663/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-02:51:03.614/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-02:53:59.834/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-02:55:43.764/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-15:54:50.054/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-15:55:54.968/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-11-21:44:31.279/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-12-00:24:21.240/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-12-00:25:04.936/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-14:18:49.653/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-15:21:25.622/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-16:18:49.982/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-16:20:50.626/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-18:19:31.788/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-19:03:50.499/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-14-19:36:37.064/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-15-23:28:45.461/\n",
+      "                                 gs://ivanmkc-test2/aiplatform-custom-training-2021-06-15-23:29:35.037/\n",
+      "                                 gs://ivanmkc-test2/artifacts/\n",
+      "                                 gs://ivanmkc-test2/cloudbuild-test/\n",
+      "                                 gs://ivanmkc-test2/code_archives/\n",
+      "                                 gs://ivanmkc-test2/data/\n",
+      "                                 gs://ivanmkc-test2/executed_notebooks/\n",
+      "                                 gs://ivanmkc-test2/keras-job-dir/\n",
+      "                                 gs://ivanmkc-test2/notebook-testing/\n",
+      "                                 gs://ivanmkc-test2/notebooks/\n",
+      "                                 gs://ivanmkc-test2/pipeline_root/\n",
+      "                                 gs://ivanmkc-test2/pipeline_staging/\n",
+      "TOTAL: 100 objects, 447899 bytes (437.4 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aiplatform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex SDK for Python\n",
+    "\n",
+    "Initialize the Vertex SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tutorial_start:automl"
+   },
+   "source": [
+    "# Tutorial\n",
+    "\n",
+    "Now you are ready to start creating your own AutoML tabular forecasting model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "import_file:u_dataset,csv"
+   },
+   "source": [
+    "#### Location of BigQuery training data.\n",
+    "\n",
+    "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "id": "import_file:covid,csv,forecast"
+   },
+   "outputs": [],
+   "source": [
+    "TRAINING_DATASET_BQ_PATH = (\n",
+    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_dataset:tabular,forecast"
+   },
+   "source": [
+    "### Create the Dataset\n",
+    "\n",
+    "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
+    "\n",
+    "- `display_name`: The human readable name for the `Dataset` resource.\n",
+    "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
+    "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
+    "\n",
+    "This operation may take several minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "id": "create_dataset:tabular,forecast"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.datasets.dataset:Creating TimeSeriesDataset\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:Create TimeSeriesDataset backing LRO: projects/1012616486416/locations/us-central1/datasets/5754817471500517376/operations/4979492517847236608\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:TimeSeriesDataset created. Resource name: projects/1012616486416/locations/us-central1/datasets/5754817471500517376\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:To use this TimeSeriesDataset in another session:\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:ds = aiplatform.TimeSeriesDataset('projects/1012616486416/locations/us-central1/datasets/5754817471500517376')\n",
+      "projects/1012616486416/locations/us-central1/datasets/5754817471500517376\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset = aiplatform.TimeSeriesDataset.create(\n",
+    "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
+    "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
+    ")\n",
+    "\n",
+    "time_column = \"date\"\n",
+    "time_series_identifier_column = \"store_name\"\n",
+    "target_column = \"sale_dollars\"\n",
+    "\n",
+    "print(dataset.resource_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "id": "f3575e7f7823"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'5754817471500517376'"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "id": "set_transformations:covid"
+   },
+   "outputs": [],
+   "source": [
+    "# COLUMN_SPECS = {\n",
+    "#     time_column: \"timestamp\",\n",
+    "#     target_column: \"numeric\",\n",
+    "#     \"city\": \"categorical\",\n",
+    "#     \"zip_code\": \"categorical\",\n",
+    "#     \"county\": \"categorical\",\n",
+    "# }\n",
+    "\n",
+    "COLUMN_TRANSFORMATIONS = [\n",
+    "    {\"timestamp\": {\"column_name\": time_column}},\n",
+    "    {\"numeric\": {\"column_name\": target_column}},\n",
+    "    {\"categorical\": {\"column_name\": \"city\"}},\n",
+    "    {\"categorical\": {\"column_name\": \"zip_code\"}},\n",
+    "    {\"categorical\": {\"column_name\": \"county\"}},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_automl_pipeline:tabular,forecast"
+   },
+   "source": [
+    "### Create and run training job\n",
+    "\n",
+    "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
+    "\n",
+    "#### Create training job\n",
+    "\n",
+    "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
+    "\n",
+    "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
+    "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
+    "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
+    "    - `minimize-rmse`\n",
+    "    - `minimize-mae`\n",
+    "    - `minimize-rmsle`\n",
+    "\n",
+    "The instantiated object is the job for the training pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "id": "create_automl_pipeline:tabular,forecast"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
+    "\n",
+    "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
+    "    display_name=MODEL_DISPLAY_NAME,\n",
+    "    optimization_objective=\"minimize-rmse\",\n",
+    "    #     column_specs=COLUMN_SPECS,\n",
+    "    column_transformations=COLUMN_TRANSFORMATIONS,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_automl_pipeline:forecast"
+   },
+   "source": [
+    "#### Run the training pipeline\n",
+    "\n",
+    "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
+    "\n",
+    "- `dataset`: The `Dataset` resource to train the model.\n",
+    "- `model_display_name`: The human readable name for the trained model.\n",
+    "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
+    "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
+    "- `target_column`: The name of the column to train as the label.\n",
+    "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
+    "- `time_column`:\n",
+    "- `time_series_identifier_column`:\n",
+    "\n",
+    "The `run` method when completed returns the `Model` resource.\n",
+    "\n",
+    "The execution of the training pipeline will take up to 20 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "id": "run_automl_pipeline:forecast"
+   },
+   "outputs": [
+    {
+     "ename": "RuntimeError",
+     "evalue": "AutoML Forecasting Training has already run.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-30-9221afa26bde>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m model = training_job.run(\n\u001b[0m\u001b[1;32m      2\u001b[0m     \u001b[0mdataset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mtarget_column\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtarget_column\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m     \u001b[0mtime_column\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtime_column\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0mtime_series_identifier_column\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtime_series_identifier_column\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/aiplatform/training_jobs.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, dataset, target_column, time_column, time_series_identifier_column, unavailable_at_forecast_columns, available_at_forecast_columns, forecast_horizon, data_granularity_unit, data_granularity_count, predefined_split_column_name, weight_column, time_series_attribute_columns, context_window, export_evaluated_data_items, export_evaluated_data_items_bigquery_destination_uri, export_evaluated_data_items_override_destination, quantiles, validation_options, budget_milli_node_hours, model_display_name, sync)\u001b[0m\n\u001b[1;32m   3235\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3236\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_has_run\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3237\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mRuntimeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"AutoML Forecasting Training has already run.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3238\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3239\u001b[0m         return self._run(\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: AutoML Forecasting Training has already run."
+     ]
+    }
+   ],
+   "source": [
+    "model = training_job.run(\n",
+    "    dataset=dataset,\n",
+    "    target_column=target_column,\n",
+    "    time_column=time_column,\n",
+    "    time_series_identifier_column=time_series_identifier_column,\n",
+    "    available_at_forecast_columns=[time_column],\n",
+    "    unavailable_at_forecast_columns=[target_column],\n",
+    "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
+    "    forecast_horizon=30,\n",
+    "    context_window=30,\n",
+    "    data_granularity_unit=\"day\",\n",
+    "    data_granularity_count=1,\n",
+    "    weight_column=None,\n",
+    "    budget_milli_node_hours=1000,\n",
+    "    model_display_name=MODEL_DISPLAY_NAME,\n",
+    "    predefined_split_column_name=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "evaluate_the_model:mbsdk"
+   },
+   "source": [
+    "## Review model evaluation scores\n",
+    "After your model has finished training, you can review the evaluation scores for it.\n",
+    "\n",
+    "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "id": "evaluate_the_model:mbsdk"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "name: \"projects/1012616486416/locations/us-central1/models/5877624124230074368/evaluations/2405091353327963614\"\n",
+      "metrics_schema_uri: \"gs://google-cloud-aiplatform/schema/modelevaluation/forecasting_metrics_1.0.0.yaml\"\n",
+      "metrics {\n",
+      "  struct_value {\n",
+      "    fields {\n",
+      "      key: \"meanAbsoluteError\"\n",
+      "      value {\n",
+      "        number_value: 3915.58\n",
+      "      }\n",
+      "    }\n",
+      "    fields {\n",
+      "      key: \"meanAbsolutePercentageError\"\n",
+      "      value {\n",
+      "        number_value: 377.37677\n",
+      "      }\n",
+      "    }\n",
+      "    fields {\n",
+      "      key: \"rSquared\"\n",
+      "      value {\n",
+      "        number_value: 0.5439744\n",
+      "      }\n",
+      "    }\n",
+      "    fields {\n",
+      "      key: \"rootMeanSquaredError\"\n",
+      "      value {\n",
+      "        number_value: 8925.371\n",
+      "      }\n",
+      "    }\n",
+      "    fields {\n",
+      "      key: \"rootMeanSquaredLogError\"\n",
+      "      value {\n",
+      "        number_value: 0.934609\n",
+      "      }\n",
+      "    }\n",
+      "  }\n",
+      "}\n",
+      "create_time {\n",
+      "  seconds: 1636488192\n",
+      "  nanos: 183194000\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get model resource ID\n",
+    "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
+    "model = models[0]\n",
+    "\n",
+    "# Get a reference to the Model Service client\n",
+    "client_options = aiplatform.initializer.global_config.get_client_options()\n",
+    "model_service_client = aiplatform.gapic.ModelServiceClient(client_options=client_options)\n",
+    "\n",
+    "model_evaluations = model_service_client.list_model_evaluations(\n",
+    "    parent=model.resource_name\n",
+    ")\n",
+    "model_evaluation = list(model_evaluations)[0]\n",
+    "print(model_evaluation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "make_prediction"
+   },
+   "source": [
+    "## Send a batch prediction request\n",
+    "\n",
+    "Send a batch prediction to your deployed model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "batch_request:mbsdk,both_csv"
+   },
+   "source": [
+    "### Make the batch prediction request\n",
+    "\n",
+    "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
+    "\n",
+    "- `job_display_name`: The human readable name for the batch prediction job.\n",
+    "- `gcs_source`: A list of one or more batch request input files.\n",
+    "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
+    "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+    "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+    "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "id": "2c9d935c6ab9"
+   },
+   "outputs": [
+    {
+     "ename": "Conflict",
+     "evalue": "409 POST https://bigquery.googleapis.com/bigquery/v2/projects/python-docs-samples-tests/datasets?prettyPrint=false: Already Exists: Dataset python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mConflict\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-48-749ba24eacd2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0mdataset_region\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"US\"\u001b[0m  \u001b[0;31m# @param {type : \"string\"}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[0mdataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlocation\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdataset_region\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m \u001b[0mdataset\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreate_dataset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     18\u001b[0m print(\n\u001b[1;32m     19\u001b[0m     \"Created bigquery dataset {} in {}\".format(\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36mcreate_dataset\u001b[0;34m(self, dataset, exists_ok, retry, timeout)\u001b[0m\n\u001b[1;32m    598\u001b[0m             \u001b[0mspan_attributes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m\"path\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    599\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 600\u001b[0;31m             api_response = self._call_api(\n\u001b[0m\u001b[1;32m    601\u001b[0m                 \u001b[0mretry\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    602\u001b[0m                 \u001b[0mspan_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"BigQuery.createDataset\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36m_call_api\u001b[0;34m(self, retry, span_name, span_attributes, job_ref, **kwargs)\u001b[0m\n\u001b[1;32m    738\u001b[0m                 \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mattributes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_attributes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjob_ref\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mjob_ref\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    739\u001b[0m             ):\n\u001b[0;32m--> 740\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    741\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    742\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_wrapped_func\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    283\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_initial\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_maximum\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiplier\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_multiplier\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    284\u001b[0m             )\n\u001b[0;32m--> 285\u001b[0;31m             return retry_target(\n\u001b[0m\u001b[1;32m    286\u001b[0m                 \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    287\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_predicate\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_target\u001b[0;34m(target, predicate, sleep_generator, deadline, on_error)\u001b[0m\n\u001b[1;32m    186\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0msleep\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msleep_generator\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 188\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    189\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0;31m# pylint: disable=broad-except\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/_http.py\u001b[0m in \u001b[0;36mapi_request\u001b[0;34m(self, method, path, query_params, data, content_type, headers, api_base_url, api_version, expect_json, _target_object, timeout)\u001b[0m\n\u001b[1;32m    481\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    482\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;36m200\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m300\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 483\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_http_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    484\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    485\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mexpect_json\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mConflict\u001b[0m: 409 POST https://bigquery.googleapis.com/bigquery/v2/projects/python-docs-samples-tests/datasets?prettyPrint=false: Already Exists: Dataset python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
+    "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
+    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+    ")\n",
+    "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
+    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+    ")\n",
+    "# Must be the same region as batch_predict_bq_input_uri\n",
+    "client = bigquery.Client()\n",
+    "dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
+    "dataset_region = \"US\"  # @param {type : \"string\"}\n",
+    "dataset.location = dataset_region\n",
+    "dataset = client.create_dataset(dataset)\n",
+    "print(\n",
+    "    \"Created bigquery dataset {} in {}\".format(\n",
+    "        batch_predict_bq_output_dataset_path, dataset_region\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "id": "batch_request:mbsdk,both_csv"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.jobs:Creating BatchPredictionJob\n",
+      "<google.cloud.aiplatform.jobs.BatchPredictionJob object at 0x14bc40280> is waiting for upstream dependencies to complete.\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob created. Resource name: projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224\n",
+      "INFO:google.cloud.aiplatform.jobs:To use this BatchPredictionJob in another session:\n",
+      "INFO:google.cloud.aiplatform.jobs:bpj = aiplatform.BatchPredictionJob('projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224')\n",
+      "INFO:google.cloud.aiplatform.jobs:View Batch Prediction Job:\n",
+      "https://console.cloud.google.com/ai/platform/locations/us-central1/batch-predictions/1776122496207028224?project=1012616486416\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n"
+     ]
+    }
+   ],
+   "source": [
+    "PREDICTION_DATASET_BQ_PATH = (\n",
+    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+    ")\n",
+    "\n",
+    "batch_prediction_job = model.batch_predict(\n",
+    "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
+    "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
+    "    instances_format=\"bigquery\",\n",
+    "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
+    "    predictions_format=\"bigquery\",\n",
+    "    sync=False,\n",
+    ")\n",
+    "\n",
+    "print(batch_prediction_job)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "batch_request_wait:mbsdk"
+   },
+   "source": [
+    "### Wait for completion of batch prediction job\n",
+    "\n",
+    "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "id": "batch_request_wait:mbsdk"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224 current state:\n",
+      "JobState.JOB_STATE_SUCCEEDED\n",
+      "INFO:google.cloud.aiplatform.jobs:BatchPredictionJob run completed. Resource name: projects/1012616486416/locations/us-central1/batchPredictionJobs/1776122496207028224\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch_prediction_job.wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "get_batch_prediction:mbsdk,forecast"
+   },
+   "source": [
+    "### Get the predictions\n",
+    "\n",
+    "Next, get the results from the completed batch prediction job.\n",
+    "\n",
+    "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
+    "\n",
+    "- CSV header + predicted_label\n",
+    "- CSV row + prediction, per prediction request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {
+    "id": "get_batch_prediction:mbsdk,forecast"
+   },
+   "outputs": [
+    {
+     "ename": "NotFound",
+     "evalue": "404 GET https://bigquery.googleapis.com/bigquery/v2/projects/1012616486416/datasets/iowa_liquor_sales_predictions_20211109124705/tables/predictions?prettyPrint=false: Not found: Table python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705.predictions",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotFound\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-51-dd878a8e21fa>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtensorflow\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mtf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mbp_iter_outputs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbatch_prediction_job\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_outputs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mprediction_results\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/aiplatform/jobs.py\u001b[0m in \u001b[0;36miter_outputs\u001b[0;34m(self, bq_max_results)\u001b[0m\n\u001b[1;32m    821\u001b[0m             \u001b[0m_\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbq_dataset_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbq_dataset\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\".\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    822\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 823\u001b[0;31m             row_iterator = bq_client.list_rows(\n\u001b[0m\u001b[1;32m    824\u001b[0m                 \u001b[0mtable\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34mf\"{bq_dataset_id}.predictions\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmax_results\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mbq_max_results\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    825\u001b[0m             )\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36mlist_rows\u001b[0;34m(self, table, selected_fields, max_results, page_token, start_index, page_size, retry, timeout)\u001b[0m\n\u001b[1;32m   3579\u001b[0m         \u001b[0;31m# columns, so get the table resource for them rather than failing.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3580\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mschema\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3581\u001b[0;31m             \u001b[0mtable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_table\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreference\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mretry\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mretry\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3582\u001b[0m             \u001b[0mschema\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mschema\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3583\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36mget_table\u001b[0;34m(self, table, retry, timeout)\u001b[0m\n\u001b[1;32m    991\u001b[0m         \u001b[0mpath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtable_ref\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    992\u001b[0m         \u001b[0mspan_attributes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m\"path\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 993\u001b[0;31m         api_response = self._call_api(\n\u001b[0m\u001b[1;32m    994\u001b[0m             \u001b[0mretry\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    995\u001b[0m             \u001b[0mspan_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"BigQuery.getTable\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/bigquery/client.py\u001b[0m in \u001b[0;36m_call_api\u001b[0;34m(self, retry, span_name, span_attributes, job_ref, **kwargs)\u001b[0m\n\u001b[1;32m    738\u001b[0m                 \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mattributes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspan_attributes\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mclient\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjob_ref\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mjob_ref\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    739\u001b[0m             ):\n\u001b[0;32m--> 740\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    741\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    742\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_wrapped_func\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    283\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_initial\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_maximum\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiplier\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_multiplier\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    284\u001b[0m             )\n\u001b[0;32m--> 285\u001b[0;31m             return retry_target(\n\u001b[0m\u001b[1;32m    286\u001b[0m                 \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    287\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_predicate\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/api_core/retry.py\u001b[0m in \u001b[0;36mretry_target\u001b[0;34m(target, predicate, sleep_generator, deadline, on_error)\u001b[0m\n\u001b[1;32m    186\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0msleep\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msleep_generator\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 188\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    189\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0;31m# pylint: disable=broad-except\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Documents/code/ai-platform-samples/env/lib/python3.8/site-packages/google/cloud/_http.py\u001b[0m in \u001b[0;36mapi_request\u001b[0;34m(self, method, path, query_params, data, content_type, headers, api_base_url, api_version, expect_json, _target_object, timeout)\u001b[0m\n\u001b[1;32m    481\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    482\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;36m200\u001b[0m \u001b[0;34m<=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0;36m300\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 483\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_http_response\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    484\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    485\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mexpect_json\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontent\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNotFound\u001b[0m: 404 GET https://bigquery.googleapis.com/bigquery/v2/projects/1012616486416/datasets/iowa_liquor_sales_predictions_20211109124705/tables/predictions?prettyPrint=false: Not found: Table python-docs-samples-tests:iowa_liquor_sales_predictions_20211109124705.predictions"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
+    "\n",
+    "prediction_results = list()\n",
+    "for blob in bp_iter_outputs:\n",
+    "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
+    "        prediction_results.append(blob.name)\n",
+    "\n",
+    "tags = list()\n",
+    "for prediction_result in prediction_results:\n",
+    "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
+    "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
+    "        for line in gfile.readlines():\n",
+    "            print(line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f82f00be2160"
+   },
+   "outputs": [],
+   "source": [
+    "# @title # Visualize the Forecasts\n",
+    "# @markdown Follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
+    "\n",
+    "import urllib\n",
+    "\n",
+    "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
+    "\n",
+    "prediction_table_id = \"\"\n",
+    "for table in tables:\n",
+    "    if (\n",
+    "        table.table_id.startswith(\"predictions_\")\n",
+    "        and table.table_id > prediction_table_id\n",
+    "    ):\n",
+    "        prediction_table_id = table.table_id\n",
+    "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
+    "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def _sanitize_bq_uri(bq_uri):\n",
+    "    if bq_uri.startswith(\"bq://\"):\n",
+    "        bq_uri = bq_uri[5:]\n",
+    "    return bq_uri.replace(\":\", \".\")\n",
+    "\n",
+    "\n",
+    "def get_data_studio_link(\n",
+    "    batch_prediction_bq_input_uri,\n",
+    "    batch_prediction_bq_output_uri,\n",
+    "    time_column,\n",
+    "    time_series_identifier_column,\n",
+    "    target_column,\n",
+    "):\n",
+    "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
+    "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
+    "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
+    "    query = (\n",
+    "        \"SELECT \\\\n\"\n",
+    "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
+    "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
+    "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
+    "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
+    "        \" * \\\\n\"\n",
+    "        \"FROM `{}` input\\\\n\"\n",
+    "        \"LEFT JOIN `{}` output\\\\n\"\n",
+    "        \"ON\\\\n\"\n",
+    "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
+    "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
+    "    )\n",
+    "    query = query.format(\n",
+    "        time_column,\n",
+    "        time_series_identifier_column,\n",
+    "        target_column,\n",
+    "        target_column,\n",
+    "        batch_prediction_bq_input_uri,\n",
+    "        batch_prediction_bq_output_uri,\n",
+    "        time_column,\n",
+    "        time_column,\n",
+    "        time_series_identifier_column,\n",
+    "        time_series_identifier_column,\n",
+    "    )\n",
+    "    params = {\n",
+    "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
+    "        \"ds0.connector\": \"BIG_QUERY\",\n",
+    "        \"ds0.projectId\": PROJECT_ID,\n",
+    "        \"ds0.billingProjectId\": PROJECT_ID,\n",
+    "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
+    "        \"ds0.sql\": query,\n",
+    "    }\n",
+    "    params_str_parts = []\n",
+    "    for k, v in params.items():\n",
+    "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
+    "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
+    "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
+    "\n",
+    "\n",
+    "print(\n",
+    "    get_data_studio_link(\n",
+    "        PREDICTION_DATASET_BQ_PATH,\n",
+    "        batch_predict_bq_output_uri,\n",
+    "        time_column,\n",
+    "        time_series_identifier_column,\n",
+    "        target_column,\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:mbsdk"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- AutoML Training Job\n",
+    "- Model\n",
+    "- Batch Prediction Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "# Delete dataset\n",
+    "dataset.delete()\n",
+    "\n",
+    "# Training job\n",
+    "training_job.delete()\n",
+    "\n",
+    "# Delete model\n",
+    "model.delete()\n",
+    "\n",
+    "# Delete batch prediction job\n",
+    "batch_prediction_job.delete()\n",
+    "\n",
+    "if os.getenv(\"IS_TESTING\"):\n",
+    "    ! gsutil rm -r $BUCKET_URI"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "sdk_automl_tabular_forecasting_batch.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -1,0 +1,1066 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title"
+      },
+      "source": [
+        "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      Open in Google Cloud Notebooks\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:automl"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "\n",
+        "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:covid,forecast"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:automl,training,batch_prediction"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a Vertex `Dataset` resource.\n",
+        "- Train the model.\n",
+        "- View the model evaluation.\n",
+        "- Make a batch prediction.\n",
+        "\n",
+        "There is one key difference between using batch prediction and using online prediction:\n",
+        "\n",
+        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
+        "\n",
+        "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
+        "\n",
+        "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
+        "\n",
+        "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_tensorflow"
+      },
+      "outputs": [],
+      "source": [
+        "if os.environ[\"IS_TESTING\"]:\n",
+        "    ! pip3 install --upgrade tensorflow $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "# PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+        "\n",
+        "PROJECT_ID = \"python-docs-samples-tests\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}\n",
+        "\n",
+        "BUCKET_NAME = \"gs://ivanmkc-test2\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex SDK for Python\n",
+        "\n",
+        "Initialize the Vertex SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tutorial_start:automl"
+      },
+      "source": [
+        "# Tutorial\n",
+        "\n",
+        "Now you are ready to start creating your own AutoML tabular forecasting model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "import_file:u_dataset,csv"
+      },
+      "source": [
+        "#### Location of BigQuery training data.\n",
+        "\n",
+        "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_file:covid,csv,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "TRAINING_DATASET_BQ_PATH = (\n",
+        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_dataset:tabular,forecast"
+      },
+      "source": [
+        "### Create the Dataset\n",
+        "\n",
+        "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
+        "\n",
+        "- `display_name`: The human readable name for the `Dataset` resource.\n",
+        "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
+        "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
+        "\n",
+        "This operation may take several minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_dataset:tabular,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "dataset = aip.TimeSeriesDataset.create(\n",
+        "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
+        "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
+        ")\n",
+        "\n",
+        "time_column = \"date\"\n",
+        "time_series_identifier_column = \"store_name\"\n",
+        "target_column = \"sale_dollars\"\n",
+        "\n",
+        "print(dataset.resource_name)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f3575e7f7823"
+      },
+      "outputs": [],
+      "source": [
+        "dataset.name"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_transformations:covid"
+      },
+      "outputs": [],
+      "source": [
+        "# COLUMN_SPECS = {\n",
+        "#     time_column: \"timestamp\",\n",
+        "#     target_column: \"numeric\",\n",
+        "#     \"city\": \"categorical\",\n",
+        "#     \"zip_code\": \"categorical\",\n",
+        "#     \"county\": \"categorical\",\n",
+        "# }\n",
+        "\n",
+        "COLUMN_TRANSFORMATIONS = [\n",
+        "    {\"timestamp\": {\"column_name\": time_column}},\n",
+        "    {\"numeric\": {\"column_name\": target_column}},\n",
+        "    {\"categorical\": {\"column_name\": \"city\"}},\n",
+        "    {\"categorical\": {\"column_name\": \"zip_code\"}},\n",
+        "    {\"categorical\": {\"column_name\": \"county\"}},\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_automl_pipeline:tabular,forecast"
+      },
+      "source": [
+        "### Create and run training job\n",
+        "\n",
+        "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
+        "\n",
+        "#### Create training job\n",
+        "\n",
+        "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
+        "\n",
+        "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
+        "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
+        "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
+        "    - `minimize-rmse`\n",
+        "    - `minimize-mae`\n",
+        "    - `minimize-rmsle`\n",
+        "\n",
+        "The instantiated object is the job for the training pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_automl_pipeline:tabular,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
+        "\n",
+        "training_job = aip.AutoMLForecastingTrainingJob(\n",
+        "    display_name=MODEL_DISPLAY_NAME,\n",
+        "    optimization_objective=\"minimize-rmse\",\n",
+        "    #     column_specs=COLUMN_SPECS,\n",
+        "    column_transformations=COLUMN_TRANSFORMATIONS,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_automl_pipeline:forecast"
+      },
+      "source": [
+        "#### Run the training pipeline\n",
+        "\n",
+        "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
+        "\n",
+        "- `dataset`: The `Dataset` resource to train the model.\n",
+        "- `model_display_name`: The human readable name for the trained model.\n",
+        "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
+        "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
+        "- `target_column`: The name of the column to train as the label.\n",
+        "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
+        "- `time_column`:\n",
+        "- `time_series_identifier_column`:\n",
+        "\n",
+        "The `run` method when completed returns the `Model` resource.\n",
+        "\n",
+        "The execution of the training pipeline will take up to 20 minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_automl_pipeline:forecast"
+      },
+      "outputs": [],
+      "source": [
+        "model = training_job.run(\n",
+        "    dataset=dataset,\n",
+        "    target_column=target_column,\n",
+        "    time_column=time_column,\n",
+        "    time_series_identifier_column=time_series_identifier_column,\n",
+        "    available_at_forecast_columns=[time_column],\n",
+        "    unavailable_at_forecast_columns=[target_column],\n",
+        "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
+        "    forecast_horizon=30,\n",
+        "    context_window=30,\n",
+        "    data_granularity_unit=\"day\",\n",
+        "    data_granularity_count=1,\n",
+        "    weight_column=None,\n",
+        "    budget_milli_node_hours=1000,\n",
+        "    model_display_name=\"iowa-liquor-sales-forecast-model\",\n",
+        "    predefined_split_column_name=None,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "evaluate_the_model:mbsdk"
+      },
+      "source": [
+        "## Review model evaluation scores\n",
+        "After your model has finished training, you can review the evaluation scores for it.\n",
+        "\n",
+        "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "evaluate_the_model:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "# Get model resource ID\n",
+        "models = aip.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
+        "\n",
+        "# Get a reference to the Model Service client\n",
+        "client_options = {\"api_endpoint\": f\"{REGION}-aiplatform.googleapis.com\"}\n",
+        "model_service_client = aip.gapic.ModelServiceClient(client_options=client_options)\n",
+        "\n",
+        "model_evaluations = model_service_client.list_model_evaluations(\n",
+        "    parent=models[0].resource_name\n",
+        ")\n",
+        "model_evaluation = list(model_evaluations)[0]\n",
+        "print(model_evaluation)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "make_prediction"
+      },
+      "source": [
+        "## Send a batch prediction request\n",
+        "\n",
+        "Send a batch prediction to your deployed model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "batch_request:mbsdk,both_csv"
+      },
+      "source": [
+        "### Make the batch prediction request\n",
+        "\n",
+        "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
+        "\n",
+        "- `job_display_name`: The human readable name for the batch prediction job.\n",
+        "- `gcs_source`: A list of one or more batch request input files.\n",
+        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
+        "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+        "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2c9d935c6ab9"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "from google.cloud import bigquery\n",
+        "\n",
+        "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
+        "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
+        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+        ")\n",
+        "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
+        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+        ")\n",
+        "# Must be the same region as batch_predict_bq_input_uri\n",
+        "client = bigquery.Client()\n",
+        "dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
+        "dataset_region = \"US\"  # @param {type : \"string\"}\n",
+        "dataset.location = dataset_region\n",
+        "dataset = client.create_dataset(dataset)\n",
+        "print(\n",
+        "    \"Created bigquery dataset {} in {}\".format(\n",
+        "        batch_predict_bq_output_dataset_path, dataset_region\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "batch_request:mbsdk,both_csv"
+      },
+      "outputs": [],
+      "source": [
+        "PREDICTION_DATASET_BQ_PATH = (\n",
+        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+        ")\n",
+        "\n",
+        "batch_prediction_job = model.batch_predict(\n",
+        "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
+        "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
+        "    instances_format=\"bigquery\",\n",
+        "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
+        "    predictions_format=\"bigquery\",\n",
+        "    sync=False,\n",
+        ")\n",
+        "\n",
+        "print(batch_prediction_job)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "batch_request_wait:mbsdk"
+      },
+      "source": [
+        "### Wait for completion of batch prediction job\n",
+        "\n",
+        "Next, wait for the batch job to complete. Alternatively, one can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "batch_request_wait:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "batch_prediction_job.wait()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "get_batch_prediction:mbsdk,forecast"
+      },
+      "source": [
+        "._gca_resource.output_info### Get the predictions\n",
+        "\n",
+        "Next, get the results from the completed batch prediction job.\n",
+        "\n",
+        "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
+        "\n",
+        "- CSV header + predicted_label\n",
+        "- CSV row + prediction, per prediction request"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "get_batch_prediction:mbsdk,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
+        "\n",
+        "prediction_results = list()\n",
+        "for blob in bp_iter_outputs:\n",
+        "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
+        "        prediction_results.append(blob.name)\n",
+        "\n",
+        "tags = list()\n",
+        "for prediction_result in prediction_results:\n",
+        "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
+        "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
+        "        for line in gfile.readlines():\n",
+        "            print(line)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f82f00be2160"
+      },
+      "outputs": [],
+      "source": [
+        "# @title # Visualize the Forecasts\n",
+        "# @markdown Follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
+        "\n",
+        "import urllib\n",
+        "\n",
+        "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
+        "\n",
+        "prediction_table_id = \"\"\n",
+        "for table in tables:\n",
+        "    if (\n",
+        "        table.table_id.startswith(\"predictions_\")\n",
+        "        and table.table_id > prediction_table_id\n",
+        "    ):\n",
+        "        prediction_table_id = table.table_id\n",
+        "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
+        "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
+        ")\n",
+        "\n",
+        "\n",
+        "def _sanitize_bq_uri(bq_uri):\n",
+        "    if bq_uri.startswith(\"bq://\"):\n",
+        "        bq_uri = bq_uri[5:]\n",
+        "    return bq_uri.replace(\":\", \".\")\n",
+        "\n",
+        "\n",
+        "def get_data_studio_link(\n",
+        "    batch_prediction_bq_input_uri,\n",
+        "    batch_prediction_bq_output_uri,\n",
+        "    time_column,\n",
+        "    time_series_identifier_column,\n",
+        "    target_column,\n",
+        "):\n",
+        "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
+        "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
+        "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
+        "    query = (\n",
+        "        \"SELECT \\\\n\"\n",
+        "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
+        "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
+        "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
+        "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
+        "        \" * \\\\n\"\n",
+        "        \"FROM `{}` input\\\\n\"\n",
+        "        \"LEFT JOIN `{}` output\\\\n\"\n",
+        "        \"ON\\\\n\"\n",
+        "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
+        "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
+        "    )\n",
+        "    query = query.format(\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        target_column,\n",
+        "        target_column,\n",
+        "        batch_prediction_bq_input_uri,\n",
+        "        batch_prediction_bq_output_uri,\n",
+        "        time_column,\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        time_series_identifier_column,\n",
+        "    )\n",
+        "    params = {\n",
+        "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
+        "        \"ds0.connector\": \"BIG_QUERY\",\n",
+        "        \"ds0.projectId\": PROJECT_ID,\n",
+        "        \"ds0.billingProjectId\": PROJECT_ID,\n",
+        "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
+        "        \"ds0.sql\": query,\n",
+        "    }\n",
+        "    params_str_parts = []\n",
+        "    for k, v in params.items():\n",
+        "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
+        "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
+        "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
+        "\n",
+        "\n",
+        "print(\n",
+        "    get_data_studio_link(\n",
+        "        PREDICTION_DATASET_BQ_PATH,\n",
+        "        batch_predict_bq_output_uri,\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        target_column,\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:mbsdk"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- AutoML Training Job\n",
+        "- Model\n",
+        "- Batch Prediction Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "# Delete dataset\n",
+        "dataset.delete()\n",
+        "\n",
+        "# Training job\n",
+        "training_job.delete()\n",
+        "\n",
+        "# Delete model\n",
+        "model.delete()\n",
+        "\n",
+        "# Delete batch prediction job\n",
+        "batch_prediction_job.delete()\n",
+        "\n",
+        "if os.getenv(\"IS_TESTING\"):\n",
+        "    ! gsutil rm -r $BUCKET_URI"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "sdk_automl_tabular_forecasting_batch.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -90,13 +90,7 @@
         "- Create a Vertex `Dataset` resource.\n",
         "- Train the model.\n",
         "- View the model evaluation.\n",
-        "- Make a batch prediction.\n",
-        "\n",
-        "There is one key difference between using batch prediction and using online prediction:\n",
-        "\n",
-        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
-        "\n",
-        "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
+        "- Make a batch prediction.\n"
       ]
     },
     {

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -1,1056 +1,1069 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title"
-      },
-      "source": [
-        "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-        "      Open in Google Cloud Notebooks\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:automl"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "\n",
-        "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:covid,forecast"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:automl,training,batch_prediction"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Create a Vertex `Dataset` resource.\n",
-        "- Train the model.\n",
-        "- View the model evaluation.\n",
-        "- Make a batch prediction.\n",
-        "\n",
-        "There is one key difference between using batch prediction and using online prediction:\n",
-        "\n",
-        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
-        "\n",
-        "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
-        "\n",
-        "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
-        "\n",
-        "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_tensorflow"
-      },
-      "outputs": [],
-      "source": [
-        "if os.environ[\"IS_TESTING\"]:\n",
-        "    ! pip3 install --upgrade tensorflow $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"[your-region]\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aiplatform"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex SDK for Python\n",
-        "\n",
-        "Initialize the Vertex SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tutorial_start:automl"
-      },
-      "source": [
-        "# Tutorial\n",
-        "\n",
-        "Now you are ready to start creating your own AutoML tabular forecasting model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "import_file:u_dataset,csv"
-      },
-      "source": [
-        "#### Location of BigQuery training data.\n",
-        "\n",
-        "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_file:covid,csv,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "TRAINING_DATASET_BQ_PATH = (\n",
-        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_dataset:tabular,forecast"
-      },
-      "source": [
-        "### Create the Dataset\n",
-        "\n",
-        "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
-        "\n",
-        "- `display_name`: The human readable name for the `Dataset` resource.\n",
-        "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
-        "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
-        "\n",
-        "This operation may take several minutes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_dataset:tabular,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "dataset = aiplatform.TimeSeriesDataset.create(\n",
-        "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
-        "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
-        ")\n",
-        "\n",
-        "time_column = \"date\"\n",
-        "time_series_identifier_column = \"store_name\"\n",
-        "target_column = \"sale_dollars\"\n",
-        "\n",
-        "print(dataset.resource_name)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_transformations:covid"
-      },
-      "outputs": [],
-      "source": [
-        "COLUMN_SPECS = {\n",
-        "    time_column: \"timestamp\",\n",
-        "    target_column: \"numeric\",\n",
-        "    \"city\": \"categorical\",\n",
-        "    \"zip_code\": \"categorical\",\n",
-        "    \"county\": \"categorical\",\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_automl_pipeline:tabular,forecast"
-      },
-      "source": [
-        "### Create and run training job\n",
-        "\n",
-        "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
-        "\n",
-        "#### Create training job\n",
-        "\n",
-        "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
-        "\n",
-        "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
-        "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
-        "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
-        "    - `minimize-rmse`\n",
-        "    - `minimize-mae`\n",
-        "    - `minimize-rmsle`\n",
-        "\n",
-        "The instantiated object is the job for the training pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_automl_pipeline:tabular,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
-        "\n",
-        "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
-        "    display_name=MODEL_DISPLAY_NAME,\n",
-        "    optimization_objective=\"minimize-rmse\",\n",
-        "    column_specs=COLUMN_SPECS,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_automl_pipeline:forecast"
-      },
-      "source": [
-        "#### Run the training pipeline\n",
-        "\n",
-        "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
-        "\n",
-        "- `dataset`: The `Dataset` resource to train the model.\n",
-        "- `model_display_name`: The human readable name for the trained model.\n",
-        "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
-        "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
-        "- `target_column`: The name of the column to train as the label.\n",
-        "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
-        "- `time_column`:\n",
-        "- `time_series_identifier_column`:\n",
-        "\n",
-        "The `run` method when completed returns the `Model` resource.\n",
-        "\n",
-        "The execution of the training pipeline will take up to 20 minutes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_automl_pipeline:forecast"
-      },
-      "outputs": [],
-      "source": [
-        "model = training_job.run(\n",
-        "    dataset=dataset,\n",
-        "    target_column=target_column,\n",
-        "    time_column=time_column,\n",
-        "    time_series_identifier_column=time_series_identifier_column,\n",
-        "    available_at_forecast_columns=[time_column],\n",
-        "    unavailable_at_forecast_columns=[target_column],\n",
-        "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
-        "    forecast_horizon=30,\n",
-        "    context_window=30,\n",
-        "    data_granularity_unit=\"day\",\n",
-        "    data_granularity_count=1,\n",
-        "    weight_column=None,\n",
-        "    budget_milli_node_hours=1000,\n",
-        "    model_display_name=MODEL_DISPLAY_NAME,\n",
-        "    predefined_split_column_name=None,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "evaluate_the_model:mbsdk"
-      },
-      "source": [
-        "## Review model evaluation scores\n",
-        "After your model has finished training, you can review the evaluation scores for it.\n",
-        "\n",
-        "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "evaluate_the_model:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "# Get model resource ID\n",
-        "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
-        "model = models[0]\n",
-        "\n",
-        "# Get a reference to the Model Service client\n",
-        "client_options = aiplatform.initializer.global_config.get_client_options()\n",
-        "model_service_client = aiplatform.gapic.ModelServiceClient(\n",
-        "    client_options=client_options\n",
-        ")\n",
-        "\n",
-        "model_evaluations = model_service_client.list_model_evaluations(\n",
-        "    parent=model.resource_name\n",
-        ")\n",
-        "model_evaluation = list(model_evaluations)[0]\n",
-        "print(model_evaluation)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "make_prediction"
-      },
-      "source": [
-        "## Send a batch prediction request\n",
-        "\n",
-        "Send a batch prediction to your deployed model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "batch_request:mbsdk,both_csv"
-      },
-      "source": [
-        "### Make the batch prediction request\n",
-        "\n",
-        "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
-        "\n",
-        "- `job_display_name`: The human readable name for the batch prediction job.\n",
-        "- `gcs_source`: A list of one or more batch request input files.\n",
-        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
-        "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-        "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2c9d935c6ab9"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "from google.cloud import bigquery\n",
-        "\n",
-        "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
-        "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
-        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-        ")\n",
-        "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
-        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-        ")\n",
-        "# Must be the same region as batch_predict_bq_input_uri\n",
-        "client = bigquery.Client()\n",
-        "dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
-        "dataset_region = \"US\"  # @param {type : \"string\"}\n",
-        "dataset.location = dataset_region\n",
-        "dataset = client.create_dataset(dataset)\n",
-        "print(\n",
-        "    \"Created bigquery dataset {} in {}\".format(\n",
-        "        batch_predict_bq_output_dataset_path, dataset_region\n",
-        "    )\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "batch_request:mbsdk,both_csv"
-      },
-      "outputs": [],
-      "source": [
-        "PREDICTION_DATASET_BQ_PATH = (\n",
-        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-        ")\n",
-        "\n",
-        "batch_prediction_job = model.batch_predict(\n",
-        "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
-        "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
-        "    instances_format=\"bigquery\",\n",
-        "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
-        "    predictions_format=\"bigquery\",\n",
-        "    sync=False,\n",
-        ")\n",
-        "\n",
-        "print(batch_prediction_job)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "batch_request_wait:mbsdk"
-      },
-      "source": [
-        "### Wait for completion of batch prediction job\n",
-        "\n",
-        "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "batch_request_wait:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "batch_prediction_job.wait()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "get_batch_prediction:mbsdk,forecast"
-      },
-      "source": [
-        "### Get the predictions\n",
-        "\n",
-        "Next, get the results from the completed batch prediction job.\n",
-        "\n",
-        "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
-        "\n",
-        "- CSV header + predicted_label\n",
-        "- CSV row + prediction, per prediction request"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "get_batch_prediction:mbsdk,forecast"
-      },
-      "outputs": [],
-      "source": [
-        "import tensorflow as tf\n",
-        "\n",
-        "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
-        "\n",
-        "prediction_results = list()\n",
-        "for blob in bp_iter_outputs:\n",
-        "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
-        "        prediction_results.append(blob.name)\n",
-        "\n",
-        "tags = list()\n",
-        "for prediction_result in prediction_results:\n",
-        "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
-        "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
-        "        for line in gfile.readlines():\n",
-        "            print(line)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "78080aa9088e"
-      },
-      "source": [
-        "### Visualize the forecasts\n",
-        "\n",
-        "Lastly, follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
-        "The code block included in this section dynamically generates a Data Studio link that specifies the template, the location of the forecasts, and the query to generate the chart. The data is populated from the forecasts generated earlier.\n",
-        "\n",
-        "You can inspect the used template at https://datastudio.google.com/c/u/0/reporting/067f70d2-8cd6-4a4c-a099-292acd1053e8. This was created by Google specifically to view forecasting predictions."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f82f00be2160"
-      },
-      "outputs": [],
-      "source": [
-        "import urllib\n",
-        "\n",
-        "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
-        "\n",
-        "prediction_table_id = \"\"\n",
-        "for table in tables:\n",
-        "    if (\n",
-        "        table.table_id.startswith(\"predictions_\")\n",
-        "        and table.table_id > prediction_table_id\n",
-        "    ):\n",
-        "        prediction_table_id = table.table_id\n",
-        "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
-        "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
-        ")\n",
-        "\n",
-        "\n",
-        "def _sanitize_bq_uri(bq_uri):\n",
-        "    if bq_uri.startswith(\"bq://\"):\n",
-        "        bq_uri = bq_uri[5:]\n",
-        "    return bq_uri.replace(\":\", \".\")\n",
-        "\n",
-        "\n",
-        "def get_data_studio_link(\n",
-        "    batch_prediction_bq_input_uri,\n",
-        "    batch_prediction_bq_output_uri,\n",
-        "    time_column,\n",
-        "    time_series_identifier_column,\n",
-        "    target_column,\n",
-        "):\n",
-        "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
-        "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
-        "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
-        "    query = (\n",
-        "        \"SELECT \\\\n\"\n",
-        "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
-        "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
-        "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
-        "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
-        "        \" * \\\\n\"\n",
-        "        \"FROM `{}` input\\\\n\"\n",
-        "        \"LEFT JOIN `{}` output\\\\n\"\n",
-        "        \"ON\\\\n\"\n",
-        "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
-        "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
-        "    )\n",
-        "    query = query.format(\n",
-        "        time_column,\n",
-        "        time_series_identifier_column,\n",
-        "        target_column,\n",
-        "        target_column,\n",
-        "        batch_prediction_bq_input_uri,\n",
-        "        batch_prediction_bq_output_uri,\n",
-        "        time_column,\n",
-        "        time_column,\n",
-        "        time_series_identifier_column,\n",
-        "        time_series_identifier_column,\n",
-        "    )\n",
-        "    params = {\n",
-        "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
-        "        \"ds0.connector\": \"BIG_QUERY\",\n",
-        "        \"ds0.projectId\": PROJECT_ID,\n",
-        "        \"ds0.billingProjectId\": PROJECT_ID,\n",
-        "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
-        "        \"ds0.sql\": query,\n",
-        "    }\n",
-        "    params_str_parts = []\n",
-        "    for k, v in params.items():\n",
-        "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
-        "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
-        "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
-        "\n",
-        "\n",
-        "print(\n",
-        "    get_data_studio_link(\n",
-        "        PREDICTION_DATASET_BQ_PATH,\n",
-        "        batch_predict_bq_output_uri,\n",
-        "        time_column,\n",
-        "        time_series_identifier_column,\n",
-        "        target_column,\n",
-        "    )\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:mbsdk"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- AutoML Training Job\n",
-        "- Model\n",
-        "- Batch Prediction Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "# Delete dataset\n",
-        "dataset.delete()\n",
-        "\n",
-        "# Training job\n",
-        "training_job.delete()\n",
-        "\n",
-        "# Delete model\n",
-        "model.delete()\n",
-        "\n",
-        "# Delete batch prediction job\n",
-        "batch_prediction_job.delete()\n",
-        "\n",
-        "if os.getenv(\"IS_TESTING\"):\n",
-        "    ! gsutil rm -r $BUCKET_URI"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "sdk_automl_tabular_forecasting_batch.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title"
+   },
+   "source": [
+    "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+    "      Open in Google Cloud Notebooks\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:automl"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "\n",
+    "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:covid,forecast"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:automl,training,batch_prediction"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Create a Vertex `Dataset` resource.\n",
+    "- Train the model.\n",
+    "- View the model evaluation.\n",
+    "- Make a batch prediction.\n",
+    "\n",
+    "There is one key difference between using batch prediction and using online prediction:\n",
+    "\n",
+    "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
+    "\n",
+    "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
+    "\n",
+    "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
+    "\n",
+    "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_tensorflow"
+   },
+   "outputs": [],
+   "source": [
+    "if os.environ[\"IS_TESTING\"]:\n",
+    "    ! pip3 install --upgrade tensorflow $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"[your-region]\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aiplatform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex SDK for Python\n",
+    "\n",
+    "Initialize the Vertex SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tutorial_start:automl"
+   },
+   "source": [
+    "# Tutorial\n",
+    "\n",
+    "Now you are ready to start creating your own AutoML tabular forecasting model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "import_file:u_dataset,csv"
+   },
+   "source": [
+    "#### Location of BigQuery training data.\n",
+    "\n",
+    "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_file:covid,csv,forecast"
+   },
+   "outputs": [],
+   "source": [
+    "TRAINING_DATASET_BQ_PATH = (\n",
+    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_dataset:tabular,forecast"
+   },
+   "source": [
+    "### Create the Dataset\n",
+    "\n",
+    "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
+    "\n",
+    "- `display_name`: The human readable name for the `Dataset` resource.\n",
+    "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
+    "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
+    "\n",
+    "This operation may take several minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_dataset:tabular,forecast"
+   },
+   "outputs": [],
+   "source": [
+    "dataset = aiplatform.TimeSeriesDataset.create(\n",
+    "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
+    "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
+    ")\n",
+    "\n",
+    "time_column = \"date\"\n",
+    "time_series_identifier_column = \"store_name\"\n",
+    "target_column = \"sale_dollars\"\n",
+    "\n",
+    "print(dataset.resource_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_transformations:covid"
+   },
+   "outputs": [],
+   "source": [
+    "COLUMN_SPECS = {\n",
+    "    time_column: \"timestamp\",\n",
+    "    target_column: \"numeric\",\n",
+    "    \"city\": \"categorical\",\n",
+    "    \"zip_code\": \"categorical\",\n",
+    "    \"county\": \"categorical\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_automl_pipeline:tabular,forecast"
+   },
+   "source": [
+    "### Create and run training job\n",
+    "\n",
+    "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
+    "\n",
+    "#### Create training job\n",
+    "\n",
+    "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
+    "\n",
+    "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
+    "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
+    "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
+    "    - `minimize-rmse`\n",
+    "    - `minimize-mae`\n",
+    "    - `minimize-rmsle`\n",
+    "\n",
+    "The instantiated object is the job for the training pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_automl_pipeline:tabular,forecast"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
+    "\n",
+    "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
+    "    display_name=MODEL_DISPLAY_NAME,\n",
+    "    optimization_objective=\"minimize-rmse\",\n",
+    "    column_specs=COLUMN_SPECS,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_automl_pipeline:forecast"
+   },
+   "source": [
+    "#### Run the training pipeline\n",
+    "\n",
+    "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
+    "\n",
+    "- `dataset`: The `Dataset` resource to train the model.\n",
+    "- `model_display_name`: The human readable name for the trained model.\n",
+    "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
+    "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
+    "- `target_column`: The name of the column to train as the label.\n",
+    "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
+    "- `time_column`:\n",
+    "- `time_series_identifier_column`:\n",
+    "\n",
+    "The `run` method when completed returns the `Model` resource.\n",
+    "\n",
+    "The execution of the training pipeline will take up to 20 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "run_automl_pipeline:forecast"
+   },
+   "outputs": [],
+   "source": [
+    "model = training_job.run(\n",
+    "    dataset=dataset,\n",
+    "    target_column=target_column,\n",
+    "    time_column=time_column,\n",
+    "    time_series_identifier_column=time_series_identifier_column,\n",
+    "    available_at_forecast_columns=[time_column],\n",
+    "    unavailable_at_forecast_columns=[target_column],\n",
+    "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
+    "    forecast_horizon=30,\n",
+    "    context_window=30,\n",
+    "    data_granularity_unit=\"day\",\n",
+    "    data_granularity_count=1,\n",
+    "    weight_column=None,\n",
+    "    budget_milli_node_hours=1000,\n",
+    "    model_display_name=MODEL_DISPLAY_NAME,\n",
+    "    predefined_split_column_name=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "evaluate_the_model:mbsdk"
+   },
+   "source": [
+    "## Review model evaluation scores\n",
+    "After your model has finished training, you can review the evaluation scores for it.\n",
+    "\n",
+    "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "evaluate_the_model:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "# Get model resource ID\n",
+    "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
+    "model = models[0]\n",
+    "\n",
+    "# Get a reference to the Model Service client\n",
+    "client_options = aiplatform.initializer.global_config.get_client_options()\n",
+    "model_service_client = aiplatform.gapic.ModelServiceClient(\n",
+    "    client_options=client_options\n",
+    ")\n",
+    "\n",
+    "model_evaluations = model_service_client.list_model_evaluations(\n",
+    "    parent=model.resource_name\n",
+    ")\n",
+    "model_evaluation = list(model_evaluations)[0]\n",
+    "print(model_evaluation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "make_prediction"
+   },
+   "source": [
+    "## Send a batch prediction request\n",
+    "\n",
+    "Send a batch prediction to your deployed model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "batch_request:mbsdk,both_csv"
+   },
+   "source": [
+    "### Make the batch prediction request\n",
+    "\n",
+    "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
+    "\n",
+    "- `job_display_name`: The human readable name for the batch prediction job.\n",
+    "- `gcs_source`: A list of one or more batch request input files.\n",
+    "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
+    "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+    "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+    "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2c9d935c6ab9"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
+    "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
+    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+    ")\n",
+    "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
+    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+    ")\n",
+    "# Must be the same region as batch_predict_bq_input_uri\n",
+    "client = bigquery.Client()\n",
+    "bq_dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
+    "dataset_region = \"US\"  # @param {type : \"string\"}\n",
+    "bq_dataset.location = dataset_region\n",
+    "bq_dataset = client.create_dataset(bq_dataset)\n",
+    "print(\n",
+    "    \"Created bigquery dataset {} in {}\".format(\n",
+    "        batch_predict_bq_output_dataset_path, dataset_region\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "batch_request:mbsdk,both_csv"
+   },
+   "outputs": [],
+   "source": [
+    "PREDICTION_DATASET_BQ_PATH = (\n",
+    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+    ")\n",
+    "\n",
+    "batch_prediction_job = model.batch_predict(\n",
+    "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
+    "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
+    "    instances_format=\"bigquery\",\n",
+    "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
+    "    predictions_format=\"bigquery\",\n",
+    "    sync=False,\n",
+    ")\n",
+    "\n",
+    "print(batch_prediction_job)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "batch_request_wait:mbsdk"
+   },
+   "source": [
+    "### Wait for completion of batch prediction job\n",
+    "\n",
+    "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "batch_request_wait:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "batch_prediction_job.wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "get_batch_prediction:mbsdk,forecast"
+   },
+   "source": [
+    "### Get the predictions\n",
+    "\n",
+    "Next, get the results from the completed batch prediction job.\n",
+    "\n",
+    "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
+    "\n",
+    "- CSV header + predicted_label\n",
+    "- CSV row + prediction, per prediction request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "get_batch_prediction:mbsdk,forecast"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
+    "\n",
+    "prediction_results = list()\n",
+    "for blob in bp_iter_outputs:\n",
+    "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
+    "        prediction_results.append(blob.name)\n",
+    "\n",
+    "tags = list()\n",
+    "for prediction_result in prediction_results:\n",
+    "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
+    "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
+    "        for line in gfile.readlines():\n",
+    "            print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "78080aa9088e"
+   },
+   "source": [
+    "### Visualize the forecasts\n",
+    "\n",
+    "Lastly, follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
+    "The code block included in this section dynamically generates a Data Studio link that specifies the template, the location of the forecasts, and the query to generate the chart. The data is populated from the forecasts generated earlier.\n",
+    "\n",
+    "You can inspect the used template at https://datastudio.google.com/c/u/0/reporting/067f70d2-8cd6-4a4c-a099-292acd1053e8. This was created by Google specifically to view forecasting predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f82f00be2160"
+   },
+   "outputs": [],
+   "source": [
+    "import urllib\n",
+    "\n",
+    "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
+    "\n",
+    "prediction_table_id = \"\"\n",
+    "for table in tables:\n",
+    "    if (\n",
+    "        table.table_id.startswith(\"predictions_\")\n",
+    "        and table.table_id > prediction_table_id\n",
+    "    ):\n",
+    "        prediction_table_id = table.table_id\n",
+    "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
+    "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def _sanitize_bq_uri(bq_uri):\n",
+    "    if bq_uri.startswith(\"bq://\"):\n",
+    "        bq_uri = bq_uri[5:]\n",
+    "    return bq_uri.replace(\":\", \".\")\n",
+    "\n",
+    "\n",
+    "def get_data_studio_link(\n",
+    "    batch_prediction_bq_input_uri,\n",
+    "    batch_prediction_bq_output_uri,\n",
+    "    time_column,\n",
+    "    time_series_identifier_column,\n",
+    "    target_column,\n",
+    "):\n",
+    "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
+    "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
+    "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
+    "    query = (\n",
+    "        \"SELECT \\\\n\"\n",
+    "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
+    "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
+    "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
+    "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
+    "        \" * \\\\n\"\n",
+    "        \"FROM `{}` input\\\\n\"\n",
+    "        \"LEFT JOIN `{}` output\\\\n\"\n",
+    "        \"ON\\\\n\"\n",
+    "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
+    "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
+    "    )\n",
+    "    query = query.format(\n",
+    "        time_column,\n",
+    "        time_series_identifier_column,\n",
+    "        target_column,\n",
+    "        target_column,\n",
+    "        batch_prediction_bq_input_uri,\n",
+    "        batch_prediction_bq_output_uri,\n",
+    "        time_column,\n",
+    "        time_column,\n",
+    "        time_series_identifier_column,\n",
+    "        time_series_identifier_column,\n",
+    "    )\n",
+    "    params = {\n",
+    "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
+    "        \"ds0.connector\": \"BIG_QUERY\",\n",
+    "        \"ds0.projectId\": PROJECT_ID,\n",
+    "        \"ds0.billingProjectId\": PROJECT_ID,\n",
+    "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
+    "        \"ds0.sql\": query,\n",
+    "    }\n",
+    "    params_str_parts = []\n",
+    "    for k, v in params.items():\n",
+    "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
+    "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
+    "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
+    "\n",
+    "\n",
+    "print(\n",
+    "    get_data_studio_link(\n",
+    "        PREDICTION_DATASET_BQ_PATH,\n",
+    "        batch_predict_bq_output_uri,\n",
+    "        time_column,\n",
+    "        time_series_identifier_column,\n",
+    "        target_column,\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:mbsdk"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- AutoML Training Job\n",
+    "- Model\n",
+    "- Batch Prediction Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "# Delete dataset\n",
+    "dataset.delete()\n",
+    "\n",
+    "# Training job\n",
+    "training_job.delete()\n",
+    "\n",
+    "# Delete model\n",
+    "model.delete()\n",
+    "\n",
+    "# Delete batch prediction job\n",
+    "batch_prediction_job.delete()\n",
+    "\n",
+    "if os.getenv(\"IS_TESTING\"):\n",
+    "    ! gsutil rm -r $BUCKET_URI"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "sdk_automl_tabular_forecasting_batch.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -29,7 +29,7 @@
         "id": "title"
       },
       "source": [
-        "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
+        "# Vertex SDK: AutoML tabular forecasting model for batch prediction\n",
         "\n",
         "<table align=\"left\">\n",
         "  <td>\n",

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -1,1069 +1,1056 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title"
+      },
+      "source": [
+        "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
+        "      Open in Google Cloud Notebooks\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:automl"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "\n",
+        "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:covid,forecast"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:automl,training,batch_prediction"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a Vertex `Dataset` resource.\n",
+        "- Train the model.\n",
+        "- View the model evaluation.\n",
+        "- Make a batch prediction.\n",
+        "\n",
+        "There is one key difference between using batch prediction and using online prediction:\n",
+        "\n",
+        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
+        "\n",
+        "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
+        "\n",
+        "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
+        "\n",
+        "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_tensorflow"
+      },
+      "outputs": [],
+      "source": [
+        "if os.environ[\"IS_TESTING\"]:\n",
+        "    ! pip3 install --upgrade tensorflow $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"[your-region]\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aiplatform"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex SDK for Python\n",
+        "\n",
+        "Initialize the Vertex SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tutorial_start:automl"
+      },
+      "source": [
+        "# Tutorial\n",
+        "\n",
+        "Now you are ready to start creating your own AutoML tabular forecasting model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "import_file:u_dataset,csv"
+      },
+      "source": [
+        "#### Location of BigQuery training data.\n",
+        "\n",
+        "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_file:covid,csv,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "TRAINING_DATASET_BQ_PATH = (\n",
+        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_dataset:tabular,forecast"
+      },
+      "source": [
+        "### Create the Dataset\n",
+        "\n",
+        "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
+        "\n",
+        "- `display_name`: The human readable name for the `Dataset` resource.\n",
+        "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
+        "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
+        "\n",
+        "This operation may take several minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_dataset:tabular,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "dataset = aiplatform.TimeSeriesDataset.create(\n",
+        "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
+        "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
+        ")\n",
+        "\n",
+        "time_column = \"date\"\n",
+        "time_series_identifier_column = \"store_name\"\n",
+        "target_column = \"sale_dollars\"\n",
+        "\n",
+        "print(dataset.resource_name)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_transformations:covid"
+      },
+      "outputs": [],
+      "source": [
+        "COLUMN_SPECS = {\n",
+        "    time_column: \"timestamp\",\n",
+        "    target_column: \"numeric\",\n",
+        "    \"city\": \"categorical\",\n",
+        "    \"zip_code\": \"categorical\",\n",
+        "    \"county\": \"categorical\",\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_automl_pipeline:tabular,forecast"
+      },
+      "source": [
+        "### Create and run training job\n",
+        "\n",
+        "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
+        "\n",
+        "#### Create training job\n",
+        "\n",
+        "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
+        "\n",
+        "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
+        "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
+        "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
+        "    - `minimize-rmse`\n",
+        "    - `minimize-mae`\n",
+        "    - `minimize-rmsle`\n",
+        "\n",
+        "The instantiated object is the job for the training pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_automl_pipeline:tabular,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
+        "\n",
+        "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
+        "    display_name=MODEL_DISPLAY_NAME,\n",
+        "    optimization_objective=\"minimize-rmse\",\n",
+        "    column_specs=COLUMN_SPECS,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_automl_pipeline:forecast"
+      },
+      "source": [
+        "#### Run the training pipeline\n",
+        "\n",
+        "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
+        "\n",
+        "- `dataset`: The `Dataset` resource to train the model.\n",
+        "- `model_display_name`: The human readable name for the trained model.\n",
+        "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
+        "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
+        "- `target_column`: The name of the column to train as the label.\n",
+        "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
+        "- `time_column`:\n",
+        "- `time_series_identifier_column`:\n",
+        "\n",
+        "The `run` method when completed returns the `Model` resource.\n",
+        "\n",
+        "The execution of the training pipeline will take up to 20 minutes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_automl_pipeline:forecast"
+      },
+      "outputs": [],
+      "source": [
+        "model = training_job.run(\n",
+        "    dataset=dataset,\n",
+        "    target_column=target_column,\n",
+        "    time_column=time_column,\n",
+        "    time_series_identifier_column=time_series_identifier_column,\n",
+        "    available_at_forecast_columns=[time_column],\n",
+        "    unavailable_at_forecast_columns=[target_column],\n",
+        "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
+        "    forecast_horizon=30,\n",
+        "    context_window=30,\n",
+        "    data_granularity_unit=\"day\",\n",
+        "    data_granularity_count=1,\n",
+        "    weight_column=None,\n",
+        "    budget_milli_node_hours=1000,\n",
+        "    model_display_name=MODEL_DISPLAY_NAME,\n",
+        "    predefined_split_column_name=None,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "evaluate_the_model:mbsdk"
+      },
+      "source": [
+        "## Review model evaluation scores\n",
+        "After your model has finished training, you can review the evaluation scores for it.\n",
+        "\n",
+        "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "evaluate_the_model:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "# Get model resource ID\n",
+        "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
+        "model = models[0]\n",
+        "\n",
+        "# Get a reference to the Model Service client\n",
+        "client_options = aiplatform.initializer.global_config.get_client_options()\n",
+        "model_service_client = aiplatform.gapic.ModelServiceClient(\n",
+        "    client_options=client_options\n",
+        ")\n",
+        "\n",
+        "model_evaluations = model_service_client.list_model_evaluations(\n",
+        "    parent=model.resource_name\n",
+        ")\n",
+        "model_evaluation = list(model_evaluations)[0]\n",
+        "print(model_evaluation)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "make_prediction"
+      },
+      "source": [
+        "## Send a batch prediction request\n",
+        "\n",
+        "Send a batch prediction to your deployed model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "batch_request:mbsdk,both_csv"
+      },
+      "source": [
+        "### Make the batch prediction request\n",
+        "\n",
+        "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
+        "\n",
+        "- `job_display_name`: The human readable name for the batch prediction job.\n",
+        "- `gcs_source`: A list of one or more batch request input files.\n",
+        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
+        "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+        "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
+        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2c9d935c6ab9"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "from google.cloud import bigquery\n",
+        "\n",
+        "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
+        "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
+        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+        ")\n",
+        "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
+        "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
+        ")\n",
+        "# Must be the same region as batch_predict_bq_input_uri\n",
+        "client = bigquery.Client()\n",
+        "bq_dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
+        "dataset_region = \"US\"  # @param {type : \"string\"}\n",
+        "bq_dataset.location = dataset_region\n",
+        "bq_dataset = client.create_dataset(bq_dataset)\n",
+        "print(\n",
+        "    \"Created bigquery dataset {} in {}\".format(\n",
+        "        batch_predict_bq_output_dataset_path, dataset_region\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "batch_request:mbsdk,both_csv"
+      },
+      "outputs": [],
+      "source": [
+        "PREDICTION_DATASET_BQ_PATH = (\n",
+        "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
+        ")\n",
+        "\n",
+        "batch_prediction_job = model.batch_predict(\n",
+        "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
+        "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
+        "    instances_format=\"bigquery\",\n",
+        "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
+        "    predictions_format=\"bigquery\",\n",
+        "    sync=False,\n",
+        ")\n",
+        "\n",
+        "print(batch_prediction_job)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "batch_request_wait:mbsdk"
+      },
+      "source": [
+        "### Wait for completion of batch prediction job\n",
+        "\n",
+        "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "batch_request_wait:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "batch_prediction_job.wait()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "get_batch_prediction:mbsdk,forecast"
+      },
+      "source": [
+        "### Get the predictions\n",
+        "\n",
+        "Next, get the results from the completed batch prediction job.\n",
+        "\n",
+        "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
+        "\n",
+        "- CSV header + predicted_label\n",
+        "- CSV row + prediction, per prediction request"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "get_batch_prediction:mbsdk,forecast"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
+        "\n",
+        "prediction_results = list()\n",
+        "for blob in bp_iter_outputs:\n",
+        "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
+        "        prediction_results.append(blob.name)\n",
+        "\n",
+        "tags = list()\n",
+        "for prediction_result in prediction_results:\n",
+        "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
+        "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
+        "        for line in gfile.readlines():\n",
+        "            print(line)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "78080aa9088e"
+      },
+      "source": [
+        "### Visualize the forecasts\n",
+        "\n",
+        "Lastly, follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
+        "The code block included in this section dynamically generates a Data Studio link that specifies the template, the location of the forecasts, and the query to generate the chart. The data is populated from the forecasts generated earlier.\n",
+        "\n",
+        "You can inspect the used template at https://datastudio.google.com/c/u/0/reporting/067f70d2-8cd6-4a4c-a099-292acd1053e8. This was created by Google specifically to view forecasting predictions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f82f00be2160"
+      },
+      "outputs": [],
+      "source": [
+        "import urllib\n",
+        "\n",
+        "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
+        "\n",
+        "prediction_table_id = \"\"\n",
+        "for table in tables:\n",
+        "    if (\n",
+        "        table.table_id.startswith(\"predictions_\")\n",
+        "        and table.table_id > prediction_table_id\n",
+        "    ):\n",
+        "        prediction_table_id = table.table_id\n",
+        "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
+        "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
+        ")\n",
+        "\n",
+        "\n",
+        "def _sanitize_bq_uri(bq_uri):\n",
+        "    if bq_uri.startswith(\"bq://\"):\n",
+        "        bq_uri = bq_uri[5:]\n",
+        "    return bq_uri.replace(\":\", \".\")\n",
+        "\n",
+        "\n",
+        "def get_data_studio_link(\n",
+        "    batch_prediction_bq_input_uri,\n",
+        "    batch_prediction_bq_output_uri,\n",
+        "    time_column,\n",
+        "    time_series_identifier_column,\n",
+        "    target_column,\n",
+        "):\n",
+        "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
+        "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
+        "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
+        "    query = (\n",
+        "        \"SELECT \\\\n\"\n",
+        "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
+        "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
+        "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
+        "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
+        "        \" * \\\\n\"\n",
+        "        \"FROM `{}` input\\\\n\"\n",
+        "        \"LEFT JOIN `{}` output\\\\n\"\n",
+        "        \"ON\\\\n\"\n",
+        "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
+        "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
+        "    )\n",
+        "    query = query.format(\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        target_column,\n",
+        "        target_column,\n",
+        "        batch_prediction_bq_input_uri,\n",
+        "        batch_prediction_bq_output_uri,\n",
+        "        time_column,\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        time_series_identifier_column,\n",
+        "    )\n",
+        "    params = {\n",
+        "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
+        "        \"ds0.connector\": \"BIG_QUERY\",\n",
+        "        \"ds0.projectId\": PROJECT_ID,\n",
+        "        \"ds0.billingProjectId\": PROJECT_ID,\n",
+        "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
+        "        \"ds0.sql\": query,\n",
+        "    }\n",
+        "    params_str_parts = []\n",
+        "    for k, v in params.items():\n",
+        "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
+        "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
+        "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
+        "\n",
+        "\n",
+        "print(\n",
+        "    get_data_studio_link(\n",
+        "        PREDICTION_DATASET_BQ_PATH,\n",
+        "        batch_predict_bq_output_uri,\n",
+        "        time_column,\n",
+        "        time_series_identifier_column,\n",
+        "        target_column,\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:mbsdk"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- AutoML Training Job\n",
+        "- Model\n",
+        "- Batch Prediction Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "# Delete dataset\n",
+        "dataset.delete()\n",
+        "\n",
+        "# Training job\n",
+        "training_job.delete()\n",
+        "\n",
+        "# Delete model\n",
+        "model.delete()\n",
+        "\n",
+        "# Delete batch prediction job\n",
+        "batch_prediction_job.delete()\n",
+        "\n",
+        "if os.getenv(\"IS_TESTING\"):\n",
+        "    ! gsutil rm -r $BUCKET_URI"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "sdk_automl_tabular_forecasting_batch.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title"
-   },
-   "source": [
-    "# Vertex SDK: AutoML training tabular forecasting model for batch prediction\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb\">\n",
-    "      Open in Google Cloud Notebooks\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:automl"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "\n",
-    "This tutorial demonstrates how to use the Vertex SDK to create tabular forecasting models and do batch prediction using a Google Cloud [AutoML](https://cloud.google.com/vertex-ai/docs/start/automl-users) model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:covid,forecast"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial a time series dataset containing samples drawn from the Iowa Liquor Retail Sales dataset. Data were made available by the Iowa Department of Commerce. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://console.cloud.google.com/marketplace/product/iowa-department-of-commerce/iowa-liquor-sales. This dataset does not require any feature engineering. The version of the dataset you will use in this tutorial is stored in BigQuery."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:automl,training,batch_prediction"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an AutoML tabular forecasting model from a Python script, and then do a batch prediction using the Vertex SDK. You can alternatively create and deploy models using the `gcloud` command-line tool or online using the Cloud Console.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Create a Vertex `Dataset` resource.\n",
-    "- Train the model.\n",
-    "- View the model evaluation.\n",
-    "- Make a batch prediction.\n",
-    "\n",
-    "There is one key difference between using batch prediction and using online prediction:\n",
-    "\n",
-    "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
-    "\n",
-    "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebooks, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](https://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.  Activate the virtual environment.\n",
-    "\n",
-    "4. To install Jupyter, run `pip3 install jupyter` on the command-line in a terminal shell.\n",
-    "\n",
-    "5. To launch Jupyter, run `jupyter notebook` on the command-line in a terminal shell.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_tensorflow"
-   },
-   "outputs": [],
-   "source": [
-    "if os.environ[\"IS_TESTING\"]:\n",
-    "    ! pip3 install --upgrade tensorflow $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the following APIs: Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. If you are running this notebook locally, you will need to install the [Cloud SDK]((https://cloud.google.com/sdk)).\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"[your-region]\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebooks**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aiplatform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex SDK for Python\n",
-    "\n",
-    "Initialize the Vertex SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "tutorial_start:automl"
-   },
-   "source": [
-    "# Tutorial\n",
-    "\n",
-    "Now you are ready to start creating your own AutoML tabular forecasting model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "import_file:u_dataset,csv"
-   },
-   "source": [
-    "#### Location of BigQuery training data.\n",
-    "\n",
-    "Now set the variable `TRAINING_DATASET_BQ_PATH` to the location of the BigQuery table. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_file:covid,csv,forecast"
-   },
-   "outputs": [],
-   "source": [
-    "TRAINING_DATASET_BQ_PATH = (\n",
-    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_dataset:tabular,forecast"
-   },
-   "source": [
-    "### Create the Dataset\n",
-    "\n",
-    "Next, create the `Dataset` resource using the `create` method for the `TimeSeriesDataset` class, which takes the following parameters:\n",
-    "\n",
-    "- `display_name`: The human readable name for the `Dataset` resource.\n",
-    "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
-    "- `bq_source`: Alternatively, import data items from a BigQuery table into the `Dataset` resource.\n",
-    "\n",
-    "This operation may take several minutes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_dataset:tabular,forecast"
-   },
-   "outputs": [],
-   "source": [
-    "dataset = aiplatform.TimeSeriesDataset.create(\n",
-    "    display_name=\"iowa_liquor_sales_train\" + \"_\" + TIMESTAMP,\n",
-    "    bq_source=[TRAINING_DATASET_BQ_PATH],\n",
-    ")\n",
-    "\n",
-    "time_column = \"date\"\n",
-    "time_series_identifier_column = \"store_name\"\n",
-    "target_column = \"sale_dollars\"\n",
-    "\n",
-    "print(dataset.resource_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_transformations:covid"
-   },
-   "outputs": [],
-   "source": [
-    "COLUMN_SPECS = {\n",
-    "    time_column: \"timestamp\",\n",
-    "    target_column: \"numeric\",\n",
-    "    \"city\": \"categorical\",\n",
-    "    \"zip_code\": \"categorical\",\n",
-    "    \"county\": \"categorical\",\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_automl_pipeline:tabular,forecast"
-   },
-   "source": [
-    "### Create and run training job\n",
-    "\n",
-    "To train an AutoML model, you perform two steps: 1) create a training job, and 2) run the job.\n",
-    "\n",
-    "#### Create training job\n",
-    "\n",
-    "An AutoML training job is created with the `AutoMLForecastingTrainingJob` class, with the following parameters:\n",
-    "\n",
-    "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
-    "- `column_transformations`: (Optional): Transformations to apply to the input columns\n",
-    "- `optimization_objective`: The optimization objective to minimize or maximize.\n",
-    "    - `minimize-rmse`\n",
-    "    - `minimize-mae`\n",
-    "    - `minimize-rmsle`\n",
-    "\n",
-    "The instantiated object is the job for the training pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_automl_pipeline:tabular,forecast"
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_DISPLAY_NAME = f\"iowa-liquor-sales-forecast-model_{TIMESTAMP}\"\n",
-    "\n",
-    "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
-    "    display_name=MODEL_DISPLAY_NAME,\n",
-    "    optimization_objective=\"minimize-rmse\",\n",
-    "    column_specs=COLUMN_SPECS,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_automl_pipeline:forecast"
-   },
-   "source": [
-    "#### Run the training pipeline\n",
-    "\n",
-    "Next, you start the training job by invoking the method `run`, with the following parameters:\n",
-    "\n",
-    "- `dataset`: The `Dataset` resource to train the model.\n",
-    "- `model_display_name`: The human readable name for the trained model.\n",
-    "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
-    "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
-    "- `target_column`: The name of the column to train as the label.\n",
-    "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
-    "- `time_column`:\n",
-    "- `time_series_identifier_column`:\n",
-    "\n",
-    "The `run` method when completed returns the `Model` resource.\n",
-    "\n",
-    "The execution of the training pipeline will take up to 20 minutes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run_automl_pipeline:forecast"
-   },
-   "outputs": [],
-   "source": [
-    "model = training_job.run(\n",
-    "    dataset=dataset,\n",
-    "    target_column=target_column,\n",
-    "    time_column=time_column,\n",
-    "    time_series_identifier_column=time_series_identifier_column,\n",
-    "    available_at_forecast_columns=[time_column],\n",
-    "    unavailable_at_forecast_columns=[target_column],\n",
-    "    time_series_attribute_columns=[\"city\", \"zip_code\", \"county\"],\n",
-    "    forecast_horizon=30,\n",
-    "    context_window=30,\n",
-    "    data_granularity_unit=\"day\",\n",
-    "    data_granularity_count=1,\n",
-    "    weight_column=None,\n",
-    "    budget_milli_node_hours=1000,\n",
-    "    model_display_name=MODEL_DISPLAY_NAME,\n",
-    "    predefined_split_column_name=None,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "evaluate_the_model:mbsdk"
-   },
-   "source": [
-    "## Review model evaluation scores\n",
-    "After your model has finished training, you can review the evaluation scores for it.\n",
-    "\n",
-    "First, you need to get a reference to the new model. As with datasets, you can either use the reference to the model variable you created when you deployed the model or you can list all of the models in your project."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "evaluate_the_model:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "# Get model resource ID\n",
-    "models = aiplatform.Model.list(filter=f\"display_name={MODEL_DISPLAY_NAME}\")\n",
-    "model = models[0]\n",
-    "\n",
-    "# Get a reference to the Model Service client\n",
-    "client_options = aiplatform.initializer.global_config.get_client_options()\n",
-    "model_service_client = aiplatform.gapic.ModelServiceClient(\n",
-    "    client_options=client_options\n",
-    ")\n",
-    "\n",
-    "model_evaluations = model_service_client.list_model_evaluations(\n",
-    "    parent=model.resource_name\n",
-    ")\n",
-    "model_evaluation = list(model_evaluations)[0]\n",
-    "print(model_evaluation)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "make_prediction"
-   },
-   "source": [
-    "## Send a batch prediction request\n",
-    "\n",
-    "Send a batch prediction to your deployed model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "batch_request:mbsdk,both_csv"
-   },
-   "source": [
-    "### Make the batch prediction request\n",
-    "\n",
-    "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
-    "\n",
-    "- `job_display_name`: The human readable name for the batch prediction job.\n",
-    "- `gcs_source`: A list of one or more batch request input files.\n",
-    "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
-    "- `instances_format`: The format for the input instances, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-    "- `predictions_format`: The format for the output predictions, either 'csv' or 'jsonl'. Defaults to 'jsonl'.\n",
-    "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "2c9d935c6ab9"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "from google.cloud import bigquery\n",
-    "\n",
-    "batch_predict_bq_output_dataset_name = f\"iowa_liquor_sales_predictions_{TIMESTAMP}\"\n",
-    "batch_predict_bq_output_dataset_path = \"{}.{}\".format(\n",
-    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-    ")\n",
-    "batch_predict_bq_output_uri_prefix = \"bq://{}.{}\".format(\n",
-    "    PROJECT_ID, batch_predict_bq_output_dataset_name\n",
-    ")\n",
-    "# Must be the same region as batch_predict_bq_input_uri\n",
-    "client = bigquery.Client()\n",
-    "bq_dataset = bigquery.Dataset(batch_predict_bq_output_dataset_path)\n",
-    "dataset_region = \"US\"  # @param {type : \"string\"}\n",
-    "bq_dataset.location = dataset_region\n",
-    "bq_dataset = client.create_dataset(bq_dataset)\n",
-    "print(\n",
-    "    \"Created bigquery dataset {} in {}\".format(\n",
-    "        batch_predict_bq_output_dataset_path, dataset_region\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "batch_request:mbsdk,both_csv"
-   },
-   "outputs": [],
-   "source": [
-    "PREDICTION_DATASET_BQ_PATH = (\n",
-    "    \"bq://bigquery-public-data:iowa_liquor_sales_forecasting.2020_sales_train\"\n",
-    ")\n",
-    "\n",
-    "batch_prediction_job = model.batch_predict(\n",
-    "    job_display_name=f\"iowa_liquor_sales_forecasting_predictions_{TIMESTAMP}\",\n",
-    "    bigquery_source=PREDICTION_DATASET_BQ_PATH,\n",
-    "    instances_format=\"bigquery\",\n",
-    "    bigquery_destination_prefix=batch_predict_bq_output_uri_prefix,\n",
-    "    predictions_format=\"bigquery\",\n",
-    "    sync=False,\n",
-    ")\n",
-    "\n",
-    "print(batch_prediction_job)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "batch_request_wait:mbsdk"
-   },
-   "source": [
-    "### Wait for completion of batch prediction job\n",
-    "\n",
-    "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "batch_request_wait:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "batch_prediction_job.wait()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "get_batch_prediction:mbsdk,forecast"
-   },
-   "source": [
-    "### Get the predictions\n",
-    "\n",
-    "Next, get the results from the completed batch prediction job.\n",
-    "\n",
-    "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a CSV format:\n",
-    "\n",
-    "- CSV header + predicted_label\n",
-    "- CSV row + prediction, per prediction request"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "get_batch_prediction:mbsdk,forecast"
-   },
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "bp_iter_outputs = batch_prediction_job.iter_outputs()\n",
-    "\n",
-    "prediction_results = list()\n",
-    "for blob in bp_iter_outputs:\n",
-    "    if blob.name.split(\"/\")[-1].startswith(\"prediction\"):\n",
-    "        prediction_results.append(blob.name)\n",
-    "\n",
-    "tags = list()\n",
-    "for prediction_result in prediction_results:\n",
-    "    gfile_name = f\"gs://{bp_iter_outputs.bucket.name}/{prediction_result}\"\n",
-    "    with tf.io.gfile.GFile(name=gfile_name, mode=\"r\") as gfile:\n",
-    "        for line in gfile.readlines():\n",
-    "            print(line)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "78080aa9088e"
-   },
-   "source": [
-    "### Visualize the forecasts\n",
-    "\n",
-    "Lastly, follow the given link to visualize the generated forecasts in [Data Studio](https://support.google.com/datastudio/answer/6283323?hl=en).\n",
-    "The code block included in this section dynamically generates a Data Studio link that specifies the template, the location of the forecasts, and the query to generate the chart. The data is populated from the forecasts generated earlier.\n",
-    "\n",
-    "You can inspect the used template at https://datastudio.google.com/c/u/0/reporting/067f70d2-8cd6-4a4c-a099-292acd1053e8. This was created by Google specifically to view forecasting predictions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "f82f00be2160"
-   },
-   "outputs": [],
-   "source": [
-    "import urllib\n",
-    "\n",
-    "tables = client.list_tables(batch_predict_bq_output_dataset_path)\n",
-    "\n",
-    "prediction_table_id = \"\"\n",
-    "for table in tables:\n",
-    "    if (\n",
-    "        table.table_id.startswith(\"predictions_\")\n",
-    "        and table.table_id > prediction_table_id\n",
-    "    ):\n",
-    "        prediction_table_id = table.table_id\n",
-    "batch_predict_bq_output_uri = \"{}.{}\".format(\n",
-    "    batch_predict_bq_output_dataset_path, prediction_table_id\n",
-    ")\n",
-    "\n",
-    "\n",
-    "def _sanitize_bq_uri(bq_uri):\n",
-    "    if bq_uri.startswith(\"bq://\"):\n",
-    "        bq_uri = bq_uri[5:]\n",
-    "    return bq_uri.replace(\":\", \".\")\n",
-    "\n",
-    "\n",
-    "def get_data_studio_link(\n",
-    "    batch_prediction_bq_input_uri,\n",
-    "    batch_prediction_bq_output_uri,\n",
-    "    time_column,\n",
-    "    time_series_identifier_column,\n",
-    "    target_column,\n",
-    "):\n",
-    "    batch_prediction_bq_input_uri = _sanitize_bq_uri(batch_prediction_bq_input_uri)\n",
-    "    batch_prediction_bq_output_uri = _sanitize_bq_uri(batch_prediction_bq_output_uri)\n",
-    "    base_url = \"https://datastudio.google.com/c/u/0/reporting\"\n",
-    "    query = (\n",
-    "        \"SELECT \\\\n\"\n",
-    "        \" CAST(input.{} as DATETIME) timestamp_col,\\\\n\"\n",
-    "        \" CAST(input.{} as STRING) time_series_identifier_col,\\\\n\"\n",
-    "        \" CAST(input.{} as NUMERIC) historical_values,\\\\n\"\n",
-    "        \" CAST(predicted_{}.value as NUMERIC) predicted_values,\\\\n\"\n",
-    "        \" * \\\\n\"\n",
-    "        \"FROM `{}` input\\\\n\"\n",
-    "        \"LEFT JOIN `{}` output\\\\n\"\n",
-    "        \"ON\\\\n\"\n",
-    "        \"CAST(input.{} as DATETIME) = CAST(output.{} as DATETIME)\\\\n\"\n",
-    "        \"AND CAST(input.{} as STRING) = CAST(output.{} as STRING)\"\n",
-    "    )\n",
-    "    query = query.format(\n",
-    "        time_column,\n",
-    "        time_series_identifier_column,\n",
-    "        target_column,\n",
-    "        target_column,\n",
-    "        batch_prediction_bq_input_uri,\n",
-    "        batch_prediction_bq_output_uri,\n",
-    "        time_column,\n",
-    "        time_column,\n",
-    "        time_series_identifier_column,\n",
-    "        time_series_identifier_column,\n",
-    "    )\n",
-    "    params = {\n",
-    "        \"templateId\": \"067f70d2-8cd6-4a4c-a099-292acd1053e8\",\n",
-    "        \"ds0.connector\": \"BIG_QUERY\",\n",
-    "        \"ds0.projectId\": PROJECT_ID,\n",
-    "        \"ds0.billingProjectId\": PROJECT_ID,\n",
-    "        \"ds0.type\": \"CUSTOM_QUERY\",\n",
-    "        \"ds0.sql\": query,\n",
-    "    }\n",
-    "    params_str_parts = []\n",
-    "    for k, v in params.items():\n",
-    "        params_str_parts.append('\"{}\":\"{}\"'.format(k, v))\n",
-    "    params_str = \"\".join([\"{\", \",\".join(params_str_parts), \"}\"])\n",
-    "    return \"{}?{}\".format(base_url, urllib.parse.urlencode({\"params\": params_str}))\n",
-    "\n",
-    "\n",
-    "print(\n",
-    "    get_data_studio_link(\n",
-    "        PREDICTION_DATASET_BQ_PATH,\n",
-    "        batch_predict_bq_output_uri,\n",
-    "        time_column,\n",
-    "        time_series_identifier_column,\n",
-    "        target_column,\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:mbsdk"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- AutoML Training Job\n",
-    "- Model\n",
-    "- Batch Prediction Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "# Delete dataset\n",
-    "dataset.delete()\n",
-    "\n",
-    "# Training job\n",
-    "training_job.delete()\n",
-    "\n",
-    "# Delete model\n",
-    "model.delete()\n",
-    "\n",
-    "# Delete batch prediction job\n",
-    "batch_prediction_job.delete()\n",
-    "\n",
-    "if os.getenv(\"IS_TESTING\"):\n",
-    "    ! gsutil rm -r $BUCKET_URI"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "sdk_automl_tabular_forecasting_batch.ipynb",
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -611,15 +611,7 @@
         "    \"city\": \"categorical\",\n",
         "    \"zip_code\": \"categorical\",\n",
         "    \"county\": \"categorical\",\n",
-        "}\n",
-        "\n",
-        "# COLUMN_TRANSFORMATIONS = [\n",
-        "#     {\"timestamp\": {\"column_name\": time_column}},\n",
-        "#     {\"numeric\": {\"column_name\": target_column}},\n",
-        "#     {\"categorical\": {\"column_name\": \"city\"}},\n",
-        "#     {\"categorical\": {\"column_name\": \"zip_code\"}},\n",
-        "#     {\"categorical\": {\"column_name\": \"county\"}},\n",
-        "# ]"
+        "}"
       ]
     },
     {
@@ -659,8 +651,7 @@
         "training_job = aiplatform.AutoMLForecastingTrainingJob(\n",
         "    display_name=MODEL_DISPLAY_NAME,\n",
         "    optimization_objective=\"minimize-rmse\",\n",
-        "    #     column_specs=COLUMN_SPECS,\n",
-        "    column_transformations=COLUMN_TRANSFORMATIONS,\n",
+        "    column_specs=COLUMN_SPECS,\n",
         ")"
       ]
     },


### PR DESCRIPTION
If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/master/notebooks/official) folder, follow this mandatory checklist: a
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [ ] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/docs/CODEOWNERS) file under `# Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

TODO: Fix the problem with no forecasted data being shown in the Data Studio link.