### PR TITLE
Relax language re: multi-region bucket for training

### DIFF
--- a/notebooks/notebook_template.ipynb
+++ b/notebooks/notebook_template.ipynb
@@ -415,9 +415,8 @@
         "Cloud Storage buckets.\n",
         "\n",
         "You may also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook. Make sure to [choose a region where Vertex AI services are\n",
-        "available](https://cloud.google.com/vertex-ai/docs/general/locations#available_regions). You may\n",
-        "not use a Multi-Regional Storage bucket for training with Vertex AI."
+        "throughout the rest of this notebook. We suggest that you [choose a region where Vertex AI services are\n",
+        "available](https://cloud.google.com/vertex-ai/docs/general/locations#available_regions)."
       ]
     },
     {


### PR DESCRIPTION
I believe you *can* use a multi-region; it just might not work as well (e.g. for latency, cost) as a regional bucket where you are doing other operations. This removes the inaccurate statement.