### PR TITLE
[WIP] Relax requirements for DLVM's

### DIFF
--- a/.cloud-build/requirements.txt
+++ b/.cloud-build/requirements.txt
@@ -1,10 +1,10 @@
 ipython
 numpy
-jupyter==1.0.0
-nbconvert==6.4.0
-papermill==2.3.4
-pandas==1.4.0
-matplotlib==3.5.1
+jupyter
+nbconvert
+papermill
+panda
+matplotlib
 tabulate
 google-cloud-aiplatform
 google-cloud-storage

--- a/.cloud-build/requirements.txt
+++ b/.cloud-build/requirements.txt
@@ -1,8 +1,8 @@
 ipython
+numpy
 jupyter==1.0.0
 nbconvert==6.4.0
 papermill==2.3.4
-numpy==1.22.1
 pandas==1.4.0
 matplotlib==3.5.1
 tabulate


### PR DESCRIPTION
DLVM's may require older/newer versions of numpy (and other dependencies), depending on their Python version and other conflicting dependencies.
This frees them up to choose.