### PR TITLE
Fixed edge case where no notebooks are detected

### DIFF
--- a/.cloud-build/ExecuteChangedNotebooks.py
+++ b/.cloud-build/ExecuteChangedNotebooks.py
@@ -331,7 +331,9 @@ def run_changed_notebooks(
     print("\n=== END RESULTS===\n")
 
     total_notebook_duration = functools.reduce(
-        operator.add, [result.duration for result in results_sorted]
+        operator.add,
+        [datetime.timedelta(seconds=0)]
+        + [result.duration for result in results_sorted],
     )
 
     print(f"Cumulative notebook duration: {format_timedelta(total_notebook_duration)}")


### PR DESCRIPTION
Fixed the error found here: https://pantheon.corp.google.com/cloud-build/builds/c963bd5b-4db2-45ed-9507-c6726ed35a73?project=python-docs-samples-tests

```
Step #4: 
Step #4: Traceback (most recent call last):
Step #4:   File "/workspace/.cloud-build/ExecuteChangedNotebooks.py", line 396, in <module>
Step #4:     run_changed_notebooks(
Step #4:   File "/workspace/.cloud-build/ExecuteChangedNotebooks.py", line 333, in run_changed_notebooks
Step #4:     total_notebook_duration = functools.reduce(
Step #4: TypeError: reduce() of empty sequence with no initial value
Finished Step #4
```