### PR TITLE
Improve CONTRIBUTING.md -- Change to pip3 and add to PATH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,13 @@ From a command-line terminal (e.g. from Vertex Workbench or locally), install
 the code analysis tools:
 
 ```shell
-pip install --user -U nbqa black flake8 isort pyupgrade git+https://github.com/tensorflow/docs
+pip3 install --user -U nbqa black flake8 isort pyupgrade git+https://github.com/tensorflow/docs
+```
+
+You'll likely need to add the directory where these were installed to your PATH:
+
+```shell
+export PATH=“$HOME/.local/bin:$PATH"
 ```
 
 Then, set an environment variable for your notebook (or directory):


### PR DESCRIPTION
Hi.  I tried to run this all through cloud shell.  pip makes to Python 2.0 there and the command fails.  So, this PR has pip3.

Also, the cloud shell path didn't know about the directory where all this stuff installed, so I've added a command to add it to PATH.