### PR TITLE
Relaxed ipython requirement

### DIFF
--- a/.cloud-build/requirements.txt
+++ b/.cloud-build/requirements.txt
@@ -1,4 +1,4 @@
-ipython==8.0.1
+ipython
 jupyter==1.0.0
 nbconvert==6.4.0
 papermill==2.3.4


### PR DESCRIPTION
Relax the ipython requirement as it conflicts with some pre-installed dependencies in the DLVM's.