### PR TITLE
[DO NOT MERGE] feat: Only lint files that are within certain folders

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: ci
-on: pull_request
-
+on:
+  pull_request:
+    paths:
+      - notebooks/official/**
+      - notebooks/notebook_template.ipynb
 jobs:
   format_and_lint:
     name: notebook format and lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,8 @@ name: ci
 on:
   pull_request:
     paths:
-      - notebooks/official/**
-      - notebooks/notebook_template.ipynb
+      - 'notebooks/official/**'
+      - 'notebooks/notebook_template.ipynb'
 jobs:
   format_and_lint:
     name: notebook format and lint


### PR DESCRIPTION
# Rationale
Non-official notebooks should need linting requirements enforced but were traditionally not exempt due to lack of a mechanism to do it.

I discovered a way to add a paths filter, as documented here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths

# TODO
- [ ] Waiting on response from Github Support regarding stalled check.