### PR TITLE
docs: Update incorrect quote mark in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ pip3 install --user -U nbqa black flake8 isort pyupgrade git+https://github.com/
 You'll likely need to add the directory where these were installed to your PATH:
 
 ```shell
-export PATH=“$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Then, set an environment variable for your notebook (or directory):


### PR DESCRIPTION
The instructions did not work properly because there were two different types of quote marks in one of the commands. This PR fixes the issue.