### PR TITLE
test: rm caching of components

### DIFF
--- a/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
+++ b/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
@@ -1,1206 +1,1188 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title:generic"
-   },
-   "source": [
-    "# Vertex AI Pipelines: AutoML Tabular pipelines using google-cloud-pipeline-components\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:pipelines,automl,beans"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines).\n",
-    "\n",
-    "You'll build a pipeline that looks like this:\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" width=\"95%\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:beans,lcn"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial is the UCI Machine Learning ['Dry beans dataset'](https://archive.ics.uci.edu/ml/datasets/Dry+Bean+Dataset), from: KOKLU, M. and OZKAN, I.A., (2020), \"Multiclass Classification of Dry Beans Using Computer Vision and Machine Learning Techniques.\"In Computers and Electronics in Agriculture, 174, 105507. [DOI](https://doi.org/10.1016/j.compag.2020.105507)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:pipelines,automl"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an AutoML tabular classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Create a `Dataset` resource.\n",
-    "- Train an AutoML `Model` resource.\n",
-    "- Creates an `Endpoint` resource.\n",
-    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-    "\n",
-    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-    "\n",
-    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-    "\n",
-    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex AI SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_storage"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-storage* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_storage"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install -U google-cloud-storage $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "check_versions"
-   },
-   "source": [
-    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.8."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "check_versions:kfp,gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "#### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = !gcloud auth list 2>/dev/null\n",
-    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "source": [
-    "#### Set service account access for Vertex AI Pipelines\n",
-    "\n",
-    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-    "\n",
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "source": [
-    "#### Vertex AI constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI:\n",
-    "\n",
-    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "outputs": [],
-   "source": [
-    "# API service endpoint\n",
-    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "source": [
-    "#### Vertex AI Pipelines constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI Pipelines:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "outputs": [],
-   "source": [
-    "PIPELINE_ROOT = \"{}/pipeline_root/beans\".format(BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "additional_imports"
-   },
-   "source": [
-    "Additional imports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "from typing import NamedTuple\n",
-    "\n",
-    "import kfp\n",
-    "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
-    "from kfp.v2 import dsl\n",
-    "from kfp.v2.dsl import (Artifact, ClassificationMetrics, Input, Metrics,\n",
-    "                        Output, component)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_component:eval"
-   },
-   "source": [
-    "## Define a metrics evaluation custom component\n",
-    "\n",
-    "In this tutorial, you define one custom pipeline component. The remaining components are pre-built\n",
-    "components for Vertex AI services.\n",
-    "\n",
-    "The custom pipeline component you define is a Python-function-based component.\n",
-    "Python function-based components make it easier to iterate quickly by letting you build your component code as a Python function and generating the component specification for you.\n",
-    "\n",
-    "Note the `@component` decorator.  When you evaluate the `classification_model_eval` function, the component is compiled to what is essentially a task factory function, that can be used in the the pipeline definition.\n",
-    "\n",
-    "In addition, a `tabular_eval_component.yaml` component definition file will be generated.  The component `yaml` file can be shared & placed under version control, and used later to define a pipeline step.\n",
-    "\n",
-    "The component definition specifies a base image for the component to use, and specifies that the `google-cloud-aiplatform` package should be installed. When not specified, the base image defaults to Python 3.7\n",
-    "\n",
-    "The custom pipeline component retrieves the classification model evaluation generated by the AutoML tabular training process, parses the evaluation data, and renders the ROC curve and confusion matrix for the model. It also uses given metrics threshold information and compares that to the evaluation results to determine whether the model is sufficiently accurate to deploy.\n",
-    "\n",
-    "*Note:* This custom component is specific to an AutoML tabular classification."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_component:eval"
-   },
-   "outputs": [],
-   "source": [
-    "@component(\n",
-    "    base_image=\"gcr.io/deeplearning-platform-release/tf2-cpu.2-6:latest\",\n",
-    "    output_component_file=\"tabular_eval_component.yaml\",\n",
-    "    packages_to_install=[\"google-cloud-aiplatform\"],\n",
-    ")\n",
-    "def classification_model_eval_metrics(\n",
-    "    project: str,\n",
-    "    location: str,  # \"us-central1\",\n",
-    "    api_endpoint: str,  # \"us-central1-aiplatform.googleapis.com\",\n",
-    "    thresholds_dict_str: str,\n",
-    "    model: Input[Artifact],\n",
-    "    metrics: Output[Metrics],\n",
-    "    metricsc: Output[ClassificationMetrics],\n",
-    ") -> NamedTuple(\"Outputs\", [(\"dep_decision\", str)]):  # Return parameter.\n",
-    "\n",
-    "    import json\n",
-    "    import logging\n",
-    "\n",
-    "    from google.cloud import aiplatform as aip\n",
-    "\n",
-    "    # Fetch model eval info\n",
-    "    def get_eval_info(client, model_name):\n",
-    "        from google.protobuf.json_format import MessageToDict\n",
-    "\n",
-    "        response = client.list_model_evaluations(parent=model_name)\n",
-    "        metrics_list = []\n",
-    "        metrics_string_list = []\n",
-    "        for evaluation in response:\n",
-    "            print(\"model_evaluation\")\n",
-    "            print(\" name:\", evaluation.name)\n",
-    "            print(\" metrics_schema_uri:\", evaluation.metrics_schema_uri)\n",
-    "            metrics = MessageToDict(evaluation._pb.metrics)\n",
-    "            for metric in metrics.keys():\n",
-    "                logging.info(\"metric: %s, value: %s\", metric, metrics[metric])\n",
-    "            metrics_str = json.dumps(metrics)\n",
-    "            metrics_list.append(metrics)\n",
-    "            metrics_string_list.append(metrics_str)\n",
-    "\n",
-    "        return (\n",
-    "            evaluation.name,\n",
-    "            metrics_list,\n",
-    "            metrics_string_list,\n",
-    "        )\n",
-    "\n",
-    "    # Use the given metrics threshold(s) to determine whether the model is\n",
-    "    # accurate enough to deploy.\n",
-    "    def classification_thresholds_check(metrics_dict, thresholds_dict):\n",
-    "        for k, v in thresholds_dict.items():\n",
-    "            logging.info(\"k {}, v {}\".format(k, v))\n",
-    "            if k in [\"auRoc\", \"auPrc\"]:  # higher is better\n",
-    "                if metrics_dict[k] < v:  # if under threshold, don't deploy\n",
-    "                    logging.info(\"{} < {}; returning False\".format(metrics_dict[k], v))\n",
-    "                    return False\n",
-    "        logging.info(\"threshold checks passed.\")\n",
-    "        return True\n",
-    "\n",
-    "    def log_metrics(metrics_list, metricsc):\n",
-    "        test_confusion_matrix = metrics_list[0][\"confusionMatrix\"]\n",
-    "        logging.info(\"rows: %s\", test_confusion_matrix[\"rows\"])\n",
-    "\n",
-    "        # log the ROC curve\n",
-    "        fpr = []\n",
-    "        tpr = []\n",
-    "        thresholds = []\n",
-    "        for item in metrics_list[0][\"confidenceMetrics\"]:\n",
-    "            fpr.append(item.get(\"falsePositiveRate\", 0.0))\n",
-    "            tpr.append(item.get(\"recall\", 0.0))\n",
-    "            thresholds.append(item.get(\"confidenceThreshold\", 0.0))\n",
-    "        print(f\"fpr: {fpr}\")\n",
-    "        print(f\"tpr: {tpr}\")\n",
-    "        print(f\"thresholds: {thresholds}\")\n",
-    "        metricsc.log_roc_curve(fpr, tpr, thresholds)\n",
-    "\n",
-    "        # log the confusion matrix\n",
-    "        annotations = []\n",
-    "        for item in test_confusion_matrix[\"annotationSpecs\"]:\n",
-    "            annotations.append(item[\"displayName\"])\n",
-    "        logging.info(\"confusion matrix annotations: %s\", annotations)\n",
-    "        metricsc.log_confusion_matrix(\n",
-    "            annotations,\n",
-    "            test_confusion_matrix[\"rows\"],\n",
-    "        )\n",
-    "\n",
-    "        # log textual metrics info as well\n",
-    "        for metric in metrics_list[0].keys():\n",
-    "            if metric != \"confidenceMetrics\":\n",
-    "                val_string = json.dumps(metrics_list[0][metric])\n",
-    "                metrics.log_metric(metric, val_string)\n",
-    "        # metrics.metadata[\"model_type\"] = \"AutoML Tabular classification\"\n",
-    "\n",
-    "    logging.getLogger().setLevel(logging.INFO)\n",
-    "    aip.init(project=project)\n",
-    "    # extract the model resource name from the input Model Artifact\n",
-    "    model_resource_path = model.metadata[\"resourceName\"]\n",
-    "    logging.info(\"model path: %s\", model_resource_path)\n",
-    "\n",
-    "    client_options = {\"api_endpoint\": api_endpoint}\n",
-    "    # Initialize client that will be used to create and send requests.\n",
-    "    client = aip.gapic.ModelServiceClient(client_options=client_options)\n",
-    "    eval_name, metrics_list, metrics_str_list = get_eval_info(\n",
-    "        client, model_resource_path\n",
-    "    )\n",
-    "    logging.info(\"got evaluation name: %s\", eval_name)\n",
-    "    logging.info(\"got metrics list: %s\", metrics_list)\n",
-    "    log_metrics(metrics_list, metricsc)\n",
-    "\n",
-    "    thresholds_dict = json.loads(thresholds_dict_str)\n",
-    "    deploy = classification_thresholds_check(metrics_list[0], thresholds_dict)\n",
-    "    if deploy:\n",
-    "        dep_decision = \"true\"\n",
-    "    else:\n",
-    "        dep_decision = \"false\"\n",
-    "    logging.info(\"deployment decision is %s\", dep_decision)\n",
-    "\n",
-    "    return (dep_decision,)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_pipeline:gcpc,beans,lcn"
-   },
-   "source": [
-    "## Define an AutoML tabular classification pipeline that uses components from `google_cloud_pipeline_components`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_pipeline:gcpc,beans,lcn"
-   },
-   "outputs": [],
-   "source": [
-    "DISPLAY_NAME = \"automl-beans{}\".format(TIMESTAMP)\n",
-    "PIPELINE_NAME = \"automl-tabular-beans-training-v2\"\n",
-    "MACHINE_TYPE = \"n1-standard-4\"\n",
-    "\n",
-    "\n",
-    "@kfp.dsl.pipeline(name=PIPELINE_NAME, pipeline_root=PIPELINE_ROOT)\n",
-    "def pipeline(\n",
-    "    bq_source: str = \"bq://aju-dev-demos.beans.beans1\",\n",
-    "    display_name: str = DISPLAY_NAME,\n",
-    "    project: str = PROJECT_ID,\n",
-    "    gcp_region: str = REGION,\n",
-    "    api_endpoint: str = API_ENDPOINT,\n",
-    "    thresholds_dict_str: str = '{\"auRoc\": 0.95}',\n",
-    "):\n",
-    "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
-    "        project=project, display_name=display_name, bq_source=bq_source\n",
-    "    )\n",
-    "\n",
-    "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
-    "        project=project,\n",
-    "        display_name=display_name,\n",
-    "        optimization_prediction_type=\"classification\",\n",
-    "        optimization_objective=\"minimize-log-loss\",\n",
-    "        budget_milli_node_hours=1000,\n",
-    "        column_specs={\n",
-    "            \"Area\": \"numeric\",\n",
-    "            \"Perimeter\": \"numeric\",\n",
-    "            \"MajorAxisLength\": \"numeric\",\n",
-    "            \"MinorAxisLength\": \"numeric\",\n",
-    "            \"AspectRation\": \"numeric\",\n",
-    "            \"Eccentricity\": \"numeric\",\n",
-    "            \"ConvexArea\": \"numeric\",\n",
-    "            \"EquivDiameter\": \"numeric\",\n",
-    "            \"Extent\": \"numeric\",\n",
-    "            \"Solidity\": \"numeric\",\n",
-    "            \"roundness\": \"numeric\",\n",
-    "            \"Compactness\": \"numeric\",\n",
-    "            \"ShapeFactor1\": \"numeric\",\n",
-    "            \"ShapeFactor2\": \"numeric\",\n",
-    "            \"ShapeFactor3\": \"numeric\",\n",
-    "            \"ShapeFactor4\": \"numeric\",\n",
-    "            \"Class\": \"categorical\",\n",
-    "        },\n",
-    "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
-    "        target_column=\"Class\",\n",
-    "    )\n",
-    "    model_eval_task = classification_model_eval_metrics(\n",
-    "        project,\n",
-    "        gcp_region,\n",
-    "        api_endpoint,\n",
-    "        thresholds_dict_str,\n",
-    "        training_op.outputs[\"model\"],\n",
-    "    )\n",
-    "\n",
-    "    with dsl.Condition(\n",
-    "        model_eval_task.outputs[\"dep_decision\"] == \"true\",\n",
-    "        name=\"deploy_decision\",\n",
-    "    ):\n",
-    "\n",
-    "        endpoint_op = gcc_aip.EndpointCreateOp(\n",
-    "            project=project,\n",
-    "            location=gcp_region,\n",
-    "            display_name=\"train-automl-beans\",\n",
-    "        )\n",
-    "\n",
-    "        gcc_aip.ModelDeployOp(\n",
-    "            model=training_op.outputs[\"model\"],\n",
-    "            endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-    "            dedicated_resources_min_replica_count=1,\n",
-    "            dedicated_resources_max_replica_count=1,\n",
-    "            dedicated_resources_machine_type=MACHINE_TYPE,\n",
-    "        )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "source": [
-    "## Compile the pipeline\n",
-    "\n",
-    "Next, compile the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "outputs": [],
-   "source": [
-    "from kfp.v2 import compiler  # noqa: F811\n",
-    "\n",
-    "compiler.Compiler().compile(\n",
-    "    pipeline_func=pipeline,\n",
-    "    package_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_pipeline:model"
-   },
-   "source": [
-    "## Run the pipeline\n",
-    "\n",
-    "Next, run the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run_pipeline:model"
-   },
-   "outputs": [],
-   "source": [
-    "DISPLAY_NAME = \"beans_\" + TIMESTAMP\n",
-    "\n",
-    "job = aip.PipelineJob(\n",
-    "    display_name=DISPLAY_NAME,\n",
-    "    template_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
-    "    pipeline_root=PIPELINE_ROOT,\n",
-    "    parameter_values={\"project\": PROJECT_ID, \"display_name\": DISPLAY_NAME},\n",
-    "    enable_caching=False\n",
-    ")\n",
-    "\n",
-    "job.submit()\n",
-    "\n",
-    "! rm tabular_classification_pipeline.json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "view_pipeline_run:model"
-   },
-   "source": [
-    "Click on the generated link to see your run in the Cloud Console.\n",
-    "\n",
-    "<!-- It should look something like this as it is running:\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compare_pipeline_runs"
-   },
-   "source": [
-    "## Compare the parameters and metrics of the pipelines run from their tracked metadata\n",
-    "\n",
-    "Next, you use the Vertex AI SDK for Python to compare the parameters and metrics of the pipeline runs. Wait until the pipeline runs have finished to run the next cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "compare_pipeline_runs"
-   },
-   "outputs": [],
-   "source": [
-    "pipeline_df = aip.get_pipeline_df(pipeline=PIPELINE_NAME)\n",
-    "print(pipeline_df.head(2))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- Pipeline\n",
-    "- Model\n",
-    "- Endpoint\n",
-    "- Batch Job\n",
-    "- Custom Job\n",
-    "- Hyperparameter Tuning Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "delete_dataset = True\n",
-    "delete_pipeline = True\n",
-    "delete_model = True\n",
-    "delete_endpoint = True\n",
-    "delete_batchjob = True\n",
-    "delete_customjob = True\n",
-    "delete_hptjob = True\n",
-    "delete_bucket = True\n",
-    "\n",
-    "try:\n",
-    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-    "        models = aip.Model.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        model = models[0]\n",
-    "        aip.Model.delete(model)\n",
-    "        print(\"Deleted model:\", model)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-    "        endpoints = aip.Endpoint.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        endpoint = endpoints[0]\n",
-    "        endpoint.undeploy_all()\n",
-    "        aip.Endpoint.delete(endpoint.resource_name)\n",
-    "        print(\"Deleted endpoint:\", endpoint)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-    "    if \"tabular\" == \"tabular\":\n",
-    "        try:\n",
-    "            datasets = aip.TabularDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TabularDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"image\":\n",
-    "        try:\n",
-    "            datasets = aip.ImageDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.ImageDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"text\":\n",
-    "        try:\n",
-    "            datasets = aip.TextDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TextDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"video\":\n",
-    "        try:\n",
-    "            datasets = aip.VideoDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.VideoDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-    "        pipelines = aip.PipelineJob.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        pipeline = pipelines[0]\n",
-    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-    "        print(\"Deleted pipeline:\", pipeline)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-    "    ! gsutil rm -r $BUCKET_NAME"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "automl_tabular_classification_beans.ipynb",
-   "toc_visible": true
-  },
-  "environment": {
-   "name": "common-cu110.m71",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title:generic"
+      },
+      "source": [
+        "# Vertex AI Pipelines: AutoML Tabular pipelines using google-cloud-pipeline-components\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:pipelines,automl,beans"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines).\n",
+        "\n",
+        "You'll build a pipeline that looks like this:\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" width=\"95%\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:beans,lcn"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial is the UCI Machine Learning ['Dry beans dataset'](https://archive.ics.uci.edu/ml/datasets/Dry+Bean+Dataset), from: KOKLU, M. and OZKAN, I.A., (2020), \"Multiclass Classification of Dry Beans Using Computer Vision and Machine Learning Techniques.\"In Computers and Electronics in Agriculture, 174, 105507. [DOI](https://doi.org/10.1016/j.compag.2020.105507)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:pipelines,automl"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML tabular classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a `Dataset` resource.\n",
+        "- Train an AutoML `Model` resource.\n",
+        "- Creates an `Endpoint` resource.\n",
+        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+        "\n",
+        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+        "\n",
+        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+        "\n",
+        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex AI SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_storage"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-storage* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_storage"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install -U google-cloud-storage $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "check_versions"
+      },
+      "source": [
+        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.8."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "check_versions:kfp,gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "#### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = !gcloud auth list 2>/dev/null\n",
+        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "source": [
+        "#### Set service account access for Vertex AI Pipelines\n",
+        "\n",
+        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+        "\n",
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "source": [
+        "#### Vertex AI constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI:\n",
+        "\n",
+        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "outputs": [],
+      "source": [
+        "# API service endpoint\n",
+        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "source": [
+        "#### Vertex AI Pipelines constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI Pipelines:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "outputs": [],
+      "source": [
+        "PIPELINE_ROOT = \"{}/pipeline_root/beans\".format(BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "additional_imports"
+      },
+      "source": [
+        "Additional imports."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "from typing import NamedTuple\n",
+        "\n",
+        "import kfp\n",
+        "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
+        "from kfp.v2 import dsl\n",
+        "from kfp.v2.dsl import (Artifact, ClassificationMetrics, Input, Metrics,\n",
+        "                        Output, component)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_component:eval"
+      },
+      "source": [
+        "## Define a metrics evaluation custom component\n",
+        "\n",
+        "In this tutorial, you define one custom pipeline component. The remaining components are pre-built\n",
+        "components for Vertex AI services.\n",
+        "\n",
+        "The custom pipeline component you define is a Python-function-based component.\n",
+        "Python function-based components make it easier to iterate quickly by letting you build your component code as a Python function and generating the component specification for you.\n",
+        "\n",
+        "Note the `@component` decorator.  When you evaluate the `classification_model_eval` function, the component is compiled to what is essentially a task factory function, that can be used in the the pipeline definition.\n",
+        "\n",
+        "In addition, a `tabular_eval_component.yaml` component definition file will be generated.  The component `yaml` file can be shared & placed under version control, and used later to define a pipeline step.\n",
+        "\n",
+        "The component definition specifies a base image for the component to use, and specifies that the `google-cloud-aiplatform` package should be installed. When not specified, the base image defaults to Python 3.7\n",
+        "\n",
+        "The custom pipeline component retrieves the classification model evaluation generated by the AutoML tabular training process, parses the evaluation data, and renders the ROC curve and confusion matrix for the model. It also uses given metrics threshold information and compares that to the evaluation results to determine whether the model is sufficiently accurate to deploy.\n",
+        "\n",
+        "*Note:* This custom component is specific to an AutoML tabular classification."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_component:eval"
+      },
+      "outputs": [],
+      "source": [
+        "@component(\n",
+        "    base_image=\"gcr.io/deeplearning-platform-release/tf2-cpu.2-6:latest\",\n",
+        "    output_component_file=\"tabular_eval_component.yaml\",\n",
+        "    packages_to_install=[\"google-cloud-aiplatform\"],\n",
+        ")\n",
+        "def classification_model_eval_metrics(\n",
+        "    project: str,\n",
+        "    location: str,  # \"us-central1\",\n",
+        "    api_endpoint: str,  # \"us-central1-aiplatform.googleapis.com\",\n",
+        "    thresholds_dict_str: str,\n",
+        "    model: Input[Artifact],\n",
+        "    metrics: Output[Metrics],\n",
+        "    metricsc: Output[ClassificationMetrics],\n",
+        ") -> NamedTuple(\"Outputs\", [(\"dep_decision\", str)]):  # Return parameter.\n",
+        "\n",
+        "    import json\n",
+        "    import logging\n",
+        "\n",
+        "    from google.cloud import aiplatform as aip\n",
+        "\n",
+        "    # Fetch model eval info\n",
+        "    def get_eval_info(client, model_name):\n",
+        "        from google.protobuf.json_format import MessageToDict\n",
+        "\n",
+        "        response = client.list_model_evaluations(parent=model_name)\n",
+        "        metrics_list = []\n",
+        "        metrics_string_list = []\n",
+        "        for evaluation in response:\n",
+        "            print(\"model_evaluation\")\n",
+        "            print(\" name:\", evaluation.name)\n",
+        "            print(\" metrics_schema_uri:\", evaluation.metrics_schema_uri)\n",
+        "            metrics = MessageToDict(evaluation._pb.metrics)\n",
+        "            for metric in metrics.keys():\n",
+        "                logging.info(\"metric: %s, value: %s\", metric, metrics[metric])\n",
+        "            metrics_str = json.dumps(metrics)\n",
+        "            metrics_list.append(metrics)\n",
+        "            metrics_string_list.append(metrics_str)\n",
+        "\n",
+        "        return (\n",
+        "            evaluation.name,\n",
+        "            metrics_list,\n",
+        "            metrics_string_list,\n",
+        "        )\n",
+        "\n",
+        "    # Use the given metrics threshold(s) to determine whether the model is\n",
+        "    # accurate enough to deploy.\n",
+        "    def classification_thresholds_check(metrics_dict, thresholds_dict):\n",
+        "        for k, v in thresholds_dict.items():\n",
+        "            logging.info(\"k {}, v {}\".format(k, v))\n",
+        "            if k in [\"auRoc\", \"auPrc\"]:  # higher is better\n",
+        "                if metrics_dict[k] < v:  # if under threshold, don't deploy\n",
+        "                    logging.info(\"{} < {}; returning False\".format(metrics_dict[k], v))\n",
+        "                    return False\n",
+        "        logging.info(\"threshold checks passed.\")\n",
+        "        return True\n",
+        "\n",
+        "    def log_metrics(metrics_list, metricsc):\n",
+        "        test_confusion_matrix = metrics_list[0][\"confusionMatrix\"]\n",
+        "        logging.info(\"rows: %s\", test_confusion_matrix[\"rows\"])\n",
+        "\n",
+        "        # log the ROC curve\n",
+        "        fpr = []\n",
+        "        tpr = []\n",
+        "        thresholds = []\n",
+        "        for item in metrics_list[0][\"confidenceMetrics\"]:\n",
+        "            fpr.append(item.get(\"falsePositiveRate\", 0.0))\n",
+        "            tpr.append(item.get(\"recall\", 0.0))\n",
+        "            thresholds.append(item.get(\"confidenceThreshold\", 0.0))\n",
+        "        print(f\"fpr: {fpr}\")\n",
+        "        print(f\"tpr: {tpr}\")\n",
+        "        print(f\"thresholds: {thresholds}\")\n",
+        "        metricsc.log_roc_curve(fpr, tpr, thresholds)\n",
+        "\n",
+        "        # log the confusion matrix\n",
+        "        annotations = []\n",
+        "        for item in test_confusion_matrix[\"annotationSpecs\"]:\n",
+        "            annotations.append(item[\"displayName\"])\n",
+        "        logging.info(\"confusion matrix annotations: %s\", annotations)\n",
+        "        metricsc.log_confusion_matrix(\n",
+        "            annotations,\n",
+        "            test_confusion_matrix[\"rows\"],\n",
+        "        )\n",
+        "\n",
+        "        # log textual metrics info as well\n",
+        "        for metric in metrics_list[0].keys():\n",
+        "            if metric != \"confidenceMetrics\":\n",
+        "                val_string = json.dumps(metrics_list[0][metric])\n",
+        "                metrics.log_metric(metric, val_string)\n",
+        "        # metrics.metadata[\"model_type\"] = \"AutoML Tabular classification\"\n",
+        "\n",
+        "    logging.getLogger().setLevel(logging.INFO)\n",
+        "    aip.init(project=project)\n",
+        "    # extract the model resource name from the input Model Artifact\n",
+        "    model_resource_path = model.metadata[\"resourceName\"]\n",
+        "    logging.info(\"model path: %s\", model_resource_path)\n",
+        "\n",
+        "    client_options = {\"api_endpoint\": api_endpoint}\n",
+        "    # Initialize client that will be used to create and send requests.\n",
+        "    client = aip.gapic.ModelServiceClient(client_options=client_options)\n",
+        "    eval_name, metrics_list, metrics_str_list = get_eval_info(\n",
+        "        client, model_resource_path\n",
+        "    )\n",
+        "    logging.info(\"got evaluation name: %s\", eval_name)\n",
+        "    logging.info(\"got metrics list: %s\", metrics_list)\n",
+        "    log_metrics(metrics_list, metricsc)\n",
+        "\n",
+        "    thresholds_dict = json.loads(thresholds_dict_str)\n",
+        "    deploy = classification_thresholds_check(metrics_list[0], thresholds_dict)\n",
+        "    if deploy:\n",
+        "        dep_decision = \"true\"\n",
+        "    else:\n",
+        "        dep_decision = \"false\"\n",
+        "    logging.info(\"deployment decision is %s\", dep_decision)\n",
+        "\n",
+        "    return (dep_decision,)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_pipeline:gcpc,beans,lcn"
+      },
+      "source": [
+        "## Define an AutoML tabular classification pipeline that uses components from `google_cloud_pipeline_components`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_pipeline:gcpc,beans,lcn"
+      },
+      "outputs": [],
+      "source": [
+        "DISPLAY_NAME = \"automl-beans{}\".format(TIMESTAMP)\n",
+        "PIPELINE_NAME = \"automl-tabular-beans-training-v2\"\n",
+        "MACHINE_TYPE = \"n1-standard-4\"\n",
+        "\n",
+        "\n",
+        "@kfp.dsl.pipeline(name=PIPELINE_NAME, pipeline_root=PIPELINE_ROOT)\n",
+        "def pipeline(\n",
+        "    bq_source: str = \"bq://aju-dev-demos.beans.beans1\",\n",
+        "    display_name: str = DISPLAY_NAME,\n",
+        "    project: str = PROJECT_ID,\n",
+        "    gcp_region: str = REGION,\n",
+        "    api_endpoint: str = API_ENDPOINT,\n",
+        "    thresholds_dict_str: str = '{\"auRoc\": 0.95}',\n",
+        "):\n",
+        "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
+        "        project=project, display_name=display_name, bq_source=bq_source\n",
+        "    )\n",
+        "\n",
+        "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
+        "        project=project,\n",
+        "        display_name=display_name,\n",
+        "        optimization_prediction_type=\"classification\",\n",
+        "        optimization_objective=\"minimize-log-loss\",\n",
+        "        budget_milli_node_hours=1000,\n",
+        "        column_specs={\n",
+        "            \"Area\": \"numeric\",\n",
+        "            \"Perimeter\": \"numeric\",\n",
+        "            \"MajorAxisLength\": \"numeric\",\n",
+        "            \"MinorAxisLength\": \"numeric\",\n",
+        "            \"AspectRation\": \"numeric\",\n",
+        "            \"Eccentricity\": \"numeric\",\n",
+        "            \"ConvexArea\": \"numeric\",\n",
+        "            \"EquivDiameter\": \"numeric\",\n",
+        "            \"Extent\": \"numeric\",\n",
+        "            \"Solidity\": \"numeric\",\n",
+        "            \"roundness\": \"numeric\",\n",
+        "            \"Compactness\": \"numeric\",\n",
+        "            \"ShapeFactor1\": \"numeric\",\n",
+        "            \"ShapeFactor2\": \"numeric\",\n",
+        "            \"ShapeFactor3\": \"numeric\",\n",
+        "            \"ShapeFactor4\": \"numeric\",\n",
+        "            \"Class\": \"categorical\",\n",
+        "        },\n",
+        "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
+        "        target_column=\"Class\",\n",
+        "    )\n",
+        "    model_eval_task = classification_model_eval_metrics(\n",
+        "        project,\n",
+        "        gcp_region,\n",
+        "        api_endpoint,\n",
+        "        thresholds_dict_str,\n",
+        "        training_op.outputs[\"model\"],\n",
+        "    )\n",
+        "\n",
+        "    with dsl.Condition(\n",
+        "        model_eval_task.outputs[\"dep_decision\"] == \"true\",\n",
+        "        name=\"deploy_decision\",\n",
+        "    ):\n",
+        "\n",
+        "        endpoint_op = gcc_aip.EndpointCreateOp(\n",
+        "            project=project,\n",
+        "            location=gcp_region,\n",
+        "            display_name=\"train-automl-beans\",\n",
+        "        )\n",
+        "\n",
+        "        gcc_aip.ModelDeployOp(\n",
+        "            model=training_op.outputs[\"model\"],\n",
+        "            endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+        "            dedicated_resources_min_replica_count=1,\n",
+        "            dedicated_resources_max_replica_count=1,\n",
+        "            dedicated_resources_machine_type=MACHINE_TYPE,\n",
+        "        )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "source": [
+        "## Compile the pipeline\n",
+        "\n",
+        "Next, compile the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "outputs": [],
+      "source": [
+        "from kfp.v2 import compiler  # noqa: F811\n",
+        "\n",
+        "compiler.Compiler().compile(\n",
+        "    pipeline_func=pipeline,\n",
+        "    package_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_pipeline:model"
+      },
+      "source": [
+        "## Run the pipeline\n",
+        "\n",
+        "Next, run the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_pipeline:model"
+      },
+      "outputs": [],
+      "source": [
+        "DISPLAY_NAME = \"beans_\" + TIMESTAMP\n",
+        "\n",
+        "job = aip.PipelineJob(\n",
+        "    display_name=DISPLAY_NAME,\n",
+        "    template_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
+        "    pipeline_root=PIPELINE_ROOT,\n",
+        "    parameter_values={\"project\": PROJECT_ID, \"display_name\": DISPLAY_NAME},\n",
+        "    enable_caching=False,\n",
+        ")\n",
+        "\n",
+        "job.submit()\n",
+        "\n",
+        "! rm tabular_classification_pipeline.json"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view_pipeline_run:model"
+      },
+      "source": [
+        "Click on the generated link to see your run in the Cloud Console.\n",
+        "\n",
+        "<!-- It should look something like this as it is running:\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "compare_pipeline_runs"
+      },
+      "source": [
+        "## Compare the parameters and metrics of the pipelines run from their tracked metadata\n",
+        "\n",
+        "Next, you use the Vertex AI SDK for Python to compare the parameters and metrics of the pipeline runs. Wait until the pipeline runs have finished to run the next cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "compare_pipeline_runs"
+      },
+      "outputs": [],
+      "source": [
+        "pipeline_df = aip.get_pipeline_df(pipeline=PIPELINE_NAME)\n",
+        "print(pipeline_df.head(2))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- Pipeline\n",
+        "- Model\n",
+        "- Endpoint\n",
+        "- Batch Job\n",
+        "- Custom Job\n",
+        "- Hyperparameter Tuning Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "delete_dataset = True\n",
+        "delete_pipeline = True\n",
+        "delete_model = True\n",
+        "delete_endpoint = True\n",
+        "delete_batchjob = True\n",
+        "delete_customjob = True\n",
+        "delete_hptjob = True\n",
+        "delete_bucket = True\n",
+        "\n",
+        "try:\n",
+        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+        "        models = aip.Model.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        model = models[0]\n",
+        "        aip.Model.delete(model)\n",
+        "        print(\"Deleted model:\", model)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+        "        endpoints = aip.Endpoint.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        endpoint = endpoints[0]\n",
+        "        endpoint.undeploy_all()\n",
+        "        aip.Endpoint.delete(endpoint.resource_name)\n",
+        "        print(\"Deleted endpoint:\", endpoint)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+        "    if \"tabular\" == \"tabular\":\n",
+        "        try:\n",
+        "            datasets = aip.TabularDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TabularDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"image\":\n",
+        "        try:\n",
+        "            datasets = aip.ImageDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.ImageDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"text\":\n",
+        "        try:\n",
+        "            datasets = aip.TextDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TextDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"video\":\n",
+        "        try:\n",
+        "            datasets = aip.VideoDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.VideoDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+        "        pipelines = aip.PipelineJob.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        pipeline = pipelines[0]\n",
+        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+        "        print(\"Deleted pipeline:\", pipeline)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+        "    ! gsutil rm -r $BUCKET_NAME"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "automl_tabular_classification_beans.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
+++ b/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
@@ -1,1187 +1,1206 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title:generic"
-      },
-      "source": [
-        "# Vertex AI Pipelines: AutoML Tabular pipelines using google-cloud-pipeline-components\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:pipelines,automl,beans"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines).\n",
-        "\n",
-        "You'll build a pipeline that looks like this:\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" width=\"95%\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:beans,lcn"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial is the UCI Machine Learning ['Dry beans dataset'](https://archive.ics.uci.edu/ml/datasets/Dry+Bean+Dataset), from: KOKLU, M. and OZKAN, I.A., (2020), \"Multiclass Classification of Dry Beans Using Computer Vision and Machine Learning Techniques.\"In Computers and Electronics in Agriculture, 174, 105507. [DOI](https://doi.org/10.1016/j.compag.2020.105507)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:pipelines,automl"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an AutoML tabular classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Create a `Dataset` resource.\n",
-        "- Train an AutoML `Model` resource.\n",
-        "- Creates an `Endpoint` resource.\n",
-        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-        "\n",
-        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-        "\n",
-        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-        "\n",
-        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex AI SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_storage"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-storage* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_storage"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install -U google-cloud-storage $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "check_versions"
-      },
-      "source": [
-        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.8."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "check_versions:kfp,gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "source": [
-        "#### Service Account\n",
-        "\n",
-        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "if (\n",
-        "    SERVICE_ACCOUNT == \"\"\n",
-        "    or SERVICE_ACCOUNT is None\n",
-        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-        "):\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = !gcloud auth list 2>/dev/null\n",
-        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "source": [
-        "#### Set service account access for Vertex AI Pipelines\n",
-        "\n",
-        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-        "\n",
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "source": [
-        "#### Vertex AI constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI:\n",
-        "\n",
-        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "outputs": [],
-      "source": [
-        "# API service endpoint\n",
-        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "source": [
-        "#### Vertex AI Pipelines constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI Pipelines:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "outputs": [],
-      "source": [
-        "PIPELINE_ROOT = \"{}/pipeline_root/beans\".format(BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "additional_imports"
-      },
-      "source": [
-        "Additional imports."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "from typing import NamedTuple\n",
-        "\n",
-        "import kfp\n",
-        "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
-        "from kfp.v2 import dsl\n",
-        "from kfp.v2.dsl import (Artifact, ClassificationMetrics, Input, Metrics,\n",
-        "                        Output, component)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex AI SDK for Python\n",
-        "\n",
-        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_component:eval"
-      },
-      "source": [
-        "## Define a metrics evaluation custom component\n",
-        "\n",
-        "In this tutorial, you define one custom pipeline component. The remaining components are pre-built\n",
-        "components for Vertex AI services.\n",
-        "\n",
-        "The custom pipeline component you define is a Python-function-based component.\n",
-        "Python function-based components make it easier to iterate quickly by letting you build your component code as a Python function and generating the component specification for you.\n",
-        "\n",
-        "Note the `@component` decorator.  When you evaluate the `classification_model_eval` function, the component is compiled to what is essentially a task factory function, that can be used in the the pipeline definition.\n",
-        "\n",
-        "In addition, a `tabular_eval_component.yaml` component definition file will be generated.  The component `yaml` file can be shared & placed under version control, and used later to define a pipeline step.\n",
-        "\n",
-        "The component definition specifies a base image for the component to use, and specifies that the `google-cloud-aiplatform` package should be installed. When not specified, the base image defaults to Python 3.7\n",
-        "\n",
-        "The custom pipeline component retrieves the classification model evaluation generated by the AutoML tabular training process, parses the evaluation data, and renders the ROC curve and confusion matrix for the model. It also uses given metrics threshold information and compares that to the evaluation results to determine whether the model is sufficiently accurate to deploy.\n",
-        "\n",
-        "*Note:* This custom component is specific to an AutoML tabular classification."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_component:eval"
-      },
-      "outputs": [],
-      "source": [
-        "@component(\n",
-        "    base_image=\"gcr.io/deeplearning-platform-release/tf2-cpu.2-6:latest\",\n",
-        "    output_component_file=\"tabular_eval_component.yaml\",\n",
-        "    packages_to_install=[\"google-cloud-aiplatform\"],\n",
-        ")\n",
-        "def classification_model_eval_metrics(\n",
-        "    project: str,\n",
-        "    location: str,  # \"us-central1\",\n",
-        "    api_endpoint: str,  # \"us-central1-aiplatform.googleapis.com\",\n",
-        "    thresholds_dict_str: str,\n",
-        "    model: Input[Artifact],\n",
-        "    metrics: Output[Metrics],\n",
-        "    metricsc: Output[ClassificationMetrics],\n",
-        ") -> NamedTuple(\"Outputs\", [(\"dep_decision\", str)]):  # Return parameter.\n",
-        "\n",
-        "    import json\n",
-        "    import logging\n",
-        "\n",
-        "    from google.cloud import aiplatform as aip\n",
-        "\n",
-        "    # Fetch model eval info\n",
-        "    def get_eval_info(client, model_name):\n",
-        "        from google.protobuf.json_format import MessageToDict\n",
-        "\n",
-        "        response = client.list_model_evaluations(parent=model_name)\n",
-        "        metrics_list = []\n",
-        "        metrics_string_list = []\n",
-        "        for evaluation in response:\n",
-        "            print(\"model_evaluation\")\n",
-        "            print(\" name:\", evaluation.name)\n",
-        "            print(\" metrics_schema_uri:\", evaluation.metrics_schema_uri)\n",
-        "            metrics = MessageToDict(evaluation._pb.metrics)\n",
-        "            for metric in metrics.keys():\n",
-        "                logging.info(\"metric: %s, value: %s\", metric, metrics[metric])\n",
-        "            metrics_str = json.dumps(metrics)\n",
-        "            metrics_list.append(metrics)\n",
-        "            metrics_string_list.append(metrics_str)\n",
-        "\n",
-        "        return (\n",
-        "            evaluation.name,\n",
-        "            metrics_list,\n",
-        "            metrics_string_list,\n",
-        "        )\n",
-        "\n",
-        "    # Use the given metrics threshold(s) to determine whether the model is\n",
-        "    # accurate enough to deploy.\n",
-        "    def classification_thresholds_check(metrics_dict, thresholds_dict):\n",
-        "        for k, v in thresholds_dict.items():\n",
-        "            logging.info(\"k {}, v {}\".format(k, v))\n",
-        "            if k in [\"auRoc\", \"auPrc\"]:  # higher is better\n",
-        "                if metrics_dict[k] < v:  # if under threshold, don't deploy\n",
-        "                    logging.info(\"{} < {}; returning False\".format(metrics_dict[k], v))\n",
-        "                    return False\n",
-        "        logging.info(\"threshold checks passed.\")\n",
-        "        return True\n",
-        "\n",
-        "    def log_metrics(metrics_list, metricsc):\n",
-        "        test_confusion_matrix = metrics_list[0][\"confusionMatrix\"]\n",
-        "        logging.info(\"rows: %s\", test_confusion_matrix[\"rows\"])\n",
-        "\n",
-        "        # log the ROC curve\n",
-        "        fpr = []\n",
-        "        tpr = []\n",
-        "        thresholds = []\n",
-        "        for item in metrics_list[0][\"confidenceMetrics\"]:\n",
-        "            fpr.append(item.get(\"falsePositiveRate\", 0.0))\n",
-        "            tpr.append(item.get(\"recall\", 0.0))\n",
-        "            thresholds.append(item.get(\"confidenceThreshold\", 0.0))\n",
-        "        print(f\"fpr: {fpr}\")\n",
-        "        print(f\"tpr: {tpr}\")\n",
-        "        print(f\"thresholds: {thresholds}\")\n",
-        "        metricsc.log_roc_curve(fpr, tpr, thresholds)\n",
-        "\n",
-        "        # log the confusion matrix\n",
-        "        annotations = []\n",
-        "        for item in test_confusion_matrix[\"annotationSpecs\"]:\n",
-        "            annotations.append(item[\"displayName\"])\n",
-        "        logging.info(\"confusion matrix annotations: %s\", annotations)\n",
-        "        metricsc.log_confusion_matrix(\n",
-        "            annotations,\n",
-        "            test_confusion_matrix[\"rows\"],\n",
-        "        )\n",
-        "\n",
-        "        # log textual metrics info as well\n",
-        "        for metric in metrics_list[0].keys():\n",
-        "            if metric != \"confidenceMetrics\":\n",
-        "                val_string = json.dumps(metrics_list[0][metric])\n",
-        "                metrics.log_metric(metric, val_string)\n",
-        "        # metrics.metadata[\"model_type\"] = \"AutoML Tabular classification\"\n",
-        "\n",
-        "    logging.getLogger().setLevel(logging.INFO)\n",
-        "    aip.init(project=project)\n",
-        "    # extract the model resource name from the input Model Artifact\n",
-        "    model_resource_path = model.metadata[\"resourceName\"]\n",
-        "    logging.info(\"model path: %s\", model_resource_path)\n",
-        "\n",
-        "    client_options = {\"api_endpoint\": api_endpoint}\n",
-        "    # Initialize client that will be used to create and send requests.\n",
-        "    client = aip.gapic.ModelServiceClient(client_options=client_options)\n",
-        "    eval_name, metrics_list, metrics_str_list = get_eval_info(\n",
-        "        client, model_resource_path\n",
-        "    )\n",
-        "    logging.info(\"got evaluation name: %s\", eval_name)\n",
-        "    logging.info(\"got metrics list: %s\", metrics_list)\n",
-        "    log_metrics(metrics_list, metricsc)\n",
-        "\n",
-        "    thresholds_dict = json.loads(thresholds_dict_str)\n",
-        "    deploy = classification_thresholds_check(metrics_list[0], thresholds_dict)\n",
-        "    if deploy:\n",
-        "        dep_decision = \"true\"\n",
-        "    else:\n",
-        "        dep_decision = \"false\"\n",
-        "    logging.info(\"deployment decision is %s\", dep_decision)\n",
-        "\n",
-        "    return (dep_decision,)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_pipeline:gcpc,beans,lcn"
-      },
-      "source": [
-        "## Define an AutoML tabular classification pipeline that uses components from `google_cloud_pipeline_components`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_pipeline:gcpc,beans,lcn"
-      },
-      "outputs": [],
-      "source": [
-        "DISPLAY_NAME = \"automl-beans{}\".format(TIMESTAMP)\n",
-        "PIPELINE_NAME = \"automl-tabular-beans-training-v2\"\n",
-        "MACHINE_TYPE = \"n1-standard-4\"\n",
-        "\n",
-        "\n",
-        "@kfp.dsl.pipeline(name=PIPELINE_NAME, pipeline_root=PIPELINE_ROOT)\n",
-        "def pipeline(\n",
-        "    bq_source: str = \"bq://aju-dev-demos.beans.beans1\",\n",
-        "    display_name: str = DISPLAY_NAME,\n",
-        "    project: str = PROJECT_ID,\n",
-        "    gcp_region: str = REGION,\n",
-        "    api_endpoint: str = API_ENDPOINT,\n",
-        "    thresholds_dict_str: str = '{\"auRoc\": 0.95}',\n",
-        "):\n",
-        "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
-        "        project=project, display_name=display_name, bq_source=bq_source\n",
-        "    )\n",
-        "\n",
-        "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
-        "        project=project,\n",
-        "        display_name=display_name,\n",
-        "        optimization_prediction_type=\"classification\",\n",
-        "        optimization_objective=\"minimize-log-loss\",\n",
-        "        budget_milli_node_hours=1000,\n",
-        "        column_specs={\n",
-        "            \"Area\": \"numeric\",\n",
-        "            \"Perimeter\": \"numeric\",\n",
-        "            \"MajorAxisLength\": \"numeric\",\n",
-        "            \"MinorAxisLength\": \"numeric\",\n",
-        "            \"AspectRation\": \"numeric\",\n",
-        "            \"Eccentricity\": \"numeric\",\n",
-        "            \"ConvexArea\": \"numeric\",\n",
-        "            \"EquivDiameter\": \"numeric\",\n",
-        "            \"Extent\": \"numeric\",\n",
-        "            \"Solidity\": \"numeric\",\n",
-        "            \"roundness\": \"numeric\",\n",
-        "            \"Compactness\": \"numeric\",\n",
-        "            \"ShapeFactor1\": \"numeric\",\n",
-        "            \"ShapeFactor2\": \"numeric\",\n",
-        "            \"ShapeFactor3\": \"numeric\",\n",
-        "            \"ShapeFactor4\": \"numeric\",\n",
-        "            \"Class\": \"categorical\",\n",
-        "        },\n",
-        "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
-        "        target_column=\"Class\",\n",
-        "    )\n",
-        "    model_eval_task = classification_model_eval_metrics(\n",
-        "        project,\n",
-        "        gcp_region,\n",
-        "        api_endpoint,\n",
-        "        thresholds_dict_str,\n",
-        "        training_op.outputs[\"model\"],\n",
-        "    )\n",
-        "\n",
-        "    with dsl.Condition(\n",
-        "        model_eval_task.outputs[\"dep_decision\"] == \"true\",\n",
-        "        name=\"deploy_decision\",\n",
-        "    ):\n",
-        "\n",
-        "        endpoint_op = gcc_aip.EndpointCreateOp(\n",
-        "            project=project,\n",
-        "            location=gcp_region,\n",
-        "            display_name=\"train-automl-beans\",\n",
-        "        )\n",
-        "\n",
-        "        gcc_aip.ModelDeployOp(\n",
-        "            model=training_op.outputs[\"model\"],\n",
-        "            endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-        "            dedicated_resources_min_replica_count=1,\n",
-        "            dedicated_resources_max_replica_count=1,\n",
-        "            dedicated_resources_machine_type=MACHINE_TYPE,\n",
-        "        )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "source": [
-        "## Compile the pipeline\n",
-        "\n",
-        "Next, compile the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "outputs": [],
-      "source": [
-        "from kfp.v2 import compiler  # noqa: F811\n",
-        "\n",
-        "compiler.Compiler().compile(\n",
-        "    pipeline_func=pipeline,\n",
-        "    package_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_pipeline:model"
-      },
-      "source": [
-        "## Run the pipeline\n",
-        "\n",
-        "Next, run the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_pipeline:model"
-      },
-      "outputs": [],
-      "source": [
-        "DISPLAY_NAME = \"beans_\" + TIMESTAMP\n",
-        "\n",
-        "job = aip.PipelineJob(\n",
-        "    display_name=DISPLAY_NAME,\n",
-        "    template_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
-        "    pipeline_root=PIPELINE_ROOT,\n",
-        "    parameter_values={\"project\": PROJECT_ID, \"display_name\": DISPLAY_NAME},\n",
-        ")\n",
-        "\n",
-        "job.submit()\n",
-        "\n",
-        "! rm tabular_classification_pipeline.json"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view_pipeline_run:model"
-      },
-      "source": [
-        "Click on the generated link to see your run in the Cloud Console.\n",
-        "\n",
-        "<!-- It should look something like this as it is running:\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "compare_pipeline_runs"
-      },
-      "source": [
-        "## Compare the parameters and metrics of the pipelines run from their tracked metadata\n",
-        "\n",
-        "Next, you use the Vertex AI SDK for Python to compare the parameters and metrics of the pipeline runs. Wait until the pipeline runs have finished to run the next cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "compare_pipeline_runs"
-      },
-      "outputs": [],
-      "source": [
-        "pipeline_df = aip.get_pipeline_df(pipeline=PIPELINE_NAME)\n",
-        "print(pipeline_df.head(2))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- Pipeline\n",
-        "- Model\n",
-        "- Endpoint\n",
-        "- Batch Job\n",
-        "- Custom Job\n",
-        "- Hyperparameter Tuning Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "delete_dataset = True\n",
-        "delete_pipeline = True\n",
-        "delete_model = True\n",
-        "delete_endpoint = True\n",
-        "delete_batchjob = True\n",
-        "delete_customjob = True\n",
-        "delete_hptjob = True\n",
-        "delete_bucket = True\n",
-        "\n",
-        "try:\n",
-        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-        "        models = aip.Model.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        model = models[0]\n",
-        "        aip.Model.delete(model)\n",
-        "        print(\"Deleted model:\", model)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-        "        endpoints = aip.Endpoint.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        endpoint = endpoints[0]\n",
-        "        endpoint.undeploy_all()\n",
-        "        aip.Endpoint.delete(endpoint.resource_name)\n",
-        "        print(\"Deleted endpoint:\", endpoint)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-        "    if \"tabular\" == \"tabular\":\n",
-        "        try:\n",
-        "            datasets = aip.TabularDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TabularDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"image\":\n",
-        "        try:\n",
-        "            datasets = aip.ImageDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.ImageDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"text\":\n",
-        "        try:\n",
-        "            datasets = aip.TextDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TextDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"video\":\n",
-        "        try:\n",
-        "            datasets = aip.VideoDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.VideoDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-        "        pipelines = aip.PipelineJob.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        pipeline = pipelines[0]\n",
-        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-        "        print(\"Deleted pipeline:\", pipeline)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-        "    ! gsutil rm -r $BUCKET_NAME"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "automl_tabular_classification_beans.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title:generic"
+   },
+   "source": [
+    "# Vertex AI Pipelines: AutoML Tabular pipelines using google-cloud-pipeline-components\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:pipelines,automl,beans"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines).\n",
+    "\n",
+    "You'll build a pipeline that looks like this:\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/beans.png\" width=\"95%\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:beans,lcn"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial is the UCI Machine Learning ['Dry beans dataset'](https://archive.ics.uci.edu/ml/datasets/Dry+Bean+Dataset), from: KOKLU, M. and OZKAN, I.A., (2020), \"Multiclass Classification of Dry Beans Using Computer Vision and Machine Learning Techniques.\"In Computers and Electronics in Agriculture, 174, 105507. [DOI](https://doi.org/10.1016/j.compag.2020.105507)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:pipelines,automl"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an AutoML tabular classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Create a `Dataset` resource.\n",
+    "- Train an AutoML `Model` resource.\n",
+    "- Creates an `Endpoint` resource.\n",
+    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+    "\n",
+    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+    "\n",
+    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+    "\n",
+    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex AI SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_storage"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-storage* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_storage"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install -U google-cloud-storage $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "check_versions"
+   },
+   "source": [
+    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.8."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "check_versions:kfp,gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "#### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = !gcloud auth list 2>/dev/null\n",
+    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "source": [
+    "#### Set service account access for Vertex AI Pipelines\n",
+    "\n",
+    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+    "\n",
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "source": [
+    "#### Vertex AI constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI:\n",
+    "\n",
+    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "outputs": [],
+   "source": [
+    "# API service endpoint\n",
+    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "source": [
+    "#### Vertex AI Pipelines constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI Pipelines:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "outputs": [],
+   "source": [
+    "PIPELINE_ROOT = \"{}/pipeline_root/beans\".format(BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "additional_imports"
+   },
+   "source": [
+    "Additional imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import NamedTuple\n",
+    "\n",
+    "import kfp\n",
+    "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
+    "from kfp.v2 import dsl\n",
+    "from kfp.v2.dsl import (Artifact, ClassificationMetrics, Input, Metrics,\n",
+    "                        Output, component)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_component:eval"
+   },
+   "source": [
+    "## Define a metrics evaluation custom component\n",
+    "\n",
+    "In this tutorial, you define one custom pipeline component. The remaining components are pre-built\n",
+    "components for Vertex AI services.\n",
+    "\n",
+    "The custom pipeline component you define is a Python-function-based component.\n",
+    "Python function-based components make it easier to iterate quickly by letting you build your component code as a Python function and generating the component specification for you.\n",
+    "\n",
+    "Note the `@component` decorator.  When you evaluate the `classification_model_eval` function, the component is compiled to what is essentially a task factory function, that can be used in the the pipeline definition.\n",
+    "\n",
+    "In addition, a `tabular_eval_component.yaml` component definition file will be generated.  The component `yaml` file can be shared & placed under version control, and used later to define a pipeline step.\n",
+    "\n",
+    "The component definition specifies a base image for the component to use, and specifies that the `google-cloud-aiplatform` package should be installed. When not specified, the base image defaults to Python 3.7\n",
+    "\n",
+    "The custom pipeline component retrieves the classification model evaluation generated by the AutoML tabular training process, parses the evaluation data, and renders the ROC curve and confusion matrix for the model. It also uses given metrics threshold information and compares that to the evaluation results to determine whether the model is sufficiently accurate to deploy.\n",
+    "\n",
+    "*Note:* This custom component is specific to an AutoML tabular classification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_component:eval"
+   },
+   "outputs": [],
+   "source": [
+    "@component(\n",
+    "    base_image=\"gcr.io/deeplearning-platform-release/tf2-cpu.2-6:latest\",\n",
+    "    output_component_file=\"tabular_eval_component.yaml\",\n",
+    "    packages_to_install=[\"google-cloud-aiplatform\"],\n",
+    ")\n",
+    "def classification_model_eval_metrics(\n",
+    "    project: str,\n",
+    "    location: str,  # \"us-central1\",\n",
+    "    api_endpoint: str,  # \"us-central1-aiplatform.googleapis.com\",\n",
+    "    thresholds_dict_str: str,\n",
+    "    model: Input[Artifact],\n",
+    "    metrics: Output[Metrics],\n",
+    "    metricsc: Output[ClassificationMetrics],\n",
+    ") -> NamedTuple(\"Outputs\", [(\"dep_decision\", str)]):  # Return parameter.\n",
+    "\n",
+    "    import json\n",
+    "    import logging\n",
+    "\n",
+    "    from google.cloud import aiplatform as aip\n",
+    "\n",
+    "    # Fetch model eval info\n",
+    "    def get_eval_info(client, model_name):\n",
+    "        from google.protobuf.json_format import MessageToDict\n",
+    "\n",
+    "        response = client.list_model_evaluations(parent=model_name)\n",
+    "        metrics_list = []\n",
+    "        metrics_string_list = []\n",
+    "        for evaluation in response:\n",
+    "            print(\"model_evaluation\")\n",
+    "            print(\" name:\", evaluation.name)\n",
+    "            print(\" metrics_schema_uri:\", evaluation.metrics_schema_uri)\n",
+    "            metrics = MessageToDict(evaluation._pb.metrics)\n",
+    "            for metric in metrics.keys():\n",
+    "                logging.info(\"metric: %s, value: %s\", metric, metrics[metric])\n",
+    "            metrics_str = json.dumps(metrics)\n",
+    "            metrics_list.append(metrics)\n",
+    "            metrics_string_list.append(metrics_str)\n",
+    "\n",
+    "        return (\n",
+    "            evaluation.name,\n",
+    "            metrics_list,\n",
+    "            metrics_string_list,\n",
+    "        )\n",
+    "\n",
+    "    # Use the given metrics threshold(s) to determine whether the model is\n",
+    "    # accurate enough to deploy.\n",
+    "    def classification_thresholds_check(metrics_dict, thresholds_dict):\n",
+    "        for k, v in thresholds_dict.items():\n",
+    "            logging.info(\"k {}, v {}\".format(k, v))\n",
+    "            if k in [\"auRoc\", \"auPrc\"]:  # higher is better\n",
+    "                if metrics_dict[k] < v:  # if under threshold, don't deploy\n",
+    "                    logging.info(\"{} < {}; returning False\".format(metrics_dict[k], v))\n",
+    "                    return False\n",
+    "        logging.info(\"threshold checks passed.\")\n",
+    "        return True\n",
+    "\n",
+    "    def log_metrics(metrics_list, metricsc):\n",
+    "        test_confusion_matrix = metrics_list[0][\"confusionMatrix\"]\n",
+    "        logging.info(\"rows: %s\", test_confusion_matrix[\"rows\"])\n",
+    "\n",
+    "        # log the ROC curve\n",
+    "        fpr = []\n",
+    "        tpr = []\n",
+    "        thresholds = []\n",
+    "        for item in metrics_list[0][\"confidenceMetrics\"]:\n",
+    "            fpr.append(item.get(\"falsePositiveRate\", 0.0))\n",
+    "            tpr.append(item.get(\"recall\", 0.0))\n",
+    "            thresholds.append(item.get(\"confidenceThreshold\", 0.0))\n",
+    "        print(f\"fpr: {fpr}\")\n",
+    "        print(f\"tpr: {tpr}\")\n",
+    "        print(f\"thresholds: {thresholds}\")\n",
+    "        metricsc.log_roc_curve(fpr, tpr, thresholds)\n",
+    "\n",
+    "        # log the confusion matrix\n",
+    "        annotations = []\n",
+    "        for item in test_confusion_matrix[\"annotationSpecs\"]:\n",
+    "            annotations.append(item[\"displayName\"])\n",
+    "        logging.info(\"confusion matrix annotations: %s\", annotations)\n",
+    "        metricsc.log_confusion_matrix(\n",
+    "            annotations,\n",
+    "            test_confusion_matrix[\"rows\"],\n",
+    "        )\n",
+    "\n",
+    "        # log textual metrics info as well\n",
+    "        for metric in metrics_list[0].keys():\n",
+    "            if metric != \"confidenceMetrics\":\n",
+    "                val_string = json.dumps(metrics_list[0][metric])\n",
+    "                metrics.log_metric(metric, val_string)\n",
+    "        # metrics.metadata[\"model_type\"] = \"AutoML Tabular classification\"\n",
+    "\n",
+    "    logging.getLogger().setLevel(logging.INFO)\n",
+    "    aip.init(project=project)\n",
+    "    # extract the model resource name from the input Model Artifact\n",
+    "    model_resource_path = model.metadata[\"resourceName\"]\n",
+    "    logging.info(\"model path: %s\", model_resource_path)\n",
+    "\n",
+    "    client_options = {\"api_endpoint\": api_endpoint}\n",
+    "    # Initialize client that will be used to create and send requests.\n",
+    "    client = aip.gapic.ModelServiceClient(client_options=client_options)\n",
+    "    eval_name, metrics_list, metrics_str_list = get_eval_info(\n",
+    "        client, model_resource_path\n",
+    "    )\n",
+    "    logging.info(\"got evaluation name: %s\", eval_name)\n",
+    "    logging.info(\"got metrics list: %s\", metrics_list)\n",
+    "    log_metrics(metrics_list, metricsc)\n",
+    "\n",
+    "    thresholds_dict = json.loads(thresholds_dict_str)\n",
+    "    deploy = classification_thresholds_check(metrics_list[0], thresholds_dict)\n",
+    "    if deploy:\n",
+    "        dep_decision = \"true\"\n",
+    "    else:\n",
+    "        dep_decision = \"false\"\n",
+    "    logging.info(\"deployment decision is %s\", dep_decision)\n",
+    "\n",
+    "    return (dep_decision,)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_pipeline:gcpc,beans,lcn"
+   },
+   "source": [
+    "## Define an AutoML tabular classification pipeline that uses components from `google_cloud_pipeline_components`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_pipeline:gcpc,beans,lcn"
+   },
+   "outputs": [],
+   "source": [
+    "DISPLAY_NAME = \"automl-beans{}\".format(TIMESTAMP)\n",
+    "PIPELINE_NAME = \"automl-tabular-beans-training-v2\"\n",
+    "MACHINE_TYPE = \"n1-standard-4\"\n",
+    "\n",
+    "\n",
+    "@kfp.dsl.pipeline(name=PIPELINE_NAME, pipeline_root=PIPELINE_ROOT)\n",
+    "def pipeline(\n",
+    "    bq_source: str = \"bq://aju-dev-demos.beans.beans1\",\n",
+    "    display_name: str = DISPLAY_NAME,\n",
+    "    project: str = PROJECT_ID,\n",
+    "    gcp_region: str = REGION,\n",
+    "    api_endpoint: str = API_ENDPOINT,\n",
+    "    thresholds_dict_str: str = '{\"auRoc\": 0.95}',\n",
+    "):\n",
+    "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
+    "        project=project, display_name=display_name, bq_source=bq_source\n",
+    "    )\n",
+    "\n",
+    "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
+    "        project=project,\n",
+    "        display_name=display_name,\n",
+    "        optimization_prediction_type=\"classification\",\n",
+    "        optimization_objective=\"minimize-log-loss\",\n",
+    "        budget_milli_node_hours=1000,\n",
+    "        column_specs={\n",
+    "            \"Area\": \"numeric\",\n",
+    "            \"Perimeter\": \"numeric\",\n",
+    "            \"MajorAxisLength\": \"numeric\",\n",
+    "            \"MinorAxisLength\": \"numeric\",\n",
+    "            \"AspectRation\": \"numeric\",\n",
+    "            \"Eccentricity\": \"numeric\",\n",
+    "            \"ConvexArea\": \"numeric\",\n",
+    "            \"EquivDiameter\": \"numeric\",\n",
+    "            \"Extent\": \"numeric\",\n",
+    "            \"Solidity\": \"numeric\",\n",
+    "            \"roundness\": \"numeric\",\n",
+    "            \"Compactness\": \"numeric\",\n",
+    "            \"ShapeFactor1\": \"numeric\",\n",
+    "            \"ShapeFactor2\": \"numeric\",\n",
+    "            \"ShapeFactor3\": \"numeric\",\n",
+    "            \"ShapeFactor4\": \"numeric\",\n",
+    "            \"Class\": \"categorical\",\n",
+    "        },\n",
+    "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
+    "        target_column=\"Class\",\n",
+    "    )\n",
+    "    model_eval_task = classification_model_eval_metrics(\n",
+    "        project,\n",
+    "        gcp_region,\n",
+    "        api_endpoint,\n",
+    "        thresholds_dict_str,\n",
+    "        training_op.outputs[\"model\"],\n",
+    "    )\n",
+    "\n",
+    "    with dsl.Condition(\n",
+    "        model_eval_task.outputs[\"dep_decision\"] == \"true\",\n",
+    "        name=\"deploy_decision\",\n",
+    "    ):\n",
+    "\n",
+    "        endpoint_op = gcc_aip.EndpointCreateOp(\n",
+    "            project=project,\n",
+    "            location=gcp_region,\n",
+    "            display_name=\"train-automl-beans\",\n",
+    "        )\n",
+    "\n",
+    "        gcc_aip.ModelDeployOp(\n",
+    "            model=training_op.outputs[\"model\"],\n",
+    "            endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+    "            dedicated_resources_min_replica_count=1,\n",
+    "            dedicated_resources_max_replica_count=1,\n",
+    "            dedicated_resources_machine_type=MACHINE_TYPE,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "source": [
+    "## Compile the pipeline\n",
+    "\n",
+    "Next, compile the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "outputs": [],
+   "source": [
+    "from kfp.v2 import compiler  # noqa: F811\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=pipeline,\n",
+    "    package_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_pipeline:model"
+   },
+   "source": [
+    "## Run the pipeline\n",
+    "\n",
+    "Next, run the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "run_pipeline:model"
+   },
+   "outputs": [],
+   "source": [
+    "DISPLAY_NAME = \"beans_\" + TIMESTAMP\n",
+    "\n",
+    "job = aip.PipelineJob(\n",
+    "    display_name=DISPLAY_NAME,\n",
+    "    template_path=\"tabular classification_pipeline.json\".replace(\" \", \"_\"),\n",
+    "    pipeline_root=PIPELINE_ROOT,\n",
+    "    parameter_values={\"project\": PROJECT_ID, \"display_name\": DISPLAY_NAME},\n",
+    "    enable_caching=False\n",
+    ")\n",
+    "\n",
+    "job.submit()\n",
+    "\n",
+    "! rm tabular_classification_pipeline.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view_pipeline_run:model"
+   },
+   "source": [
+    "Click on the generated link to see your run in the Cloud Console.\n",
+    "\n",
+    "<!-- It should look something like this as it is running:\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "compare_pipeline_runs"
+   },
+   "source": [
+    "## Compare the parameters and metrics of the pipelines run from their tracked metadata\n",
+    "\n",
+    "Next, you use the Vertex AI SDK for Python to compare the parameters and metrics of the pipeline runs. Wait until the pipeline runs have finished to run the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "compare_pipeline_runs"
+   },
+   "outputs": [],
+   "source": [
+    "pipeline_df = aip.get_pipeline_df(pipeline=PIPELINE_NAME)\n",
+    "print(pipeline_df.head(2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- Pipeline\n",
+    "- Model\n",
+    "- Endpoint\n",
+    "- Batch Job\n",
+    "- Custom Job\n",
+    "- Hyperparameter Tuning Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "delete_dataset = True\n",
+    "delete_pipeline = True\n",
+    "delete_model = True\n",
+    "delete_endpoint = True\n",
+    "delete_batchjob = True\n",
+    "delete_customjob = True\n",
+    "delete_hptjob = True\n",
+    "delete_bucket = True\n",
+    "\n",
+    "try:\n",
+    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+    "        models = aip.Model.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        model = models[0]\n",
+    "        aip.Model.delete(model)\n",
+    "        print(\"Deleted model:\", model)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+    "        endpoints = aip.Endpoint.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        endpoint = endpoints[0]\n",
+    "        endpoint.undeploy_all()\n",
+    "        aip.Endpoint.delete(endpoint.resource_name)\n",
+    "        print(\"Deleted endpoint:\", endpoint)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+    "    if \"tabular\" == \"tabular\":\n",
+    "        try:\n",
+    "            datasets = aip.TabularDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TabularDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"image\":\n",
+    "        try:\n",
+    "            datasets = aip.ImageDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.ImageDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"text\":\n",
+    "        try:\n",
+    "            datasets = aip.TextDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TextDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"video\":\n",
+    "        try:\n",
+    "            datasets = aip.VideoDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.VideoDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+    "        pipelines = aip.PipelineJob.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        pipeline = pipelines[0]\n",
+    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+    "        print(\"Deleted pipeline:\", pipeline)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+    "    ! gsutil rm -r $BUCKET_NAME"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "automl_tabular_classification_beans.ipynb",
+   "toc_visible": true
+  },
+  "environment": {
+   "name": "common-cu110.m71",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
+++ b/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
@@ -178,7 +178,7 @@
         "else:\n",
         "    USER_FLAG = \"\"\n",
         "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+        "! pip3 install --upgrade google-cloud-aiplatform[full] $USER_FLAG"
       ]
     },
     {

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb
@@ -1,994 +1,976 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title:generic"
+      },
+      "source": [
+        "# Vertex AI Pipelines: AutoML image classification pipelines using google-cloud-pipeline-components\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:pipelines,automl"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML image classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:flowers,icn"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial is the [Flowers dataset](https://www.tensorflow.org/datasets/catalog/tf_flowers) from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket. The trained model predicts the type of flower an image is from a class of five flowers: daisy, dandelion, rose, sunflower, or tulip."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:pipelines,automl"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML image classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a `Dataset` resource.\n",
+        "- Train an AutoML `Model` resource.\n",
+        "- Creates an `Endpoint` resource.\n",
+        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+        "\n",
+        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+        "\n",
+        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+        "\n",
+        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex AI SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_storage"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-storage* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_storage"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install -U google-cloud-storage $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "check_versions"
+      },
+      "source": [
+        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "check_versions:kfp,gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "#### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = !gcloud auth list 2>/dev/null\n",
+        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "source": [
+        "#### Set service account access for Vertex AI Pipelines\n",
+        "\n",
+        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+        "\n",
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "source": [
+        "#### Vertex AI constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI:\n",
+        "\n",
+        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "outputs": [],
+      "source": [
+        "# API service endpoint\n",
+        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "source": [
+        "#### Vertex AI Pipelines constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI Pipelines:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "outputs": [],
+      "source": [
+        "PIPELINE_ROOT = \"{}/pipeline_root/flowers\".format(BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "additional_imports"
+      },
+      "source": [
+        "Additional imports."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_pipelines:min"
+      },
+      "outputs": [],
+      "source": [
+        "import kfp\n",
+        "from google_cloud_pipeline_components import aiplatform as gcc_aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_pipeline:gcpc,automl,flowers,icn"
+      },
+      "source": [
+        "## Define AutoML image classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
+        "\n",
+        "Next, you define the pipeline.\n",
+        "\n",
+        "Create and deploy an AutoML image classification `Model` resource using a `Dataset` resource."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_pipeline:gcpc,automl,flowers,icn"
+      },
+      "outputs": [],
+      "source": [
+        "@kfp.dsl.pipeline(name=\"automl-image-training-v2\")\n",
+        "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
+        "    ds_op = gcc_aip.ImageDatasetCreateOp(\n",
+        "        project=project,\n",
+        "        display_name=\"flowers\",\n",
+        "        gcs_source=\"gs://cloud-samples-data/vision/automl_classification/flowers/all_data_v2.csv\",\n",
+        "        import_schema_uri=aip.schema.dataset.ioformat.image.single_label_classification,\n",
+        "    )\n",
+        "\n",
+        "    training_job_run_op = gcc_aip.AutoMLImageTrainingJobRunOp(\n",
+        "        project=project,\n",
+        "        display_name=\"train-automl-flowers\",\n",
+        "        prediction_type=\"classification\",\n",
+        "        model_type=\"CLOUD\",\n",
+        "        base_model=None,\n",
+        "        dataset=ds_op.outputs[\"dataset\"],\n",
+        "        model_display_name=\"train-automl-flowers\",\n",
+        "        training_fraction_split=0.6,\n",
+        "        validation_fraction_split=0.2,\n",
+        "        test_fraction_split=0.2,\n",
+        "        budget_milli_node_hours=8000,\n",
+        "    )\n",
+        "\n",
+        "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
+        "        project=project,\n",
+        "        location=region,\n",
+        "        display_name=\"train-automl-flowers\",\n",
+        "    )\n",
+        "\n",
+        "    gcc_aip.ModelDeployOp(\n",
+        "        model=training_job_run_op.outputs[\"model\"],\n",
+        "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+        "        automatic_resources_min_replica_count=1,\n",
+        "        automatic_resources_max_replica_count=1,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "source": [
+        "## Compile the pipeline\n",
+        "\n",
+        "Next, compile the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "outputs": [],
+      "source": [
+        "from kfp.v2 import compiler  # noqa: F811\n",
+        "\n",
+        "compiler.Compiler().compile(\n",
+        "    pipeline_func=pipeline,\n",
+        "    package_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_pipeline:automl,image"
+      },
+      "source": [
+        "## Run the pipeline\n",
+        "\n",
+        "Next, run the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_pipeline:automl,image"
+      },
+      "outputs": [],
+      "source": [
+        "DISPLAY_NAME = \"flowers_\" + TIMESTAMP\n",
+        "\n",
+        "job = aip.PipelineJob(\n",
+        "    display_name=DISPLAY_NAME,\n",
+        "    template_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
+        "    pipeline_root=PIPELINE_ROOT,\n",
+        "    enable_caching=False,\n",
+        ")\n",
+        "\n",
+        "job.run()\n",
+        "\n",
+        "! rm image_classification_pipeline.json"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view_pipeline_run:automl,image"
+      },
+      "source": [
+        "Click on the generated link to see your run in the Cloud Console.\n",
+        "\n",
+        "<!-- It should look something like this as it is running:\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+        "\n",
+        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" width=\"40%\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- Pipeline\n",
+        "- Model\n",
+        "- Endpoint\n",
+        "- Batch Job\n",
+        "- Custom Job\n",
+        "- Hyperparameter Tuning Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "delete_dataset = True\n",
+        "delete_pipeline = True\n",
+        "delete_model = True\n",
+        "delete_endpoint = True\n",
+        "delete_batchjob = True\n",
+        "delete_customjob = True\n",
+        "delete_hptjob = True\n",
+        "delete_bucket = True\n",
+        "\n",
+        "try:\n",
+        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+        "        models = aip.Model.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        model = models[0]\n",
+        "        aip.Model.delete(model)\n",
+        "        print(\"Deleted model:\", model)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+        "        endpoints = aip.Endpoint.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        endpoint = endpoints[0]\n",
+        "        endpoint.undeploy_all()\n",
+        "        aip.Endpoint.delete(endpoint.resource_name)\n",
+        "        print(\"Deleted endpoint:\", endpoint)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+        "    if \"image\" == \"tabular\":\n",
+        "        try:\n",
+        "            datasets = aip.TabularDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TabularDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"image\" == \"image\":\n",
+        "        try:\n",
+        "            datasets = aip.ImageDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.ImageDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"image\" == \"text\":\n",
+        "        try:\n",
+        "            datasets = aip.TextDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TextDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"image\" == \"video\":\n",
+        "        try:\n",
+        "            datasets = aip.VideoDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.VideoDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+        "        pipelines = aip.PipelineJob.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        pipeline = pipelines[0]\n",
+        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+        "        print(\"Deleted pipeline:\", pipeline)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+        "    ! gsutil rm -r $BUCKET_NAME"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "google_cloud_pipeline_components_automl_images.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title:generic"
-   },
-   "source": [
-    "# Vertex AI Pipelines: AutoML image classification pipelines using google-cloud-pipeline-components\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:pipelines,automl"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML image classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:flowers,icn"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial is the [Flowers dataset](https://www.tensorflow.org/datasets/catalog/tf_flowers) from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket. The trained model predicts the type of flower an image is from a class of five flowers: daisy, dandelion, rose, sunflower, or tulip."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:pipelines,automl"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an AutoML image classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Create a `Dataset` resource.\n",
-    "- Train an AutoML `Model` resource.\n",
-    "- Creates an `Endpoint` resource.\n",
-    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-    "\n",
-    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-    "\n",
-    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-    "\n",
-    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex AI SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_storage"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-storage* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_storage"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install -U google-cloud-storage $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "check_versions"
-   },
-   "source": [
-    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "check_versions:kfp,gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "#### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = !gcloud auth list 2>/dev/null\n",
-    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "source": [
-    "#### Set service account access for Vertex AI Pipelines\n",
-    "\n",
-    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-    "\n",
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "source": [
-    "#### Vertex AI constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI:\n",
-    "\n",
-    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "outputs": [],
-   "source": [
-    "# API service endpoint\n",
-    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "source": [
-    "#### Vertex AI Pipelines constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI Pipelines:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "outputs": [],
-   "source": [
-    "PIPELINE_ROOT = \"{}/pipeline_root/flowers\".format(BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "additional_imports"
-   },
-   "source": [
-    "Additional imports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_pipelines:min"
-   },
-   "outputs": [],
-   "source": [
-    "import kfp\n",
-    "from google_cloud_pipeline_components import aiplatform as gcc_aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_pipeline:gcpc,automl,flowers,icn"
-   },
-   "source": [
-    "## Define AutoML image classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
-    "\n",
-    "Next, you define the pipeline.\n",
-    "\n",
-    "Create and deploy an AutoML image classification `Model` resource using a `Dataset` resource."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_pipeline:gcpc,automl,flowers,icn"
-   },
-   "outputs": [],
-   "source": [
-    "@kfp.dsl.pipeline(name=\"automl-image-training-v2\")\n",
-    "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
-    "    ds_op = gcc_aip.ImageDatasetCreateOp(\n",
-    "        project=project,\n",
-    "        display_name=\"flowers\",\n",
-    "        gcs_source=\"gs://cloud-samples-data/vision/automl_classification/flowers/all_data_v2.csv\",\n",
-    "        import_schema_uri=aip.schema.dataset.ioformat.image.single_label_classification,\n",
-    "    )\n",
-    "\n",
-    "    training_job_run_op = gcc_aip.AutoMLImageTrainingJobRunOp(\n",
-    "        project=project,\n",
-    "        display_name=\"train-automl-flowers\",\n",
-    "        prediction_type=\"classification\",\n",
-    "        model_type=\"CLOUD\",\n",
-    "        base_model=None,\n",
-    "        dataset=ds_op.outputs[\"dataset\"],\n",
-    "        model_display_name=\"train-automl-flowers\",\n",
-    "        training_fraction_split=0.6,\n",
-    "        validation_fraction_split=0.2,\n",
-    "        test_fraction_split=0.2,\n",
-    "        budget_milli_node_hours=8000,\n",
-    "    )\n",
-    "\n",
-    "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
-    "        project=project,\n",
-    "        location=region,\n",
-    "        display_name=\"train-automl-flowers\",\n",
-    "    )\n",
-    "\n",
-    "    gcc_aip.ModelDeployOp(\n",
-    "        model=training_job_run_op.outputs[\"model\"],\n",
-    "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-    "        automatic_resources_min_replica_count=1,\n",
-    "        automatic_resources_max_replica_count=1,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "source": [
-    "## Compile the pipeline\n",
-    "\n",
-    "Next, compile the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "outputs": [],
-   "source": [
-    "from kfp.v2 import compiler  # noqa: F811\n",
-    "\n",
-    "compiler.Compiler().compile(\n",
-    "    pipeline_func=pipeline,\n",
-    "    package_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_pipeline:automl,image"
-   },
-   "source": [
-    "## Run the pipeline\n",
-    "\n",
-    "Next, run the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run_pipeline:automl,image"
-   },
-   "outputs": [],
-   "source": [
-    "DISPLAY_NAME = \"flowers_\" + TIMESTAMP\n",
-    "\n",
-    "job = aip.PipelineJob(\n",
-    "    display_name=DISPLAY_NAME,\n",
-    "    template_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
-    "    pipeline_root=PIPELINE_ROOT,\n",
-    "    enable_caching=False\n",
-    ")\n",
-    "\n",
-    "job.run()\n",
-    "\n",
-    "! rm image_classification_pipeline.json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "view_pipeline_run:automl,image"
-   },
-   "source": [
-    "Click on the generated link to see your run in the Cloud Console.\n",
-    "\n",
-    "<!-- It should look something like this as it is running:\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-    "\n",
-    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" width=\"40%\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- Pipeline\n",
-    "- Model\n",
-    "- Endpoint\n",
-    "- Batch Job\n",
-    "- Custom Job\n",
-    "- Hyperparameter Tuning Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "delete_dataset = True\n",
-    "delete_pipeline = True\n",
-    "delete_model = True\n",
-    "delete_endpoint = True\n",
-    "delete_batchjob = True\n",
-    "delete_customjob = True\n",
-    "delete_hptjob = True\n",
-    "delete_bucket = True\n",
-    "\n",
-    "try:\n",
-    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-    "        models = aip.Model.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        model = models[0]\n",
-    "        aip.Model.delete(model)\n",
-    "        print(\"Deleted model:\", model)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-    "        endpoints = aip.Endpoint.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        endpoint = endpoints[0]\n",
-    "        endpoint.undeploy_all()\n",
-    "        aip.Endpoint.delete(endpoint.resource_name)\n",
-    "        print(\"Deleted endpoint:\", endpoint)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-    "    if \"image\" == \"tabular\":\n",
-    "        try:\n",
-    "            datasets = aip.TabularDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TabularDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"image\" == \"image\":\n",
-    "        try:\n",
-    "            datasets = aip.ImageDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.ImageDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"image\" == \"text\":\n",
-    "        try:\n",
-    "            datasets = aip.TextDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TextDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"image\" == \"video\":\n",
-    "        try:\n",
-    "            datasets = aip.VideoDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.VideoDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-    "        pipelines = aip.PipelineJob.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        pipeline = pipelines[0]\n",
-    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-    "        print(\"Deleted pipeline:\", pipeline)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-    "    ! gsutil rm -r $BUCKET_NAME"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "google_cloud_pipeline_components_automl_images.ipynb",
-   "toc_visible": true
-  },
-  "environment": {
-   "name": "common-cu110.m71",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb
@@ -1,975 +1,994 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title:generic"
-      },
-      "source": [
-        "# Vertex AI Pipelines: AutoML image classification pipelines using google-cloud-pipeline-components\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:pipelines,automl"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML image classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:flowers,icn"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial is the [Flowers dataset](https://www.tensorflow.org/datasets/catalog/tf_flowers) from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket. The trained model predicts the type of flower an image is from a class of five flowers: daisy, dandelion, rose, sunflower, or tulip."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:pipelines,automl"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an AutoML image classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Create a `Dataset` resource.\n",
-        "- Train an AutoML `Model` resource.\n",
-        "- Creates an `Endpoint` resource.\n",
-        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-        "\n",
-        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-        "\n",
-        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-        "\n",
-        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex AI SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_storage"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-storage* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_storage"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install -U google-cloud-storage $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "check_versions"
-      },
-      "source": [
-        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "check_versions:kfp,gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "source": [
-        "#### Service Account\n",
-        "\n",
-        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "if (\n",
-        "    SERVICE_ACCOUNT == \"\"\n",
-        "    or SERVICE_ACCOUNT is None\n",
-        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-        "):\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = !gcloud auth list 2>/dev/null\n",
-        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "source": [
-        "#### Set service account access for Vertex AI Pipelines\n",
-        "\n",
-        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-        "\n",
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "source": [
-        "#### Vertex AI constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI:\n",
-        "\n",
-        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "outputs": [],
-      "source": [
-        "# API service endpoint\n",
-        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "source": [
-        "#### Vertex AI Pipelines constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI Pipelines:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "outputs": [],
-      "source": [
-        "PIPELINE_ROOT = \"{}/pipeline_root/flowers\".format(BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "additional_imports"
-      },
-      "source": [
-        "Additional imports."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_pipelines:min"
-      },
-      "outputs": [],
-      "source": [
-        "import kfp\n",
-        "from google_cloud_pipeline_components import aiplatform as gcc_aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex AI SDK for Python\n",
-        "\n",
-        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_pipeline:gcpc,automl,flowers,icn"
-      },
-      "source": [
-        "## Define AutoML image classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
-        "\n",
-        "Next, you define the pipeline.\n",
-        "\n",
-        "Create and deploy an AutoML image classification `Model` resource using a `Dataset` resource."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_pipeline:gcpc,automl,flowers,icn"
-      },
-      "outputs": [],
-      "source": [
-        "@kfp.dsl.pipeline(name=\"automl-image-training-v2\")\n",
-        "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
-        "    ds_op = gcc_aip.ImageDatasetCreateOp(\n",
-        "        project=project,\n",
-        "        display_name=\"flowers\",\n",
-        "        gcs_source=\"gs://cloud-samples-data/vision/automl_classification/flowers/all_data_v2.csv\",\n",
-        "        import_schema_uri=aip.schema.dataset.ioformat.image.single_label_classification,\n",
-        "    )\n",
-        "\n",
-        "    training_job_run_op = gcc_aip.AutoMLImageTrainingJobRunOp(\n",
-        "        project=project,\n",
-        "        display_name=\"train-automl-flowers\",\n",
-        "        prediction_type=\"classification\",\n",
-        "        model_type=\"CLOUD\",\n",
-        "        base_model=None,\n",
-        "        dataset=ds_op.outputs[\"dataset\"],\n",
-        "        model_display_name=\"train-automl-flowers\",\n",
-        "        training_fraction_split=0.6,\n",
-        "        validation_fraction_split=0.2,\n",
-        "        test_fraction_split=0.2,\n",
-        "        budget_milli_node_hours=8000,\n",
-        "    )\n",
-        "\n",
-        "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
-        "        project=project,\n",
-        "        location=region,\n",
-        "        display_name=\"train-automl-flowers\",\n",
-        "    )\n",
-        "\n",
-        "    gcc_aip.ModelDeployOp(\n",
-        "        model=training_job_run_op.outputs[\"model\"],\n",
-        "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-        "        automatic_resources_min_replica_count=1,\n",
-        "        automatic_resources_max_replica_count=1,\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "source": [
-        "## Compile the pipeline\n",
-        "\n",
-        "Next, compile the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "outputs": [],
-      "source": [
-        "from kfp.v2 import compiler  # noqa: F811\n",
-        "\n",
-        "compiler.Compiler().compile(\n",
-        "    pipeline_func=pipeline,\n",
-        "    package_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_pipeline:automl,image"
-      },
-      "source": [
-        "## Run the pipeline\n",
-        "\n",
-        "Next, run the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_pipeline:automl,image"
-      },
-      "outputs": [],
-      "source": [
-        "DISPLAY_NAME = \"flowers_\" + TIMESTAMP\n",
-        "\n",
-        "job = aip.PipelineJob(\n",
-        "    display_name=DISPLAY_NAME,\n",
-        "    template_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
-        "    pipeline_root=PIPELINE_ROOT,\n",
-        ")\n",
-        "\n",
-        "job.run()\n",
-        "\n",
-        "! rm image_classification_pipeline.json"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view_pipeline_run:automl,image"
-      },
-      "source": [
-        "Click on the generated link to see your run in the Cloud Console.\n",
-        "\n",
-        "<!-- It should look something like this as it is running:\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-        "\n",
-        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" width=\"40%\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- Pipeline\n",
-        "- Model\n",
-        "- Endpoint\n",
-        "- Batch Job\n",
-        "- Custom Job\n",
-        "- Hyperparameter Tuning Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "delete_dataset = True\n",
-        "delete_pipeline = True\n",
-        "delete_model = True\n",
-        "delete_endpoint = True\n",
-        "delete_batchjob = True\n",
-        "delete_customjob = True\n",
-        "delete_hptjob = True\n",
-        "delete_bucket = True\n",
-        "\n",
-        "try:\n",
-        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-        "        models = aip.Model.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        model = models[0]\n",
-        "        aip.Model.delete(model)\n",
-        "        print(\"Deleted model:\", model)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-        "        endpoints = aip.Endpoint.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        endpoint = endpoints[0]\n",
-        "        endpoint.undeploy_all()\n",
-        "        aip.Endpoint.delete(endpoint.resource_name)\n",
-        "        print(\"Deleted endpoint:\", endpoint)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-        "    if \"image\" == \"tabular\":\n",
-        "        try:\n",
-        "            datasets = aip.TabularDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TabularDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"image\" == \"image\":\n",
-        "        try:\n",
-        "            datasets = aip.ImageDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.ImageDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"image\" == \"text\":\n",
-        "        try:\n",
-        "            datasets = aip.TextDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TextDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"image\" == \"video\":\n",
-        "        try:\n",
-        "            datasets = aip.VideoDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.VideoDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-        "        pipelines = aip.PipelineJob.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        pipeline = pipelines[0]\n",
-        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-        "        print(\"Deleted pipeline:\", pipeline)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-        "    ! gsutil rm -r $BUCKET_NAME"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "google_cloud_pipeline_components_automl_images.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title:generic"
+   },
+   "source": [
+    "# Vertex AI Pipelines: AutoML image classification pipelines using google-cloud-pipeline-components\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:pipelines,automl"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML image classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:flowers,icn"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial is the [Flowers dataset](https://www.tensorflow.org/datasets/catalog/tf_flowers) from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket. The trained model predicts the type of flower an image is from a class of five flowers: daisy, dandelion, rose, sunflower, or tulip."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:pipelines,automl"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an AutoML image classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Create a `Dataset` resource.\n",
+    "- Train an AutoML `Model` resource.\n",
+    "- Creates an `Endpoint` resource.\n",
+    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+    "\n",
+    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+    "\n",
+    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+    "\n",
+    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex AI SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_storage"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-storage* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_storage"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install -U google-cloud-storage $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "check_versions"
+   },
+   "source": [
+    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "check_versions:kfp,gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "#### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = !gcloud auth list 2>/dev/null\n",
+    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "source": [
+    "#### Set service account access for Vertex AI Pipelines\n",
+    "\n",
+    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+    "\n",
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "source": [
+    "#### Vertex AI constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI:\n",
+    "\n",
+    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "outputs": [],
+   "source": [
+    "# API service endpoint\n",
+    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "source": [
+    "#### Vertex AI Pipelines constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI Pipelines:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "outputs": [],
+   "source": [
+    "PIPELINE_ROOT = \"{}/pipeline_root/flowers\".format(BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "additional_imports"
+   },
+   "source": [
+    "Additional imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_pipelines:min"
+   },
+   "outputs": [],
+   "source": [
+    "import kfp\n",
+    "from google_cloud_pipeline_components import aiplatform as gcc_aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_pipeline:gcpc,automl,flowers,icn"
+   },
+   "source": [
+    "## Define AutoML image classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
+    "\n",
+    "Next, you define the pipeline.\n",
+    "\n",
+    "Create and deploy an AutoML image classification `Model` resource using a `Dataset` resource."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_pipeline:gcpc,automl,flowers,icn"
+   },
+   "outputs": [],
+   "source": [
+    "@kfp.dsl.pipeline(name=\"automl-image-training-v2\")\n",
+    "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
+    "    ds_op = gcc_aip.ImageDatasetCreateOp(\n",
+    "        project=project,\n",
+    "        display_name=\"flowers\",\n",
+    "        gcs_source=\"gs://cloud-samples-data/vision/automl_classification/flowers/all_data_v2.csv\",\n",
+    "        import_schema_uri=aip.schema.dataset.ioformat.image.single_label_classification,\n",
+    "    )\n",
+    "\n",
+    "    training_job_run_op = gcc_aip.AutoMLImageTrainingJobRunOp(\n",
+    "        project=project,\n",
+    "        display_name=\"train-automl-flowers\",\n",
+    "        prediction_type=\"classification\",\n",
+    "        model_type=\"CLOUD\",\n",
+    "        base_model=None,\n",
+    "        dataset=ds_op.outputs[\"dataset\"],\n",
+    "        model_display_name=\"train-automl-flowers\",\n",
+    "        training_fraction_split=0.6,\n",
+    "        validation_fraction_split=0.2,\n",
+    "        test_fraction_split=0.2,\n",
+    "        budget_milli_node_hours=8000,\n",
+    "    )\n",
+    "\n",
+    "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
+    "        project=project,\n",
+    "        location=region,\n",
+    "        display_name=\"train-automl-flowers\",\n",
+    "    )\n",
+    "\n",
+    "    gcc_aip.ModelDeployOp(\n",
+    "        model=training_job_run_op.outputs[\"model\"],\n",
+    "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+    "        automatic_resources_min_replica_count=1,\n",
+    "        automatic_resources_max_replica_count=1,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "source": [
+    "## Compile the pipeline\n",
+    "\n",
+    "Next, compile the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "outputs": [],
+   "source": [
+    "from kfp.v2 import compiler  # noqa: F811\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=pipeline,\n",
+    "    package_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_pipeline:automl,image"
+   },
+   "source": [
+    "## Run the pipeline\n",
+    "\n",
+    "Next, run the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "run_pipeline:automl,image"
+   },
+   "outputs": [],
+   "source": [
+    "DISPLAY_NAME = \"flowers_\" + TIMESTAMP\n",
+    "\n",
+    "job = aip.PipelineJob(\n",
+    "    display_name=DISPLAY_NAME,\n",
+    "    template_path=\"image classification_pipeline.json\".replace(\" \", \"_\"),\n",
+    "    pipeline_root=PIPELINE_ROOT,\n",
+    "    enable_caching=False\n",
+    ")\n",
+    "\n",
+    "job.run()\n",
+    "\n",
+    "! rm image_classification_pipeline.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view_pipeline_run:automl,image"
+   },
+   "source": [
+    "Click on the generated link to see your run in the Cloud Console.\n",
+    "\n",
+    "<!-- It should look something like this as it is running:\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+    "\n",
+    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_image_classif.png\" width=\"40%\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- Pipeline\n",
+    "- Model\n",
+    "- Endpoint\n",
+    "- Batch Job\n",
+    "- Custom Job\n",
+    "- Hyperparameter Tuning Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "delete_dataset = True\n",
+    "delete_pipeline = True\n",
+    "delete_model = True\n",
+    "delete_endpoint = True\n",
+    "delete_batchjob = True\n",
+    "delete_customjob = True\n",
+    "delete_hptjob = True\n",
+    "delete_bucket = True\n",
+    "\n",
+    "try:\n",
+    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+    "        models = aip.Model.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        model = models[0]\n",
+    "        aip.Model.delete(model)\n",
+    "        print(\"Deleted model:\", model)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+    "        endpoints = aip.Endpoint.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        endpoint = endpoints[0]\n",
+    "        endpoint.undeploy_all()\n",
+    "        aip.Endpoint.delete(endpoint.resource_name)\n",
+    "        print(\"Deleted endpoint:\", endpoint)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+    "    if \"image\" == \"tabular\":\n",
+    "        try:\n",
+    "            datasets = aip.TabularDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TabularDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"image\" == \"image\":\n",
+    "        try:\n",
+    "            datasets = aip.ImageDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.ImageDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"image\" == \"text\":\n",
+    "        try:\n",
+    "            datasets = aip.TextDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TextDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"image\" == \"video\":\n",
+    "        try:\n",
+    "            datasets = aip.VideoDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.VideoDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+    "        pipelines = aip.PipelineJob.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        pipeline = pipelines[0]\n",
+    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+    "        print(\"Deleted pipeline:\", pipeline)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+    "    ! gsutil rm -r $BUCKET_NAME"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "google_cloud_pipeline_components_automl_images.ipynb",
+   "toc_visible": true
+  },
+  "environment": {
+   "name": "common-cu110.m71",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
@@ -1,1007 +1,989 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title:generic"
+      },
+      "source": [
+        "# Vertex AI Pipelines: AutoML tabular regression pipelines using google-cloud-pipeline-components\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:pipelines,automl"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular regression workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:cal_housing,lrg"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial is the [California Housing dataset from the 1990 Census](https://developers.google.com/machine-learning/crash-course/california-housing-data-description)\n",
+        "\n",
+        "The dataset predicts the median house price."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:pipelines,automl"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML tabular regression using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a `Dataset` resource.\n",
+        "- Train an AutoML `Model` resource.\n",
+        "- Creates an `Endpoint` resource.\n",
+        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+        "\n",
+        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+        "\n",
+        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+        "\n",
+        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex AI SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_storage"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-storage* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_storage"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install -U google-cloud-storage $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "check_versions"
+      },
+      "source": [
+        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "check_versions:kfp,gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "#### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = !gcloud auth list 2>/dev/null\n",
+        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "source": [
+        "#### Set service account access for Vertex AI Pipelines\n",
+        "\n",
+        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+        "\n",
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "source": [
+        "#### Vertex AI constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI:\n",
+        "\n",
+        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "outputs": [],
+      "source": [
+        "# API service endpoint\n",
+        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "source": [
+        "#### Vertex AI Pipelines constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI Pipelines:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "outputs": [],
+      "source": [
+        "PIPELINE_ROOT = \"{}/pipeline_root/cal_housing\".format(BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "additional_imports"
+      },
+      "source": [
+        "Additional imports."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_pipelines:gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "import kfp\n",
+        "from google_cloud_pipeline_components import aiplatform as gcc_aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
+      },
+      "source": [
+        "## Define AutoML tabular regression model pipeline that uses components from `google_cloud_pipeline_components`\n",
+        "\n",
+        "Next, you define the pipeline.\n",
+        "\n",
+        "Create and deploy an AutoML tabular regression `Model` resource using a `Dataset` resource."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
+      },
+      "outputs": [],
+      "source": [
+        "TRAIN_FILE_NAME = \"california_housing_train.csv\"\n",
+        "! gsutil cp gs://aju-dev-demos-codelabs/sample_data/california_housing_train.csv {PIPELINE_ROOT}/data/\n",
+        "\n",
+        "gcs_csv_path = f\"{PIPELINE_ROOT}/data/{TRAIN_FILE_NAME}\"\n",
+        "\n",
+        "\n",
+        "@kfp.dsl.pipeline(name=\"automl-tab-training-v2\")\n",
+        "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
+        "\n",
+        "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
+        "        project=project, display_name=\"housing\", gcs_source=gcs_csv_path\n",
+        "    )\n",
+        "\n",
+        "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
+        "        project=project,\n",
+        "        display_name=\"train-automl-cal_housing\",\n",
+        "        optimization_prediction_type=\"regression\",\n",
+        "        optimization_objective=\"minimize-rmse\",\n",
+        "        column_transformations=[\n",
+        "            {\"numeric\": {\"column_name\": \"longitude\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"latitude\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"housing_median_age\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"total_rooms\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"total_bedrooms\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"population\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"households\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"median_income\"}},\n",
+        "            {\"numeric\": {\"column_name\": \"median_house_value\"}},\n",
+        "        ],\n",
+        "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
+        "        target_column=\"median_house_value\",\n",
+        "    )\n",
+        "\n",
+        "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
+        "        project=project,\n",
+        "        location=region,\n",
+        "        display_name=\"train-automl-flowers\",\n",
+        "    )\n",
+        "\n",
+        "    gcc_aip.ModelDeployOp(\n",
+        "        model=training_op.outputs[\"model\"],\n",
+        "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+        "        dedicated_resources_machine_type=\"n1-standard-4\",\n",
+        "        dedicated_resources_min_replica_count=1,\n",
+        "        dedicated_resources_max_replica_count=1,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "source": [
+        "## Compile the pipeline\n",
+        "\n",
+        "Next, compile the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "outputs": [],
+      "source": [
+        "from kfp.v2 import compiler  # noqa: F811\n",
+        "\n",
+        "compiler.Compiler().compile(\n",
+        "    pipeline_func=pipeline,\n",
+        "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_pipeline:automl,tabular"
+      },
+      "source": [
+        "## Run the pipeline\n",
+        "\n",
+        "Next, run the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_pipeline:automl,tabular"
+      },
+      "outputs": [],
+      "source": [
+        "DISPLAY_NAME = \"cal_housing_\" + TIMESTAMP\n",
+        "\n",
+        "job = aip.PipelineJob(\n",
+        "    display_name=DISPLAY_NAME,\n",
+        "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+        "    pipeline_root=PIPELINE_ROOT,\n",
+        "    enable_caching=False,\n",
+        ")\n",
+        "\n",
+        "job.run()\n",
+        "\n",
+        "! rm tabular_regression_pipeline.json"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view_pipeline_run:automl,tabular"
+      },
+      "source": [
+        "Click on the generated link to see your run in the Cloud Console.\n",
+        "\n",
+        "<!-- It should look something like this as it is running:\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+        "\n",
+        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- Pipeline\n",
+        "- Model\n",
+        "- Endpoint\n",
+        "- Batch Job\n",
+        "- Custom Job\n",
+        "- Hyperparameter Tuning Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "delete_dataset = True\n",
+        "delete_pipeline = True\n",
+        "delete_model = True\n",
+        "delete_endpoint = True\n",
+        "delete_batchjob = True\n",
+        "delete_customjob = True\n",
+        "delete_hptjob = True\n",
+        "delete_bucket = True\n",
+        "\n",
+        "try:\n",
+        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+        "        models = aip.Model.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        model = models[0]\n",
+        "        aip.Model.delete(model)\n",
+        "        print(\"Deleted model:\", model)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+        "        endpoints = aip.Endpoint.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        endpoint = endpoints[0]\n",
+        "        endpoint.undeploy_all()\n",
+        "        aip.Endpoint.delete(endpoint.resource_name)\n",
+        "        print(\"Deleted endpoint:\", endpoint)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+        "    if \"tabular\" == \"tabular\":\n",
+        "        try:\n",
+        "            datasets = aip.TabularDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TabularDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"image\":\n",
+        "        try:\n",
+        "            datasets = aip.ImageDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.ImageDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"text\":\n",
+        "        try:\n",
+        "            datasets = aip.TextDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TextDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"video\":\n",
+        "        try:\n",
+        "            datasets = aip.VideoDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.VideoDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+        "        pipelines = aip.PipelineJob.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        pipeline = pipelines[0]\n",
+        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+        "        print(\"Deleted pipeline:\", pipeline)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+        "    ! gsutil rm -r $BUCKET_NAME"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "google_cloud_pipeline_components_automl_tabular.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title:generic"
-   },
-   "source": [
-    "# Vertex AI Pipelines: AutoML tabular regression pipelines using google-cloud-pipeline-components\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:pipelines,automl"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular regression workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:cal_housing,lrg"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial is the [California Housing dataset from the 1990 Census](https://developers.google.com/machine-learning/crash-course/california-housing-data-description)\n",
-    "\n",
-    "The dataset predicts the median house price."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:pipelines,automl"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an AutoML tabular regression using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Create a `Dataset` resource.\n",
-    "- Train an AutoML `Model` resource.\n",
-    "- Creates an `Endpoint` resource.\n",
-    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-    "\n",
-    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-    "\n",
-    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-    "\n",
-    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex AI SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_storage"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-storage* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_storage"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install -U google-cloud-storage $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "check_versions"
-   },
-   "source": [
-    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "check_versions:kfp,gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "#### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = !gcloud auth list 2>/dev/null\n",
-    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "source": [
-    "#### Set service account access for Vertex AI Pipelines\n",
-    "\n",
-    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-    "\n",
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "source": [
-    "#### Vertex AI constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI:\n",
-    "\n",
-    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "outputs": [],
-   "source": [
-    "# API service endpoint\n",
-    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "source": [
-    "#### Vertex AI Pipelines constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI Pipelines:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "outputs": [],
-   "source": [
-    "PIPELINE_ROOT = \"{}/pipeline_root/cal_housing\".format(BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "additional_imports"
-   },
-   "source": [
-    "Additional imports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_pipelines:gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "import kfp\n",
-    "from google_cloud_pipeline_components import aiplatform as gcc_aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
-   },
-   "source": [
-    "## Define AutoML tabular regression model pipeline that uses components from `google_cloud_pipeline_components`\n",
-    "\n",
-    "Next, you define the pipeline.\n",
-    "\n",
-    "Create and deploy an AutoML tabular regression `Model` resource using a `Dataset` resource."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
-   },
-   "outputs": [],
-   "source": [
-    "TRAIN_FILE_NAME = \"california_housing_train.csv\"\n",
-    "! gsutil cp gs://aju-dev-demos-codelabs/sample_data/california_housing_train.csv {PIPELINE_ROOT}/data/\n",
-    "\n",
-    "gcs_csv_path = f\"{PIPELINE_ROOT}/data/{TRAIN_FILE_NAME}\"\n",
-    "\n",
-    "\n",
-    "@kfp.dsl.pipeline(name=\"automl-tab-training-v2\")\n",
-    "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
-    "\n",
-    "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
-    "        project=project, display_name=\"housing\", gcs_source=gcs_csv_path\n",
-    "    )\n",
-    "\n",
-    "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
-    "        project=project,\n",
-    "        display_name=\"train-automl-cal_housing\",\n",
-    "        optimization_prediction_type=\"regression\",\n",
-    "        optimization_objective=\"minimize-rmse\",\n",
-    "        column_transformations=[\n",
-    "            {\"numeric\": {\"column_name\": \"longitude\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"latitude\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"housing_median_age\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"total_rooms\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"total_bedrooms\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"population\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"households\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"median_income\"}},\n",
-    "            {\"numeric\": {\"column_name\": \"median_house_value\"}},\n",
-    "        ],\n",
-    "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
-    "        target_column=\"median_house_value\",\n",
-    "    )\n",
-    "\n",
-    "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
-    "        project=project,\n",
-    "        location=region,\n",
-    "        display_name=\"train-automl-flowers\",\n",
-    "    )\n",
-    "\n",
-    "    gcc_aip.ModelDeployOp(\n",
-    "        model=training_op.outputs[\"model\"],\n",
-    "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-    "        dedicated_resources_machine_type=\"n1-standard-4\",\n",
-    "        dedicated_resources_min_replica_count=1,\n",
-    "        dedicated_resources_max_replica_count=1,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "source": [
-    "## Compile the pipeline\n",
-    "\n",
-    "Next, compile the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "outputs": [],
-   "source": [
-    "from kfp.v2 import compiler  # noqa: F811\n",
-    "\n",
-    "compiler.Compiler().compile(\n",
-    "    pipeline_func=pipeline,\n",
-    "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_pipeline:automl,tabular"
-   },
-   "source": [
-    "## Run the pipeline\n",
-    "\n",
-    "Next, run the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run_pipeline:automl,tabular"
-   },
-   "outputs": [],
-   "source": [
-    "DISPLAY_NAME = \"cal_housing_\" + TIMESTAMP\n",
-    "\n",
-    "job = aip.PipelineJob(\n",
-    "    display_name=DISPLAY_NAME,\n",
-    "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-    "    pipeline_root=PIPELINE_ROOT,\n",
-    "    enable_caching=False\n",
-    ")\n",
-    "\n",
-    "job.run()\n",
-    "\n",
-    "! rm tabular_regression_pipeline.json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "view_pipeline_run:automl,tabular"
-   },
-   "source": [
-    "Click on the generated link to see your run in the Cloud Console.\n",
-    "\n",
-    "<!-- It should look something like this as it is running:\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-    "\n",
-    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- Pipeline\n",
-    "- Model\n",
-    "- Endpoint\n",
-    "- Batch Job\n",
-    "- Custom Job\n",
-    "- Hyperparameter Tuning Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "delete_dataset = True\n",
-    "delete_pipeline = True\n",
-    "delete_model = True\n",
-    "delete_endpoint = True\n",
-    "delete_batchjob = True\n",
-    "delete_customjob = True\n",
-    "delete_hptjob = True\n",
-    "delete_bucket = True\n",
-    "\n",
-    "try:\n",
-    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-    "        models = aip.Model.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        model = models[0]\n",
-    "        aip.Model.delete(model)\n",
-    "        print(\"Deleted model:\", model)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-    "        endpoints = aip.Endpoint.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        endpoint = endpoints[0]\n",
-    "        endpoint.undeploy_all()\n",
-    "        aip.Endpoint.delete(endpoint.resource_name)\n",
-    "        print(\"Deleted endpoint:\", endpoint)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-    "    if \"tabular\" == \"tabular\":\n",
-    "        try:\n",
-    "            datasets = aip.TabularDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TabularDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"image\":\n",
-    "        try:\n",
-    "            datasets = aip.ImageDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.ImageDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"text\":\n",
-    "        try:\n",
-    "            datasets = aip.TextDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TextDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"video\":\n",
-    "        try:\n",
-    "            datasets = aip.VideoDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.VideoDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-    "        pipelines = aip.PipelineJob.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        pipeline = pipelines[0]\n",
-    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-    "        print(\"Deleted pipeline:\", pipeline)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-    "    ! gsutil rm -r $BUCKET_NAME"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "google_cloud_pipeline_components_automl_tabular.ipynb",
-   "toc_visible": true
-  },
-  "environment": {
-   "name": "common-cu110.m71",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
@@ -1,988 +1,1007 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title:generic"
-      },
-      "source": [
-        "# Vertex AI Pipelines: AutoML tabular regression pipelines using google-cloud-pipeline-components\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:pipelines,automl"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular regression workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:cal_housing,lrg"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial is the [California Housing dataset from the 1990 Census](https://developers.google.com/machine-learning/crash-course/california-housing-data-description)\n",
-        "\n",
-        "The dataset predicts the median house price."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:pipelines,automl"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an AutoML tabular regression using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Create a `Dataset` resource.\n",
-        "- Train an AutoML `Model` resource.\n",
-        "- Creates an `Endpoint` resource.\n",
-        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-        "\n",
-        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-        "\n",
-        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-        "\n",
-        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex AI SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_storage"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-storage* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_storage"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install -U google-cloud-storage $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "check_versions"
-      },
-      "source": [
-        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "check_versions:kfp,gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "source": [
-        "#### Service Account\n",
-        "\n",
-        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "if (\n",
-        "    SERVICE_ACCOUNT == \"\"\n",
-        "    or SERVICE_ACCOUNT is None\n",
-        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-        "):\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = !gcloud auth list 2>/dev/null\n",
-        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "source": [
-        "#### Set service account access for Vertex AI Pipelines\n",
-        "\n",
-        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-        "\n",
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "source": [
-        "#### Vertex AI constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI:\n",
-        "\n",
-        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "outputs": [],
-      "source": [
-        "# API service endpoint\n",
-        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "source": [
-        "#### Vertex AI Pipelines constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI Pipelines:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "outputs": [],
-      "source": [
-        "PIPELINE_ROOT = \"{}/pipeline_root/cal_housing\".format(BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "additional_imports"
-      },
-      "source": [
-        "Additional imports."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_pipelines:gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "import kfp\n",
-        "from google_cloud_pipeline_components import aiplatform as gcc_aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex AI SDK for Python\n",
-        "\n",
-        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
-      },
-      "source": [
-        "## Define AutoML tabular regression model pipeline that uses components from `google_cloud_pipeline_components`\n",
-        "\n",
-        "Next, you define the pipeline.\n",
-        "\n",
-        "Create and deploy an AutoML tabular regression `Model` resource using a `Dataset` resource."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
-      },
-      "outputs": [],
-      "source": [
-        "TRAIN_FILE_NAME = \"california_housing_train.csv\"\n",
-        "! gsutil cp gs://aju-dev-demos-codelabs/sample_data/california_housing_train.csv {PIPELINE_ROOT}/data/\n",
-        "\n",
-        "gcs_csv_path = f\"{PIPELINE_ROOT}/data/{TRAIN_FILE_NAME}\"\n",
-        "\n",
-        "\n",
-        "@kfp.dsl.pipeline(name=\"automl-tab-training-v2\")\n",
-        "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
-        "\n",
-        "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
-        "        project=project, display_name=\"housing\", gcs_source=gcs_csv_path\n",
-        "    )\n",
-        "\n",
-        "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
-        "        project=project,\n",
-        "        display_name=\"train-automl-cal_housing\",\n",
-        "        optimization_prediction_type=\"regression\",\n",
-        "        optimization_objective=\"minimize-rmse\",\n",
-        "        column_transformations=[\n",
-        "            {\"numeric\": {\"column_name\": \"longitude\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"latitude\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"housing_median_age\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"total_rooms\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"total_bedrooms\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"population\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"households\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"median_income\"}},\n",
-        "            {\"numeric\": {\"column_name\": \"median_house_value\"}},\n",
-        "        ],\n",
-        "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
-        "        target_column=\"median_house_value\",\n",
-        "    )\n",
-        "\n",
-        "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
-        "        project=project,\n",
-        "        location=region,\n",
-        "        display_name=\"train-automl-flowers\",\n",
-        "    )\n",
-        "\n",
-        "    gcc_aip.ModelDeployOp(\n",
-        "        model=training_op.outputs[\"model\"],\n",
-        "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-        "        dedicated_resources_machine_type=\"n1-standard-4\",\n",
-        "        dedicated_resources_min_replica_count=1,\n",
-        "        dedicated_resources_max_replica_count=1,\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "source": [
-        "## Compile the pipeline\n",
-        "\n",
-        "Next, compile the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "outputs": [],
-      "source": [
-        "from kfp.v2 import compiler  # noqa: F811\n",
-        "\n",
-        "compiler.Compiler().compile(\n",
-        "    pipeline_func=pipeline,\n",
-        "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_pipeline:automl,tabular"
-      },
-      "source": [
-        "## Run the pipeline\n",
-        "\n",
-        "Next, run the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_pipeline:automl,tabular"
-      },
-      "outputs": [],
-      "source": [
-        "DISPLAY_NAME = \"cal_housing_\" + TIMESTAMP\n",
-        "\n",
-        "job = aip.PipelineJob(\n",
-        "    display_name=DISPLAY_NAME,\n",
-        "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-        "    pipeline_root=PIPELINE_ROOT,\n",
-        ")\n",
-        "\n",
-        "job.run()\n",
-        "\n",
-        "! rm tabular_regression_pipeline.json"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view_pipeline_run:automl,tabular"
-      },
-      "source": [
-        "Click on the generated link to see your run in the Cloud Console.\n",
-        "\n",
-        "<!-- It should look something like this as it is running:\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-        "\n",
-        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- Pipeline\n",
-        "- Model\n",
-        "- Endpoint\n",
-        "- Batch Job\n",
-        "- Custom Job\n",
-        "- Hyperparameter Tuning Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "delete_dataset = True\n",
-        "delete_pipeline = True\n",
-        "delete_model = True\n",
-        "delete_endpoint = True\n",
-        "delete_batchjob = True\n",
-        "delete_customjob = True\n",
-        "delete_hptjob = True\n",
-        "delete_bucket = True\n",
-        "\n",
-        "try:\n",
-        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-        "        models = aip.Model.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        model = models[0]\n",
-        "        aip.Model.delete(model)\n",
-        "        print(\"Deleted model:\", model)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-        "        endpoints = aip.Endpoint.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        endpoint = endpoints[0]\n",
-        "        endpoint.undeploy_all()\n",
-        "        aip.Endpoint.delete(endpoint.resource_name)\n",
-        "        print(\"Deleted endpoint:\", endpoint)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-        "    if \"tabular\" == \"tabular\":\n",
-        "        try:\n",
-        "            datasets = aip.TabularDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TabularDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"image\":\n",
-        "        try:\n",
-        "            datasets = aip.ImageDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.ImageDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"text\":\n",
-        "        try:\n",
-        "            datasets = aip.TextDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TextDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"video\":\n",
-        "        try:\n",
-        "            datasets = aip.VideoDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.VideoDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-        "        pipelines = aip.PipelineJob.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        pipeline = pipelines[0]\n",
-        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-        "        print(\"Deleted pipeline:\", pipeline)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-        "    ! gsutil rm -r $BUCKET_NAME"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "google_cloud_pipeline_components_automl_tabular.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title:generic"
+   },
+   "source": [
+    "# Vertex AI Pipelines: AutoML tabular regression pipelines using google-cloud-pipeline-components\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:pipelines,automl"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML tabular regression workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:cal_housing,lrg"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial is the [California Housing dataset from the 1990 Census](https://developers.google.com/machine-learning/crash-course/california-housing-data-description)\n",
+    "\n",
+    "The dataset predicts the median house price."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:pipelines,automl"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an AutoML tabular regression using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Create a `Dataset` resource.\n",
+    "- Train an AutoML `Model` resource.\n",
+    "- Creates an `Endpoint` resource.\n",
+    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+    "\n",
+    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+    "\n",
+    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+    "\n",
+    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex AI SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_storage"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-storage* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_storage"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install -U google-cloud-storage $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "check_versions"
+   },
+   "source": [
+    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "check_versions:kfp,gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "#### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = !gcloud auth list 2>/dev/null\n",
+    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "source": [
+    "#### Set service account access for Vertex AI Pipelines\n",
+    "\n",
+    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+    "\n",
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "source": [
+    "#### Vertex AI constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI:\n",
+    "\n",
+    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "outputs": [],
+   "source": [
+    "# API service endpoint\n",
+    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "source": [
+    "#### Vertex AI Pipelines constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI Pipelines:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "outputs": [],
+   "source": [
+    "PIPELINE_ROOT = \"{}/pipeline_root/cal_housing\".format(BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "additional_imports"
+   },
+   "source": [
+    "Additional imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_pipelines:gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "import kfp\n",
+    "from google_cloud_pipeline_components import aiplatform as gcc_aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
+   },
+   "source": [
+    "## Define AutoML tabular regression model pipeline that uses components from `google_cloud_pipeline_components`\n",
+    "\n",
+    "Next, you define the pipeline.\n",
+    "\n",
+    "Create and deploy an AutoML tabular regression `Model` resource using a `Dataset` resource."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_pipeline:gcpc,automl,cal_housing,lrg"
+   },
+   "outputs": [],
+   "source": [
+    "TRAIN_FILE_NAME = \"california_housing_train.csv\"\n",
+    "! gsutil cp gs://aju-dev-demos-codelabs/sample_data/california_housing_train.csv {PIPELINE_ROOT}/data/\n",
+    "\n",
+    "gcs_csv_path = f\"{PIPELINE_ROOT}/data/{TRAIN_FILE_NAME}\"\n",
+    "\n",
+    "\n",
+    "@kfp.dsl.pipeline(name=\"automl-tab-training-v2\")\n",
+    "def pipeline(project: str = PROJECT_ID, region: str = REGION):\n",
+    "\n",
+    "    dataset_create_op = gcc_aip.TabularDatasetCreateOp(\n",
+    "        project=project, display_name=\"housing\", gcs_source=gcs_csv_path\n",
+    "    )\n",
+    "\n",
+    "    training_op = gcc_aip.AutoMLTabularTrainingJobRunOp(\n",
+    "        project=project,\n",
+    "        display_name=\"train-automl-cal_housing\",\n",
+    "        optimization_prediction_type=\"regression\",\n",
+    "        optimization_objective=\"minimize-rmse\",\n",
+    "        column_transformations=[\n",
+    "            {\"numeric\": {\"column_name\": \"longitude\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"latitude\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"housing_median_age\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"total_rooms\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"total_bedrooms\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"population\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"households\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"median_income\"}},\n",
+    "            {\"numeric\": {\"column_name\": \"median_house_value\"}},\n",
+    "        ],\n",
+    "        dataset=dataset_create_op.outputs[\"dataset\"],\n",
+    "        target_column=\"median_house_value\",\n",
+    "    )\n",
+    "\n",
+    "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
+    "        project=project,\n",
+    "        location=region,\n",
+    "        display_name=\"train-automl-flowers\",\n",
+    "    )\n",
+    "\n",
+    "    gcc_aip.ModelDeployOp(\n",
+    "        model=training_op.outputs[\"model\"],\n",
+    "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+    "        dedicated_resources_machine_type=\"n1-standard-4\",\n",
+    "        dedicated_resources_min_replica_count=1,\n",
+    "        dedicated_resources_max_replica_count=1,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "source": [
+    "## Compile the pipeline\n",
+    "\n",
+    "Next, compile the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "outputs": [],
+   "source": [
+    "from kfp.v2 import compiler  # noqa: F811\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=pipeline,\n",
+    "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_pipeline:automl,tabular"
+   },
+   "source": [
+    "## Run the pipeline\n",
+    "\n",
+    "Next, run the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "run_pipeline:automl,tabular"
+   },
+   "outputs": [],
+   "source": [
+    "DISPLAY_NAME = \"cal_housing_\" + TIMESTAMP\n",
+    "\n",
+    "job = aip.PipelineJob(\n",
+    "    display_name=DISPLAY_NAME,\n",
+    "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+    "    pipeline_root=PIPELINE_ROOT,\n",
+    "    enable_caching=False\n",
+    ")\n",
+    "\n",
+    "job.run()\n",
+    "\n",
+    "! rm tabular_regression_pipeline.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view_pipeline_run:automl,tabular"
+   },
+   "source": [
+    "Click on the generated link to see your run in the Cloud Console.\n",
+    "\n",
+    "<!-- It should look something like this as it is running:\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+    "\n",
+    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- Pipeline\n",
+    "- Model\n",
+    "- Endpoint\n",
+    "- Batch Job\n",
+    "- Custom Job\n",
+    "- Hyperparameter Tuning Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "delete_dataset = True\n",
+    "delete_pipeline = True\n",
+    "delete_model = True\n",
+    "delete_endpoint = True\n",
+    "delete_batchjob = True\n",
+    "delete_customjob = True\n",
+    "delete_hptjob = True\n",
+    "delete_bucket = True\n",
+    "\n",
+    "try:\n",
+    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+    "        models = aip.Model.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        model = models[0]\n",
+    "        aip.Model.delete(model)\n",
+    "        print(\"Deleted model:\", model)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+    "        endpoints = aip.Endpoint.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        endpoint = endpoints[0]\n",
+    "        endpoint.undeploy_all()\n",
+    "        aip.Endpoint.delete(endpoint.resource_name)\n",
+    "        print(\"Deleted endpoint:\", endpoint)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+    "    if \"tabular\" == \"tabular\":\n",
+    "        try:\n",
+    "            datasets = aip.TabularDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TabularDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"image\":\n",
+    "        try:\n",
+    "            datasets = aip.ImageDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.ImageDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"text\":\n",
+    "        try:\n",
+    "            datasets = aip.TextDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TextDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"video\":\n",
+    "        try:\n",
+    "            datasets = aip.VideoDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.VideoDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+    "        pipelines = aip.PipelineJob.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        pipeline = pipelines[0]\n",
+    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+    "        print(\"Deleted pipeline:\", pipeline)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+    "    ! gsutil rm -r $BUCKET_NAME"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "google_cloud_pipeline_components_automl_tabular.ipynb",
+   "toc_visible": true
+  },
+  "environment": {
+   "name": "common-cu110.m71",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb
@@ -1,979 +1,998 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title:generic"
-      },
-      "source": [
-        "# Vertex AI Pipelines: AutoML text classification pipelines using google-cloud-pipeline-components\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:pipelines,automl"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML text classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:happydb,tcn"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial is the [Happy Moments dataset](https://www.kaggle.com/ritresearch/happydb) from [Kaggle Datasets](https://www.kaggle.com/ritresearch/happydb). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:pipelines,automl"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an AutoML text classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Create a `Dataset` resource.\n",
-        "- Train an AutoML `Model` resource.\n",
-        "- Creates an `Endpoint` resource.\n",
-        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-        "\n",
-        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-        "\n",
-        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-        "\n",
-        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex AI SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_storage"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-storage* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_storage"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install -U google-cloud-storage $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "check_versions"
-      },
-      "source": [
-        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "check_versions:kfp,gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "source": [
-        "#### Service Account\n",
-        "\n",
-        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "if (\n",
-        "    SERVICE_ACCOUNT == \"\"\n",
-        "    or SERVICE_ACCOUNT is None\n",
-        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-        "):\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = !gcloud auth list 2>/dev/null\n",
-        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "source": [
-        "#### Set service account access for Vertex AI Pipelines\n",
-        "\n",
-        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-        "\n",
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "source": [
-        "#### Vertex AI constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI:\n",
-        "\n",
-        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aip_constants:endpoint"
-      },
-      "outputs": [],
-      "source": [
-        "# API service endpoint\n",
-        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "source": [
-        "#### Vertex AI Pipelines constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI Pipelines:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "outputs": [],
-      "source": [
-        "PIPELINE_ROOT = \"{}/pipeline_root/happydb\".format(BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "additional_imports"
-      },
-      "source": [
-        "Additional imports."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_pipelines:gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "import kfp\n",
-        "from google_cloud_pipeline_components import aiplatform as gcc_aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex AI SDK for Python\n",
-        "\n",
-        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_pipeline:gcpc,automl,happydb,tcn"
-      },
-      "source": [
-        "## Define AutoML text classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
-        "\n",
-        "Next, you define the pipeline.\n",
-        "\n",
-        "Create and deploy an AutoML text classification `Model` resource using a `Dataset` resource."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_pipeline:gcpc,automl,happydb,tcn"
-      },
-      "outputs": [],
-      "source": [
-        "IMPORT_FILE = \"gs://cloud-ml-data/NL-classification/happiness.csv\"\n",
-        "\n",
-        "\n",
-        "@kfp.dsl.pipeline(name=\"automl-text-classification\" + TIMESTAMP)\n",
-        "def pipeline(\n",
-        "    project: str = PROJECT_ID, region: str = REGION, import_file: str = IMPORT_FILE\n",
-        "):\n",
-        "\n",
-        "    dataset_create_task = gcc_aip.TextDatasetCreateOp(\n",
-        "        display_name=\"train-automl-happydb\",\n",
-        "        gcs_source=import_file,\n",
-        "        import_schema_uri=aip.schema.dataset.ioformat.text.multi_label_classification,\n",
-        "        project=project,\n",
-        "    )\n",
-        "\n",
-        "    training_run_task = gcc_aip.AutoMLTextTrainingJobRunOp(\n",
-        "        dataset=dataset_create_task.outputs[\"dataset\"],\n",
-        "        display_name=\"train-automl-happydb\",\n",
-        "        prediction_type=\"classification\",\n",
-        "        multi_label=True,\n",
-        "        training_fraction_split=0.6,\n",
-        "        validation_fraction_split=0.2,\n",
-        "        test_fraction_split=0.2,\n",
-        "        model_display_name=\"train-automl-happydb\",\n",
-        "        project=project,\n",
-        "    )\n",
-        "\n",
-        "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
-        "        project=project,\n",
-        "        location=region,\n",
-        "        display_name=\"train-automl-flowers\",\n",
-        "    )\n",
-        "\n",
-        "    gcc_aip.ModelDeployOp(\n",
-        "        model=training_run_task.outputs[\"model\"],\n",
-        "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-        "        automatic_resources_min_replica_count=1,\n",
-        "        automatic_resources_max_replica_count=1,\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "source": [
-        "## Compile the pipeline\n",
-        "\n",
-        "Next, compile the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "outputs": [],
-      "source": [
-        "from kfp.v2 import compiler  # noqa: F811\n",
-        "\n",
-        "compiler.Compiler().compile(\n",
-        "    pipeline_func=pipeline,\n",
-        "    package_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_pipeline:automl,text"
-      },
-      "source": [
-        "## Run the pipeline\n",
-        "\n",
-        "Next, run the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_pipeline:automl,text"
-      },
-      "outputs": [],
-      "source": [
-        "DISPLAY_NAME = \"happydb_\" + TIMESTAMP\n",
-        "\n",
-        "job = aip.PipelineJob(\n",
-        "    display_name=DISPLAY_NAME,\n",
-        "    template_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
-        "    pipeline_root=PIPELINE_ROOT,\n",
-        ")\n",
-        "\n",
-        "job.run()\n",
-        "\n",
-        "! rm text_classification_pipeline.json"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view_pipeline_run:automl,text"
-      },
-      "source": [
-        "Click on the generated link to see your run in the Cloud Console.\n",
-        "\n",
-        "<!-- It should look something like this as it is running:\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-        "\n",
-        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" width=\"40%\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- Pipeline\n",
-        "- Model\n",
-        "- Endpoint\n",
-        "- Batch Job\n",
-        "- Custom Job\n",
-        "- Hyperparameter Tuning Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "delete_dataset = True\n",
-        "delete_pipeline = True\n",
-        "delete_model = True\n",
-        "delete_endpoint = True\n",
-        "delete_batchjob = True\n",
-        "delete_customjob = True\n",
-        "delete_hptjob = True\n",
-        "delete_bucket = True\n",
-        "\n",
-        "try:\n",
-        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-        "        models = aip.Model.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        model = models[0]\n",
-        "        aip.Model.delete(model)\n",
-        "        print(\"Deleted model:\", model)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-        "        endpoints = aip.Endpoint.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        endpoint = endpoints[0]\n",
-        "        endpoint.undeploy_all()\n",
-        "        aip.Endpoint.delete(endpoint.resource_name)\n",
-        "        print(\"Deleted endpoint:\", endpoint)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-        "    if \"text\" == \"tabular\":\n",
-        "        try:\n",
-        "            datasets = aip.TabularDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TabularDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"text\" == \"image\":\n",
-        "        try:\n",
-        "            datasets = aip.ImageDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.ImageDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"text\" == \"text\":\n",
-        "        try:\n",
-        "            datasets = aip.TextDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TextDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"text\" == \"video\":\n",
-        "        try:\n",
-        "            datasets = aip.VideoDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.VideoDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-        "        pipelines = aip.PipelineJob.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        pipeline = pipelines[0]\n",
-        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-        "        print(\"Deleted pipeline:\", pipeline)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-        "    ! gsutil rm -r $BUCKET_NAME"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "google_cloud_pipeline_components_automl_text.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title:generic"
+   },
+   "source": [
+    "# Vertex AI Pipelines: AutoML text classification pipelines using google-cloud-pipeline-components\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:pipelines,automl"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML text classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:happydb,tcn"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial is the [Happy Moments dataset](https://www.kaggle.com/ritresearch/happydb) from [Kaggle Datasets](https://www.kaggle.com/ritresearch/happydb). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:pipelines,automl"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an AutoML text classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Create a `Dataset` resource.\n",
+    "- Train an AutoML `Model` resource.\n",
+    "- Creates an `Endpoint` resource.\n",
+    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+    "\n",
+    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+    "\n",
+    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+    "\n",
+    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex AI SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_storage"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-storage* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_storage"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install -U google-cloud-storage $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "check_versions"
+   },
+   "source": [
+    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "check_versions:kfp,gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "#### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = !gcloud auth list 2>/dev/null\n",
+    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "source": [
+    "#### Set service account access for Vertex AI Pipelines\n",
+    "\n",
+    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+    "\n",
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "source": [
+    "#### Vertex AI constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI:\n",
+    "\n",
+    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aip_constants:endpoint"
+   },
+   "outputs": [],
+   "source": [
+    "# API service endpoint\n",
+    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "source": [
+    "#### Vertex AI Pipelines constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI Pipelines:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "outputs": [],
+   "source": [
+    "PIPELINE_ROOT = \"{}/pipeline_root/happydb\".format(BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "additional_imports"
+   },
+   "source": [
+    "Additional imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_pipelines:gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "import kfp\n",
+    "from google_cloud_pipeline_components import aiplatform as gcc_aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_pipeline:gcpc,automl,happydb,tcn"
+   },
+   "source": [
+    "## Define AutoML text classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
+    "\n",
+    "Next, you define the pipeline.\n",
+    "\n",
+    "Create and deploy an AutoML text classification `Model` resource using a `Dataset` resource."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_pipeline:gcpc,automl,happydb,tcn"
+   },
+   "outputs": [],
+   "source": [
+    "IMPORT_FILE = \"gs://cloud-ml-data/NL-classification/happiness.csv\"\n",
+    "\n",
+    "\n",
+    "@kfp.dsl.pipeline(name=\"automl-text-classification\" + TIMESTAMP)\n",
+    "def pipeline(\n",
+    "    project: str = PROJECT_ID, region: str = REGION, import_file: str = IMPORT_FILE\n",
+    "):\n",
+    "\n",
+    "    dataset_create_task = gcc_aip.TextDatasetCreateOp(\n",
+    "        display_name=\"train-automl-happydb\",\n",
+    "        gcs_source=import_file,\n",
+    "        import_schema_uri=aip.schema.dataset.ioformat.text.multi_label_classification,\n",
+    "        project=project,\n",
+    "    )\n",
+    "\n",
+    "    training_run_task = gcc_aip.AutoMLTextTrainingJobRunOp(\n",
+    "        dataset=dataset_create_task.outputs[\"dataset\"],\n",
+    "        display_name=\"train-automl-happydb\",\n",
+    "        prediction_type=\"classification\",\n",
+    "        multi_label=True,\n",
+    "        training_fraction_split=0.6,\n",
+    "        validation_fraction_split=0.2,\n",
+    "        test_fraction_split=0.2,\n",
+    "        model_display_name=\"train-automl-happydb\",\n",
+    "        project=project,\n",
+    "    )\n",
+    "\n",
+    "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
+    "        project=project,\n",
+    "        location=region,\n",
+    "        display_name=\"train-automl-flowers\",\n",
+    "    )\n",
+    "\n",
+    "    gcc_aip.ModelDeployOp(\n",
+    "        model=training_run_task.outputs[\"model\"],\n",
+    "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+    "        automatic_resources_min_replica_count=1,\n",
+    "        automatic_resources_max_replica_count=1,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "source": [
+    "## Compile the pipeline\n",
+    "\n",
+    "Next, compile the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "outputs": [],
+   "source": [
+    "from kfp.v2 import compiler  # noqa: F811\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=pipeline,\n",
+    "    package_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_pipeline:automl,text"
+   },
+   "source": [
+    "## Run the pipeline\n",
+    "\n",
+    "Next, run the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "run_pipeline:automl,text"
+   },
+   "outputs": [],
+   "source": [
+    "DISPLAY_NAME = \"happydb_\" + TIMESTAMP\n",
+    "\n",
+    "job = aip.PipelineJob(\n",
+    "    display_name=DISPLAY_NAME,\n",
+    "    template_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
+    "    pipeline_root=PIPELINE_ROOT,\n",
+    "    enable_caching=False\n",
+    ")\n",
+    "\n",
+    "job.run()\n",
+    "\n",
+    "! rm text_classification_pipeline.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view_pipeline_run:automl,text"
+   },
+   "source": [
+    "Click on the generated link to see your run in the Cloud Console.\n",
+    "\n",
+    "<!-- It should look something like this as it is running:\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+    "\n",
+    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" width=\"40%\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- Pipeline\n",
+    "- Model\n",
+    "- Endpoint\n",
+    "- Batch Job\n",
+    "- Custom Job\n",
+    "- Hyperparameter Tuning Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "delete_dataset = True\n",
+    "delete_pipeline = True\n",
+    "delete_model = True\n",
+    "delete_endpoint = True\n",
+    "delete_batchjob = True\n",
+    "delete_customjob = True\n",
+    "delete_hptjob = True\n",
+    "delete_bucket = True\n",
+    "\n",
+    "try:\n",
+    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+    "        models = aip.Model.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        model = models[0]\n",
+    "        aip.Model.delete(model)\n",
+    "        print(\"Deleted model:\", model)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+    "        endpoints = aip.Endpoint.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        endpoint = endpoints[0]\n",
+    "        endpoint.undeploy_all()\n",
+    "        aip.Endpoint.delete(endpoint.resource_name)\n",
+    "        print(\"Deleted endpoint:\", endpoint)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+    "    if \"text\" == \"tabular\":\n",
+    "        try:\n",
+    "            datasets = aip.TabularDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TabularDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"text\" == \"image\":\n",
+    "        try:\n",
+    "            datasets = aip.ImageDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.ImageDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"text\" == \"text\":\n",
+    "        try:\n",
+    "            datasets = aip.TextDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TextDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"text\" == \"video\":\n",
+    "        try:\n",
+    "            datasets = aip.VideoDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.VideoDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+    "        pipelines = aip.PipelineJob.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        pipeline = pipelines[0]\n",
+    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+    "        print(\"Deleted pipeline:\", pipeline)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+    "    ! gsutil rm -r $BUCKET_NAME"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "google_cloud_pipeline_components_automl_text.ipynb",
+   "toc_visible": true
+  },
+  "environment": {
+   "name": "common-cu110.m71",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb
@@ -1,998 +1,980 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title:generic"
+      },
+      "source": [
+        "# Vertex AI Pipelines: AutoML text classification pipelines using google-cloud-pipeline-components\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:pipelines,automl"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML text classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:happydb,tcn"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial is the [Happy Moments dataset](https://www.kaggle.com/ritresearch/happydb) from [Kaggle Datasets](https://www.kaggle.com/ritresearch/happydb). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:pipelines,automl"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an AutoML text classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Create a `Dataset` resource.\n",
+        "- Train an AutoML `Model` resource.\n",
+        "- Creates an `Endpoint` resource.\n",
+        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+        "\n",
+        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+        "\n",
+        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+        "\n",
+        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex AI SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_storage"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-storage* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_storage"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install -U google-cloud-storage $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "check_versions"
+      },
+      "source": [
+        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "check_versions:kfp,gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "#### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = !gcloud auth list 2>/dev/null\n",
+        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "source": [
+        "#### Set service account access for Vertex AI Pipelines\n",
+        "\n",
+        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+        "\n",
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "source": [
+        "#### Vertex AI constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI:\n",
+        "\n",
+        "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aip_constants:endpoint"
+      },
+      "outputs": [],
+      "source": [
+        "# API service endpoint\n",
+        "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "source": [
+        "#### Vertex AI Pipelines constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI Pipelines:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "outputs": [],
+      "source": [
+        "PIPELINE_ROOT = \"{}/pipeline_root/happydb\".format(BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "additional_imports"
+      },
+      "source": [
+        "Additional imports."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_pipelines:gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "import kfp\n",
+        "from google_cloud_pipeline_components import aiplatform as gcc_aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_pipeline:gcpc,automl,happydb,tcn"
+      },
+      "source": [
+        "## Define AutoML text classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
+        "\n",
+        "Next, you define the pipeline.\n",
+        "\n",
+        "Create and deploy an AutoML text classification `Model` resource using a `Dataset` resource."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_pipeline:gcpc,automl,happydb,tcn"
+      },
+      "outputs": [],
+      "source": [
+        "IMPORT_FILE = \"gs://cloud-ml-data/NL-classification/happiness.csv\"\n",
+        "\n",
+        "\n",
+        "@kfp.dsl.pipeline(name=\"automl-text-classification\" + TIMESTAMP)\n",
+        "def pipeline(\n",
+        "    project: str = PROJECT_ID, region: str = REGION, import_file: str = IMPORT_FILE\n",
+        "):\n",
+        "\n",
+        "    dataset_create_task = gcc_aip.TextDatasetCreateOp(\n",
+        "        display_name=\"train-automl-happydb\",\n",
+        "        gcs_source=import_file,\n",
+        "        import_schema_uri=aip.schema.dataset.ioformat.text.multi_label_classification,\n",
+        "        project=project,\n",
+        "    )\n",
+        "\n",
+        "    training_run_task = gcc_aip.AutoMLTextTrainingJobRunOp(\n",
+        "        dataset=dataset_create_task.outputs[\"dataset\"],\n",
+        "        display_name=\"train-automl-happydb\",\n",
+        "        prediction_type=\"classification\",\n",
+        "        multi_label=True,\n",
+        "        training_fraction_split=0.6,\n",
+        "        validation_fraction_split=0.2,\n",
+        "        test_fraction_split=0.2,\n",
+        "        model_display_name=\"train-automl-happydb\",\n",
+        "        project=project,\n",
+        "    )\n",
+        "\n",
+        "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
+        "        project=project,\n",
+        "        location=region,\n",
+        "        display_name=\"train-automl-flowers\",\n",
+        "    )\n",
+        "\n",
+        "    gcc_aip.ModelDeployOp(\n",
+        "        model=training_run_task.outputs[\"model\"],\n",
+        "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
+        "        automatic_resources_min_replica_count=1,\n",
+        "        automatic_resources_max_replica_count=1,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "source": [
+        "## Compile the pipeline\n",
+        "\n",
+        "Next, compile the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "outputs": [],
+      "source": [
+        "from kfp.v2 import compiler  # noqa: F811\n",
+        "\n",
+        "compiler.Compiler().compile(\n",
+        "    pipeline_func=pipeline,\n",
+        "    package_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_pipeline:automl,text"
+      },
+      "source": [
+        "## Run the pipeline\n",
+        "\n",
+        "Next, run the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_pipeline:automl,text"
+      },
+      "outputs": [],
+      "source": [
+        "DISPLAY_NAME = \"happydb_\" + TIMESTAMP\n",
+        "\n",
+        "job = aip.PipelineJob(\n",
+        "    display_name=DISPLAY_NAME,\n",
+        "    template_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
+        "    pipeline_root=PIPELINE_ROOT,\n",
+        "    enable_caching=False,\n",
+        ")\n",
+        "\n",
+        "job.run()\n",
+        "\n",
+        "! rm text_classification_pipeline.json"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view_pipeline_run:automl,text"
+      },
+      "source": [
+        "Click on the generated link to see your run in the Cloud Console.\n",
+        "\n",
+        "<!-- It should look something like this as it is running:\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+        "\n",
+        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" width=\"40%\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- Pipeline\n",
+        "- Model\n",
+        "- Endpoint\n",
+        "- Batch Job\n",
+        "- Custom Job\n",
+        "- Hyperparameter Tuning Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "delete_dataset = True\n",
+        "delete_pipeline = True\n",
+        "delete_model = True\n",
+        "delete_endpoint = True\n",
+        "delete_batchjob = True\n",
+        "delete_customjob = True\n",
+        "delete_hptjob = True\n",
+        "delete_bucket = True\n",
+        "\n",
+        "try:\n",
+        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+        "        models = aip.Model.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        model = models[0]\n",
+        "        aip.Model.delete(model)\n",
+        "        print(\"Deleted model:\", model)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+        "        endpoints = aip.Endpoint.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        endpoint = endpoints[0]\n",
+        "        endpoint.undeploy_all()\n",
+        "        aip.Endpoint.delete(endpoint.resource_name)\n",
+        "        print(\"Deleted endpoint:\", endpoint)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+        "    if \"text\" == \"tabular\":\n",
+        "        try:\n",
+        "            datasets = aip.TabularDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TabularDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"text\" == \"image\":\n",
+        "        try:\n",
+        "            datasets = aip.ImageDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.ImageDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"text\" == \"text\":\n",
+        "        try:\n",
+        "            datasets = aip.TextDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TextDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"text\" == \"video\":\n",
+        "        try:\n",
+        "            datasets = aip.VideoDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.VideoDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+        "        pipelines = aip.PipelineJob.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        pipeline = pipelines[0]\n",
+        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+        "        print(\"Deleted pipeline:\", pipeline)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+        "    ! gsutil rm -r $BUCKET_NAME"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "google_cloud_pipeline_components_automl_text.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title:generic"
-   },
-   "source": [
-    "# Vertex AI Pipelines: AutoML text classification pipelines using google-cloud-pipeline-components\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:pipelines,automl"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) to build an AutoML text classification workflow on [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:happydb,tcn"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial is the [Happy Moments dataset](https://www.kaggle.com/ritresearch/happydb) from [Kaggle Datasets](https://www.kaggle.com/ritresearch/happydb). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:pipelines,automl"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an AutoML text classification using a pipeline with components from  `google_cloud_pipeline_components`.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Create a `Dataset` resource.\n",
-    "- Train an AutoML `Model` resource.\n",
-    "- Creates an `Endpoint` resource.\n",
-    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-    "\n",
-    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-    "\n",
-    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-    "\n",
-    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex AI SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_storage"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-storage* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_storage"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install -U google-cloud-storage $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "check_versions"
-   },
-   "source": [
-    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "check_versions:kfp,gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "#### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = !gcloud auth list 2>/dev/null\n",
-    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "source": [
-    "#### Set service account access for Vertex AI Pipelines\n",
-    "\n",
-    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-    "\n",
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "source": [
-    "#### Vertex AI constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI:\n",
-    "\n",
-    "- `API_ENDPOINT`: The Vertex AI API service endpoint for `Dataset`, `Model`, `Job`, `Pipeline` and `Endpoint` services."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "aip_constants:endpoint"
-   },
-   "outputs": [],
-   "source": [
-    "# API service endpoint\n",
-    "API_ENDPOINT = \"{}-aiplatform.googleapis.com\".format(REGION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "source": [
-    "#### Vertex AI Pipelines constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI Pipelines:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "outputs": [],
-   "source": [
-    "PIPELINE_ROOT = \"{}/pipeline_root/happydb\".format(BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "additional_imports"
-   },
-   "source": [
-    "Additional imports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_pipelines:gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "import kfp\n",
-    "from google_cloud_pipeline_components import aiplatform as gcc_aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_pipeline:gcpc,automl,happydb,tcn"
-   },
-   "source": [
-    "## Define AutoML text classification model pipeline that uses components from `google_cloud_pipeline_components`\n",
-    "\n",
-    "Next, you define the pipeline.\n",
-    "\n",
-    "Create and deploy an AutoML text classification `Model` resource using a `Dataset` resource."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_pipeline:gcpc,automl,happydb,tcn"
-   },
-   "outputs": [],
-   "source": [
-    "IMPORT_FILE = \"gs://cloud-ml-data/NL-classification/happiness.csv\"\n",
-    "\n",
-    "\n",
-    "@kfp.dsl.pipeline(name=\"automl-text-classification\" + TIMESTAMP)\n",
-    "def pipeline(\n",
-    "    project: str = PROJECT_ID, region: str = REGION, import_file: str = IMPORT_FILE\n",
-    "):\n",
-    "\n",
-    "    dataset_create_task = gcc_aip.TextDatasetCreateOp(\n",
-    "        display_name=\"train-automl-happydb\",\n",
-    "        gcs_source=import_file,\n",
-    "        import_schema_uri=aip.schema.dataset.ioformat.text.multi_label_classification,\n",
-    "        project=project,\n",
-    "    )\n",
-    "\n",
-    "    training_run_task = gcc_aip.AutoMLTextTrainingJobRunOp(\n",
-    "        dataset=dataset_create_task.outputs[\"dataset\"],\n",
-    "        display_name=\"train-automl-happydb\",\n",
-    "        prediction_type=\"classification\",\n",
-    "        multi_label=True,\n",
-    "        training_fraction_split=0.6,\n",
-    "        validation_fraction_split=0.2,\n",
-    "        test_fraction_split=0.2,\n",
-    "        model_display_name=\"train-automl-happydb\",\n",
-    "        project=project,\n",
-    "    )\n",
-    "\n",
-    "    endpoint_op = gcc_aip.EndpointCreateOp(\n",
-    "        project=project,\n",
-    "        location=region,\n",
-    "        display_name=\"train-automl-flowers\",\n",
-    "    )\n",
-    "\n",
-    "    gcc_aip.ModelDeployOp(\n",
-    "        model=training_run_task.outputs[\"model\"],\n",
-    "        endpoint=endpoint_op.outputs[\"endpoint\"],\n",
-    "        automatic_resources_min_replica_count=1,\n",
-    "        automatic_resources_max_replica_count=1,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "source": [
-    "## Compile the pipeline\n",
-    "\n",
-    "Next, compile the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "outputs": [],
-   "source": [
-    "from kfp.v2 import compiler  # noqa: F811\n",
-    "\n",
-    "compiler.Compiler().compile(\n",
-    "    pipeline_func=pipeline,\n",
-    "    package_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_pipeline:automl,text"
-   },
-   "source": [
-    "## Run the pipeline\n",
-    "\n",
-    "Next, run the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run_pipeline:automl,text"
-   },
-   "outputs": [],
-   "source": [
-    "DISPLAY_NAME = \"happydb_\" + TIMESTAMP\n",
-    "\n",
-    "job = aip.PipelineJob(\n",
-    "    display_name=DISPLAY_NAME,\n",
-    "    template_path=\"text classification_pipeline.json\".replace(\" \", \"_\"),\n",
-    "    pipeline_root=PIPELINE_ROOT,\n",
-    "    enable_caching=False\n",
-    ")\n",
-    "\n",
-    "job.run()\n",
-    "\n",
-    "! rm text_classification_pipeline.json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "view_pipeline_run:automl,text"
-   },
-   "source": [
-    "Click on the generated link to see your run in the Cloud Console.\n",
-    "\n",
-    "<!-- It should look something like this as it is running:\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-    "\n",
-    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_text_classif.png\" width=\"40%\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- Pipeline\n",
-    "- Model\n",
-    "- Endpoint\n",
-    "- Batch Job\n",
-    "- Custom Job\n",
-    "- Hyperparameter Tuning Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "delete_dataset = True\n",
-    "delete_pipeline = True\n",
-    "delete_model = True\n",
-    "delete_endpoint = True\n",
-    "delete_batchjob = True\n",
-    "delete_customjob = True\n",
-    "delete_hptjob = True\n",
-    "delete_bucket = True\n",
-    "\n",
-    "try:\n",
-    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-    "        models = aip.Model.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        model = models[0]\n",
-    "        aip.Model.delete(model)\n",
-    "        print(\"Deleted model:\", model)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-    "        endpoints = aip.Endpoint.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        endpoint = endpoints[0]\n",
-    "        endpoint.undeploy_all()\n",
-    "        aip.Endpoint.delete(endpoint.resource_name)\n",
-    "        print(\"Deleted endpoint:\", endpoint)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-    "    if \"text\" == \"tabular\":\n",
-    "        try:\n",
-    "            datasets = aip.TabularDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TabularDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"text\" == \"image\":\n",
-    "        try:\n",
-    "            datasets = aip.ImageDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.ImageDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"text\" == \"text\":\n",
-    "        try:\n",
-    "            datasets = aip.TextDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TextDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"text\" == \"video\":\n",
-    "        try:\n",
-    "            datasets = aip.VideoDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.VideoDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-    "        pipelines = aip.PipelineJob.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        pipeline = pipelines[0]\n",
-    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-    "        print(\"Deleted pipeline:\", pipeline)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-    "    ! gsutil rm -r $BUCKET_NAME"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "google_cloud_pipeline_components_automl_text.ipynb",
-   "toc_visible": true
-  },
-  "environment": {
-   "name": "common-cu110.m71",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
@@ -1,1031 +1,1013 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "copyright"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2021 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "copyright"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2021 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "title:generic"
+      },
+      "source": [
+        "# Vertex AI Pipelines:  model train, upload, and deploy using google-cloud-pipeline-components\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>\n",
+        "<br/><br/><br/>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "overview:pipelines,custom"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) in conjunction with an experimental `run_as_aiplatform_custom_job` method, to build a [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines) workflow that trains a [custom model](https://cloud.google.com/vertex-ai/docs/training/containers-overview), uploads the model as a `Model` resource, creates an `Endpoint` resource, and deploys the `Model` resource to the `Endpoint` resource."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dataset:bikes_weather,lrg"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for this tutorial is [Cloud Public Dataset Program](https://cloud.google.com/bigquery/public-data/) [London Bikes Rental](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=london_bicycles&page=dataset&_ga=2.122237643.-1779725180.1624895157) combined with [NOAA weather data ](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=noaa_gsod&page=dataset&_ga=2.179861860.-1779725180.1624895157)\n",
+        "\n",
+        "The dataset predicts the duration of the bike rental."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "objective:pipelines,custom"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you create an custom model using a pipeline with components from `google_cloud_pipeline_components` and a custom pipeline component you build.\n",
+        "\n",
+        "In addition, you'll use the `kfp.v2.google.experimental.run_as_aiplatform_custom_job` method to train a custom model.\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Train a custom model.\n",
+        "- Uploads the trained model as a `Model` resource.\n",
+        "- Creates an `Endpoint` resource.\n",
+        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+        "\n",
+        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform).\n",
+        "(From that page, see also the `CustomPythonPackageTrainingJobRunOp` and `CustomContainerTrainingJobRunOp` components, which similarly run 'custom' training, but as with the related `google.cloud.aiplatform.CustomContainerTrainingJob` and `google.cloud.aiplatform.CustomPythonPackageTrainingJob` methods from the [Vertex AI SDK](https://googleapis.dev/python/aiplatform/latest/aiplatform.html), also upload the trained model)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "costs"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_local"
+      },
+      "source": [
+        "### Set up your local development environment\n",
+        "\n",
+        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+        "\n",
+        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+        "\n",
+        "- The Cloud Storage SDK\n",
+        "- Git\n",
+        "- Python 3\n",
+        "- virtualenv\n",
+        "- Jupyter notebook running in a virtual environment with Python 3\n",
+        "\n",
+        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+        "\n",
+        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+        "\n",
+        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+        "\n",
+        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+        "\n",
+        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+        "\n",
+        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+        "\n",
+        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the latest version of Vertex SDK for Python."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "# Google Cloud Notebook\n",
+        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    USER_FLAG = \"--user\"\n",
+        "else:\n",
+        "    USER_FLAG = \"\"\n",
+        "\n",
+        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_storage"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-storage* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_storage"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install -U google-cloud-storage $USER_FLAG"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "source": [
+        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "install_gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "restart"
+      },
+      "source": [
+        "### Restart the kernel\n",
+        "\n",
+        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "restart"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "check_versions"
+      },
+      "source": [
+        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "check_versions:kfp,gcpc"
+      },
+      "outputs": [],
+      "source": [
+        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "before_you_begin:nogpu"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### GPU runtime\n",
+        "\n",
+        "This tutorial does not require a GPU runtime.\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+        "\n",
+        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+        "\n",
+        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+        "\n",
+        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+        "    PROJECT_ID = shell_output[0]\n",
+        "    print(\"Project ID:\", PROJECT_ID)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_gcloud_project_id"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud config set project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable, which is used for operations\n",
+        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+        "\n",
+        "- Americas: `us-central1`\n",
+        "- Europe: `europe-west4`\n",
+        "- Asia Pacific: `asia-east1`\n",
+        "\n",
+        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+        "\n",
+        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "region"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "timestamp"
+      },
+      "source": [
+        "#### Timestamp\n",
+        "\n",
+        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "timestamp"
+      },
+      "outputs": [],
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+        "\n",
+        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+        "\n",
+        "**Otherwise**, follow these steps:\n",
+        "\n",
+        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+        "\n",
+        "**Click Create service account**.\n",
+        "\n",
+        "In the **Service account name** field, enter a name, and click **Create**.\n",
+        "\n",
+        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+        "\n",
+        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+        "\n",
+        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gcp_authenticate"
+      },
+      "outputs": [],
+      "source": [
+        "# If you are running this notebook in Colab, run this cell and follow the\n",
+        "# instructions to authenticate your GCP account. This provides access to your\n",
+        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+        "# requests.\n",
+        "\n",
+        "import os\n",
+        "import sys\n",
+        "\n",
+        "# If on Google Cloud Notebook, then don't execute this code\n",
+        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+        "    if \"google.colab\" in sys.modules:\n",
+        "        from google.colab import auth as google_auth\n",
+        "\n",
+        "        google_auth.authenticate_user()\n",
+        "\n",
+        "    # If you are running this notebook locally, replace the string below with the\n",
+        "    # path to your service account key and run this cell to authenticate your GCP\n",
+        "    # account.\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
+        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bucket:mbsdk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+        "\n",
+        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bucket"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "create_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "source": [
+        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "validate_bucket"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil ls -al $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "#### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your GCP project id from gcloud\n",
+        "    shell_output = !gcloud auth list 2>/dev/null\n",
+        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "source": [
+        "#### Set service account access for Vertex AI Pipelines\n",
+        "\n",
+        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "set_service_account:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+        "\n",
+        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "setup_vars"
+      },
+      "source": [
+        "### Set up variables\n",
+        "\n",
+        "Next, set up some variables used throughout the tutorial.\n",
+        "### Import libraries and define constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "import google.cloud.aiplatform as aip"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "source": [
+        "#### Vertex AI Pipelines constants\n",
+        "\n",
+        "Setup up the following constants for Vertex AI Pipelines:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pipeline_constants"
+      },
+      "outputs": [],
+      "source": [
+        "PIPELINE_ROOT = \"{}/pipeline_root/bikes_weather\".format(BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "additional_imports"
+      },
+      "source": [
+        "Additional imports."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "import_pipelines:min"
+      },
+      "outputs": [],
+      "source": [
+        "import kfp\n",
+        "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
+        "from kfp.v2.dsl import component\n",
+        "from kfp.v2.google import experimental"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "source": [
+        "## Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "init_aip:mbsdk"
+      },
+      "outputs": [],
+      "source": [
+        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_component:print_op"
+      },
+      "source": [
+        "## Define pipeline components\n",
+        "\n",
+        "The following example define a custom pipeline component for this tutorial:\n",
+        "\n",
+        "-  This component doesn't do anything (but run a print statement)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_component:print_op"
+      },
+      "outputs": [],
+      "source": [
+        "@component\n",
+        "def print_op(input1: str):\n",
+        "    print(\"training task: {}\".format(input1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "define_pipeline:gcpc,bikes_weather,lrg"
+      },
+      "source": [
+        "## Define custom model pipeline that uses components from `google_cloud_pipeline_components`\n",
+        "\n",
+        "Next, you define the pipeline.\n",
+        "\n",
+        "The `experimental.run_as_aiplatform_custom_job` method takes as arguments the previously defined component, and the list of `worker_pool_specs`— in this case one— with which the custom training job is configured.\n",
+        "\n",
+        "Then, [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) components are used to define the rest of the pipeline: upload the model, create an endpoint, and deploy the model to the endpoint.\n",
+        "\n",
+        "*Note:* While not shown in this example, the model deploy will create an endpoint if one is not provided."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "define_pipeline:gcpc,bikes_weather,lrg"
+      },
+      "outputs": [],
+      "source": [
+        "hp_dict: str = '{\"num_hidden_layers\": 3, \"hidden_size\": 32, \"learning_rate\": 0.01, \"epochs\": 1, \"steps_per_epoch\": -1}'\n",
+        "data_dir: str = \"gs://aju-dev-demos-codelabs/bikes_weather/\"\n",
+        "TRAINER_ARGS = [\"--data-dir\", data_dir, \"--hptune-dict\", hp_dict]\n",
+        "\n",
+        "# create working dir to pass to job spec\n",
+        "WORKING_DIR = f\"{PIPELINE_ROOT}/{TIMESTAMP}\"\n",
+        "\n",
+        "MODEL_DISPLAY_NAME = f\"train_deploy{TIMESTAMP}\"\n",
+        "print(TRAINER_ARGS, WORKING_DIR, MODEL_DISPLAY_NAME)\n",
+        "\n",
+        "\n",
+        "@kfp.dsl.pipeline(name=\"train-endpoint-deploy\" + TIMESTAMP)\n",
+        "def pipeline(\n",
+        "    project: str = PROJECT_ID,\n",
+        "    model_display_name: str = MODEL_DISPLAY_NAME,\n",
+        "    serving_container_image_uri: str = \"us-docker.pkg.dev/cloud-aiplatform/prediction/tf2-cpu.2-3:latest\",\n",
+        "):\n",
+        "\n",
+        "    train_task = print_op(\"model training\")\n",
+        "    experimental.run_as_aiplatform_custom_job(\n",
+        "        train_task,\n",
+        "        worker_pool_specs=[\n",
+        "            {\n",
+        "                \"containerSpec\": {\n",
+        "                    \"args\": TRAINER_ARGS,\n",
+        "                    \"env\": [{\"name\": \"AIP_MODEL_DIR\", \"value\": WORKING_DIR}],\n",
+        "                    \"imageUri\": \"gcr.io/google-samples/bw-cc-train:latest\",\n",
+        "                },\n",
+        "                \"replicaCount\": \"1\",\n",
+        "                \"machineSpec\": {\n",
+        "                    \"machineType\": \"n1-standard-16\",\n",
+        "                    \"accelerator_type\": aip.gapic.AcceleratorType.NVIDIA_TESLA_K80,\n",
+        "                    \"accelerator_count\": 2,\n",
+        "                },\n",
+        "            }\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "    model_upload_op = gcc_aip.ModelUploadOp(\n",
+        "        project=project,\n",
+        "        display_name=model_display_name,\n",
+        "        artifact_uri=WORKING_DIR,\n",
+        "        serving_container_image_uri=serving_container_image_uri,\n",
+        "        # serving_container_environment_variables={\"NOT_USED\": \"NO_VALUE\"},\n",
+        "    )\n",
+        "    model_upload_op.after(train_task)\n",
+        "\n",
+        "    endpoint_create_op = gcc_aip.EndpointCreateOp(\n",
+        "        project=project,\n",
+        "        display_name=\"pipelines-created-endpoint\",\n",
+        "    )\n",
+        "\n",
+        "    gcc_aip.ModelDeployOp(\n",
+        "        endpoint=endpoint_create_op.outputs[\"endpoint\"],\n",
+        "        model=model_upload_op.outputs[\"model\"],\n",
+        "        deployed_model_display_name=model_display_name,\n",
+        "        dedicated_resources_machine_type=\"n1-standard-16\",\n",
+        "        dedicated_resources_min_replica_count=1,\n",
+        "        dedicated_resources_max_replica_count=1,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "source": [
+        "## Compile the pipeline\n",
+        "\n",
+        "Next, compile the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "compile_pipeline"
+      },
+      "outputs": [],
+      "source": [
+        "from kfp.v2 import compiler  # noqa: F811\n",
+        "\n",
+        "compiler.Compiler().compile(\n",
+        "    pipeline_func=pipeline,\n",
+        "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "run_pipeline:custom"
+      },
+      "source": [
+        "## Run the pipeline\n",
+        "\n",
+        "Next, run the pipeline."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "run_pipeline:custom"
+      },
+      "outputs": [],
+      "source": [
+        "DISPLAY_NAME = \"bikes_weather_\" + TIMESTAMP\n",
+        "\n",
+        "job = aip.PipelineJob(\n",
+        "    display_name=DISPLAY_NAME,\n",
+        "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+        "    pipeline_root=PIPELINE_ROOT,\n",
+        "    enable_caching=False,\n",
+        ")\n",
+        "\n",
+        "job.run()\n",
+        "\n",
+        "! rm tabular_regression_pipeline.json"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view_pipeline_run:custom"
+      },
+      "source": [
+        "Click on the generated link to see your run in the Cloud Console.\n",
+        "\n",
+        "<!-- It should look something like this as it is running:\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+        "\n",
+        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+        "\n",
+        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" width=\"75%\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "source": [
+        "# Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+        "\n",
+        "- Dataset\n",
+        "- Pipeline\n",
+        "- Model\n",
+        "- Endpoint\n",
+        "- Batch Job\n",
+        "- Custom Job\n",
+        "- Hyperparameter Tuning Job\n",
+        "- Cloud Storage Bucket"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cleanup:pipelines"
+      },
+      "outputs": [],
+      "source": [
+        "delete_dataset = True\n",
+        "delete_pipeline = True\n",
+        "delete_model = True\n",
+        "delete_endpoint = True\n",
+        "delete_batchjob = True\n",
+        "delete_customjob = True\n",
+        "delete_hptjob = True\n",
+        "delete_bucket = True\n",
+        "\n",
+        "try:\n",
+        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+        "        models = aip.Model.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        model = models[0]\n",
+        "        aip.Model.delete(model)\n",
+        "        print(\"Deleted model:\", model)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+        "        endpoints = aip.Endpoint.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        endpoint = endpoints[0]\n",
+        "        endpoint.undeploy_all()\n",
+        "        aip.Endpoint.delete(endpoint.resource_name)\n",
+        "        print(\"Deleted endpoint:\", endpoint)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+        "    if \"tabular\" == \"tabular\":\n",
+        "        try:\n",
+        "            datasets = aip.TabularDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TabularDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"image\":\n",
+        "        try:\n",
+        "            datasets = aip.ImageDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.ImageDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"text\":\n",
+        "        try:\n",
+        "            datasets = aip.TextDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.TextDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "    if \"tabular\" == \"video\":\n",
+        "        try:\n",
+        "            datasets = aip.VideoDataset.list(\n",
+        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "            )\n",
+        "            dataset = datasets[0]\n",
+        "            aip.VideoDataset.delete(dataset.resource_name)\n",
+        "            print(\"Deleted dataset:\", dataset)\n",
+        "        except Exception as e:\n",
+        "            print(e)\n",
+        "\n",
+        "try:\n",
+        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+        "        pipelines = aip.PipelineJob.list(\n",
+        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+        "        )\n",
+        "        pipeline = pipelines[0]\n",
+        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+        "        print(\"Deleted pipeline:\", pipeline)\n",
+        "except Exception as e:\n",
+        "    print(e)\n",
+        "\n",
+        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+        "    ! gsutil rm -r $BUCKET_NAME"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "google_cloud_pipeline_components_model_train_upload_deploy.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "title:generic"
-   },
-   "source": [
-    "# Vertex AI Pipelines:  model train, upload, and deploy using google-cloud-pipeline-components\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>\n",
-    "<br/><br/><br/>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "overview:pipelines,custom"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) in conjunction with an experimental `run_as_aiplatform_custom_job` method, to build a [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines) workflow that trains a [custom model](https://cloud.google.com/vertex-ai/docs/training/containers-overview), uploads the model as a `Model` resource, creates an `Endpoint` resource, and deploys the `Model` resource to the `Endpoint` resource."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dataset:bikes_weather,lrg"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for this tutorial is [Cloud Public Dataset Program](https://cloud.google.com/bigquery/public-data/) [London Bikes Rental](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=london_bicycles&page=dataset&_ga=2.122237643.-1779725180.1624895157) combined with [NOAA weather data ](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=noaa_gsod&page=dataset&_ga=2.179861860.-1779725180.1624895157)\n",
-    "\n",
-    "The dataset predicts the duration of the bike rental."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "objective:pipelines,custom"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you create an custom model using a pipeline with components from `google_cloud_pipeline_components` and a custom pipeline component you build.\n",
-    "\n",
-    "In addition, you'll use the `kfp.v2.google.experimental.run_as_aiplatform_custom_job` method to train a custom model.\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Train a custom model.\n",
-    "- Uploads the trained model as a `Model` resource.\n",
-    "- Creates an `Endpoint` resource.\n",
-    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-    "\n",
-    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform).\n",
-    "(From that page, see also the `CustomPythonPackageTrainingJobRunOp` and `CustomContainerTrainingJobRunOp` components, which similarly run 'custom' training, but as with the related `google.cloud.aiplatform.CustomContainerTrainingJob` and `google.cloud.aiplatform.CustomPythonPackageTrainingJob` methods from the [Vertex AI SDK](https://googleapis.dev/python/aiplatform/latest/aiplatform.html), also upload the trained model)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "costs"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "\n",
-    "Learn about [Vertex AI\n",
-    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-    "Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_local"
-   },
-   "source": [
-    "### Set up your local development environment\n",
-    "\n",
-    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-    "\n",
-    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-    "\n",
-    "- The Cloud Storage SDK\n",
-    "- Git\n",
-    "- Python 3\n",
-    "- virtualenv\n",
-    "- Jupyter notebook running in a virtual environment with Python 3\n",
-    "\n",
-    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-    "\n",
-    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-    "\n",
-    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-    "\n",
-    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-    "\n",
-    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-    "\n",
-    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-    "\n",
-    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the latest version of Vertex SDK for Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Google Cloud Notebook\n",
-    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    USER_FLAG = \"--user\"\n",
-    "else:\n",
-    "    USER_FLAG = \"\"\n",
-    "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_storage"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-storage* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_storage"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install -U google-cloud-storage $USER_FLAG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "source": [
-    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "install_gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "restart"
-   },
-   "source": [
-    "### Restart the kernel\n",
-    "\n",
-    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "restart"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    # Automatically restart kernel after installs\n",
-    "    import IPython\n",
-    "\n",
-    "    app = IPython.Application.instance()\n",
-    "    app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "check_versions"
-   },
-   "source": [
-    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "check_versions:kfp,gcpc"
-   },
-   "outputs": [],
-   "source": [
-    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "before_you_begin:nogpu"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### GPU runtime\n",
-    "\n",
-    "This tutorial does not require a GPU runtime.\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-    "\n",
-    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-    "\n",
-    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-    "\n",
-    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-    "Cloud SDK uses the right project for all the commands in this notebook.\n",
-    "\n",
-    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-    "    PROJECT_ID = shell_output[0]\n",
-    "    print(\"Project ID:\", PROJECT_ID)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_gcloud_project_id"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud config set project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable, which is used for operations\n",
-    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-    "\n",
-    "- Americas: `us-central1`\n",
-    "- Europe: `europe-west4`\n",
-    "- Asia Pacific: `asia-east1`\n",
-    "\n",
-    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-    "\n",
-    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "region"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "timestamp"
-   },
-   "source": [
-    "#### Timestamp\n",
-    "\n",
-    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "timestamp"
-   },
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-    "\n",
-    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-    "\n",
-    "**Otherwise**, follow these steps:\n",
-    "\n",
-    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-    "\n",
-    "**Click Create service account**.\n",
-    "\n",
-    "In the **Service account name** field, enter a name, and click **Create**.\n",
-    "\n",
-    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-    "\n",
-    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-    "\n",
-    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "gcp_authenticate"
-   },
-   "outputs": [],
-   "source": [
-    "# If you are running this notebook in Colab, run this cell and follow the\n",
-    "# instructions to authenticate your GCP account. This provides access to your\n",
-    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-    "# requests.\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
-    "# If on Google Cloud Notebook, then don't execute this code\n",
-    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-    "    if \"google.colab\" in sys.modules:\n",
-    "        from google.colab import auth as google_auth\n",
-    "\n",
-    "        google_auth.authenticate_user()\n",
-    "\n",
-    "    # If you are running this notebook locally, replace the string below with the\n",
-    "    # path to your service account key and run this cell to authenticate your GCP\n",
-    "    # account.\n",
-    "    elif not os.getenv(\"IS_TESTING\"):\n",
-    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bucket:mbsdk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-    "\n",
-    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "bucket"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "create_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "source": [
-    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "validate_bucket"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil ls -al $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "#### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your GCP project id from gcloud\n",
-    "    shell_output = !gcloud auth list 2>/dev/null\n",
-    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "source": [
-    "#### Set service account access for Vertex AI Pipelines\n",
-    "\n",
-    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "set_service_account:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-    "\n",
-    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "setup_vars"
-   },
-   "source": [
-    "### Set up variables\n",
-    "\n",
-    "Next, set up some variables used throughout the tutorial.\n",
-    "### Import libraries and define constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "import google.cloud.aiplatform as aip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "source": [
-    "#### Vertex AI Pipelines constants\n",
-    "\n",
-    "Setup up the following constants for Vertex AI Pipelines:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pipeline_constants"
-   },
-   "outputs": [],
-   "source": [
-    "PIPELINE_ROOT = \"{}/pipeline_root/bikes_weather\".format(BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "additional_imports"
-   },
-   "source": [
-    "Additional imports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "import_pipelines:min"
-   },
-   "outputs": [],
-   "source": [
-    "import kfp\n",
-    "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
-    "from kfp.v2.dsl import component\n",
-    "from kfp.v2.google import experimental"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "source": [
-    "## Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "init_aip:mbsdk"
-   },
-   "outputs": [],
-   "source": [
-    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_component:print_op"
-   },
-   "source": [
-    "## Define pipeline components\n",
-    "\n",
-    "The following example define a custom pipeline component for this tutorial:\n",
-    "\n",
-    "-  This component doesn't do anything (but run a print statement)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_component:print_op"
-   },
-   "outputs": [],
-   "source": [
-    "@component\n",
-    "def print_op(input1: str):\n",
-    "    print(\"training task: {}\".format(input1))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "define_pipeline:gcpc,bikes_weather,lrg"
-   },
-   "source": [
-    "## Define custom model pipeline that uses components from `google_cloud_pipeline_components`\n",
-    "\n",
-    "Next, you define the pipeline.\n",
-    "\n",
-    "The `experimental.run_as_aiplatform_custom_job` method takes as arguments the previously defined component, and the list of `worker_pool_specs`— in this case one— with which the custom training job is configured.\n",
-    "\n",
-    "Then, [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) components are used to define the rest of the pipeline: upload the model, create an endpoint, and deploy the model to the endpoint.\n",
-    "\n",
-    "*Note:* While not shown in this example, the model deploy will create an endpoint if one is not provided."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "define_pipeline:gcpc,bikes_weather,lrg"
-   },
-   "outputs": [],
-   "source": [
-    "hp_dict: str = '{\"num_hidden_layers\": 3, \"hidden_size\": 32, \"learning_rate\": 0.01, \"epochs\": 1, \"steps_per_epoch\": -1}'\n",
-    "data_dir: str = \"gs://aju-dev-demos-codelabs/bikes_weather/\"\n",
-    "TRAINER_ARGS = [\"--data-dir\", data_dir, \"--hptune-dict\", hp_dict]\n",
-    "\n",
-    "# create working dir to pass to job spec\n",
-    "WORKING_DIR = f\"{PIPELINE_ROOT}/{TIMESTAMP}\"\n",
-    "\n",
-    "MODEL_DISPLAY_NAME = f\"train_deploy{TIMESTAMP}\"\n",
-    "print(TRAINER_ARGS, WORKING_DIR, MODEL_DISPLAY_NAME)\n",
-    "\n",
-    "\n",
-    "@kfp.dsl.pipeline(name=\"train-endpoint-deploy\" + TIMESTAMP)\n",
-    "def pipeline(\n",
-    "    project: str = PROJECT_ID,\n",
-    "    model_display_name: str = MODEL_DISPLAY_NAME,\n",
-    "    serving_container_image_uri: str = \"us-docker.pkg.dev/cloud-aiplatform/prediction/tf2-cpu.2-3:latest\",\n",
-    "):\n",
-    "\n",
-    "    train_task = print_op(\"model training\")\n",
-    "    experimental.run_as_aiplatform_custom_job(\n",
-    "        train_task,\n",
-    "        worker_pool_specs=[\n",
-    "            {\n",
-    "                \"containerSpec\": {\n",
-    "                    \"args\": TRAINER_ARGS,\n",
-    "                    \"env\": [{\"name\": \"AIP_MODEL_DIR\", \"value\": WORKING_DIR}],\n",
-    "                    \"imageUri\": \"gcr.io/google-samples/bw-cc-train:latest\",\n",
-    "                },\n",
-    "                \"replicaCount\": \"1\",\n",
-    "                \"machineSpec\": {\n",
-    "                    \"machineType\": \"n1-standard-16\",\n",
-    "                    \"accelerator_type\": aip.gapic.AcceleratorType.NVIDIA_TESLA_K80,\n",
-    "                    \"accelerator_count\": 2,\n",
-    "                },\n",
-    "            }\n",
-    "        ],\n",
-    "    )\n",
-    "\n",
-    "    model_upload_op = gcc_aip.ModelUploadOp(\n",
-    "        project=project,\n",
-    "        display_name=model_display_name,\n",
-    "        artifact_uri=WORKING_DIR,\n",
-    "        serving_container_image_uri=serving_container_image_uri,\n",
-    "        # serving_container_environment_variables={\"NOT_USED\": \"NO_VALUE\"},\n",
-    "    )\n",
-    "    model_upload_op.after(train_task)\n",
-    "\n",
-    "    endpoint_create_op = gcc_aip.EndpointCreateOp(\n",
-    "        project=project,\n",
-    "        display_name=\"pipelines-created-endpoint\",\n",
-    "    )\n",
-    "\n",
-    "    gcc_aip.ModelDeployOp(\n",
-    "        endpoint=endpoint_create_op.outputs[\"endpoint\"],\n",
-    "        model=model_upload_op.outputs[\"model\"],\n",
-    "        deployed_model_display_name=model_display_name,\n",
-    "        dedicated_resources_machine_type=\"n1-standard-16\",\n",
-    "        dedicated_resources_min_replica_count=1,\n",
-    "        dedicated_resources_max_replica_count=1,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "source": [
-    "## Compile the pipeline\n",
-    "\n",
-    "Next, compile the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "compile_pipeline"
-   },
-   "outputs": [],
-   "source": [
-    "from kfp.v2 import compiler  # noqa: F811\n",
-    "\n",
-    "compiler.Compiler().compile(\n",
-    "    pipeline_func=pipeline,\n",
-    "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "run_pipeline:custom"
-   },
-   "source": [
-    "## Run the pipeline\n",
-    "\n",
-    "Next, run the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "run_pipeline:custom"
-   },
-   "outputs": [],
-   "source": [
-    "DISPLAY_NAME = \"bikes_weather_\" + TIMESTAMP\n",
-    "\n",
-    "job = aip.PipelineJob(\n",
-    "    display_name=DISPLAY_NAME,\n",
-    "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-    "    pipeline_root=PIPELINE_ROOT,\n",
-    "    enable_caching=False\n",
-    ")\n",
-    "\n",
-    "job.run()\n",
-    "\n",
-    "! rm tabular_regression_pipeline.json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "view_pipeline_run:custom"
-   },
-   "source": [
-    "Click on the generated link to see your run in the Cloud Console.\n",
-    "\n",
-    "<!-- It should look something like this as it is running:\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-    "\n",
-    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-    "\n",
-    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" width=\"75%\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "source": [
-    "# Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-    "\n",
-    "- Dataset\n",
-    "- Pipeline\n",
-    "- Model\n",
-    "- Endpoint\n",
-    "- Batch Job\n",
-    "- Custom Job\n",
-    "- Hyperparameter Tuning Job\n",
-    "- Cloud Storage Bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "cleanup:pipelines"
-   },
-   "outputs": [],
-   "source": [
-    "delete_dataset = True\n",
-    "delete_pipeline = True\n",
-    "delete_model = True\n",
-    "delete_endpoint = True\n",
-    "delete_batchjob = True\n",
-    "delete_customjob = True\n",
-    "delete_hptjob = True\n",
-    "delete_bucket = True\n",
-    "\n",
-    "try:\n",
-    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-    "        models = aip.Model.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        model = models[0]\n",
-    "        aip.Model.delete(model)\n",
-    "        print(\"Deleted model:\", model)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-    "        endpoints = aip.Endpoint.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        endpoint = endpoints[0]\n",
-    "        endpoint.undeploy_all()\n",
-    "        aip.Endpoint.delete(endpoint.resource_name)\n",
-    "        print(\"Deleted endpoint:\", endpoint)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-    "    if \"tabular\" == \"tabular\":\n",
-    "        try:\n",
-    "            datasets = aip.TabularDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TabularDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"image\":\n",
-    "        try:\n",
-    "            datasets = aip.ImageDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.ImageDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"text\":\n",
-    "        try:\n",
-    "            datasets = aip.TextDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.TextDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "    if \"tabular\" == \"video\":\n",
-    "        try:\n",
-    "            datasets = aip.VideoDataset.list(\n",
-    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "            )\n",
-    "            dataset = datasets[0]\n",
-    "            aip.VideoDataset.delete(dataset.resource_name)\n",
-    "            print(\"Deleted dataset:\", dataset)\n",
-    "        except Exception as e:\n",
-    "            print(e)\n",
-    "\n",
-    "try:\n",
-    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-    "        pipelines = aip.PipelineJob.list(\n",
-    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-    "        )\n",
-    "        pipeline = pipelines[0]\n",
-    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-    "        print(\"Deleted pipeline:\", pipeline)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-    "    ! gsutil rm -r $BUCKET_NAME"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "google_cloud_pipeline_components_model_train_upload_deploy.ipynb",
-   "toc_visible": true
-  },
-  "environment": {
-   "name": "common-cu110.m71",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
@@ -1,1012 +1,1031 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "copyright"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "title:generic"
-      },
-      "source": [
-        "# Vertex AI Pipelines:  model train, upload, and deploy using google-cloud-pipeline-components\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "overview:pipelines,custom"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) in conjunction with an experimental `run_as_aiplatform_custom_job` method, to build a [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines) workflow that trains a [custom model](https://cloud.google.com/vertex-ai/docs/training/containers-overview), uploads the model as a `Model` resource, creates an `Endpoint` resource, and deploys the `Model` resource to the `Endpoint` resource."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dataset:bikes_weather,lrg"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for this tutorial is [Cloud Public Dataset Program](https://cloud.google.com/bigquery/public-data/) [London Bikes Rental](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=london_bicycles&page=dataset&_ga=2.122237643.-1779725180.1624895157) combined with [NOAA weather data ](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=noaa_gsod&page=dataset&_ga=2.179861860.-1779725180.1624895157)\n",
-        "\n",
-        "The dataset predicts the duration of the bike rental."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "objective:pipelines,custom"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you create an custom model using a pipeline with components from `google_cloud_pipeline_components` and a custom pipeline component you build.\n",
-        "\n",
-        "In addition, you'll use the `kfp.v2.google.experimental.run_as_aiplatform_custom_job` method to train a custom model.\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Train a custom model.\n",
-        "- Uploads the trained model as a `Model` resource.\n",
-        "- Creates an `Endpoint` resource.\n",
-        "- Deploys the `Model` resource to the `Endpoint` resource.\n",
-        "\n",
-        "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform).\n",
-        "(From that page, see also the `CustomPythonPackageTrainingJobRunOp` and `CustomContainerTrainingJobRunOp` components, which similarly run 'custom' training, but as with the related `google.cloud.aiplatform.CustomContainerTrainingJob` and `google.cloud.aiplatform.CustomPythonPackageTrainingJob` methods from the [Vertex AI SDK](https://googleapis.dev/python/aiplatform/latest/aiplatform.html), also upload the trained model)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "costs"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "\n",
-        "Learn about [Vertex AI\n",
-        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
-        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
-        "Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_local"
-      },
-      "source": [
-        "### Set up your local development environment\n",
-        "\n",
-        "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
-        "\n",
-        "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
-        "\n",
-        "- The Cloud Storage SDK\n",
-        "- Git\n",
-        "- Python 3\n",
-        "- virtualenv\n",
-        "- Jupyter notebook running in a virtual environment with Python 3\n",
-        "\n",
-        "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
-        "\n",
-        "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
-        "\n",
-        "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
-        "\n",
-        "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
-        "\n",
-        "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
-        "\n",
-        "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
-        "\n",
-        "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex SDK for Python."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "# Google Cloud Notebook\n",
-        "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    USER_FLAG = \"--user\"\n",
-        "else:\n",
-        "    USER_FLAG = \"\"\n",
-        "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_storage"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-storage* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_storage"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install -U google-cloud-storage $USER_FLAG"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "source": [
-        "Install the latest GA version of *google-cloud-pipeline-components* library as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "install_gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart the kernel\n",
-        "\n",
-        "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "restart"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    # Automatically restart kernel after installs\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "check_versions"
-      },
-      "source": [
-        "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "check_versions:kfp,gcpc"
-      },
-      "outputs": [],
-      "source": [
-        "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
-        "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "before_you_begin:nogpu"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### GPU runtime\n",
-        "\n",
-        "This tutorial does not require a GPU runtime.\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
-        "\n",
-        "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
-        "\n",
-        "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
-        "\n",
-        "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
-        "Cloud SDK uses the right project for all the commands in this notebook.\n",
-        "\n",
-        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
-        "    PROJECT_ID = shell_output[0]\n",
-        "    print(\"Project ID:\", PROJECT_ID)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_gcloud_project_id"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable, which is used for operations\n",
-        "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
-        "\n",
-        "- Americas: `us-central1`\n",
-        "- Europe: `europe-west4`\n",
-        "- Asia Pacific: `asia-east1`\n",
-        "\n",
-        "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
-        "\n",
-        "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "timestamp"
-      },
-      "source": [
-        "#### Timestamp\n",
-        "\n",
-        "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "timestamp"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "\n",
-        "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
-        "\n",
-        "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
-        "\n",
-        "**Otherwise**, follow these steps:\n",
-        "\n",
-        "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
-        "\n",
-        "**Click Create service account**.\n",
-        "\n",
-        "In the **Service account name** field, enter a name, and click **Create**.\n",
-        "\n",
-        "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
-        "\n",
-        "Click Create. A JSON file that contains your key downloads to your local environment.\n",
-        "\n",
-        "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "outputs": [],
-      "source": [
-        "# If you are running this notebook in Colab, run this cell and follow the\n",
-        "# instructions to authenticate your GCP account. This provides access to your\n",
-        "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
-        "# requests.\n",
-        "\n",
-        "import os\n",
-        "import sys\n",
-        "\n",
-        "# If on Google Cloud Notebook, then don't execute this code\n",
-        "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
-        "    if \"google.colab\" in sys.modules:\n",
-        "        from google.colab import auth as google_auth\n",
-        "\n",
-        "        google_auth.authenticate_user()\n",
-        "\n",
-        "    # If you are running this notebook locally, replace the string below with the\n",
-        "    # path to your service account key and run this cell to authenticate your GCP\n",
-        "    # account.\n",
-        "    elif not os.getenv(\"IS_TESTING\"):\n",
-        "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bucket:mbsdk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
-        "\n",
-        "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "bucket"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
-        "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "create_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "source": [
-        "Finally, validate access to your Cloud Storage bucket by examining its contents:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "validate_bucket"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil ls -al $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "source": [
-        "#### Service Account\n",
-        "\n",
-        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "if (\n",
-        "    SERVICE_ACCOUNT == \"\"\n",
-        "    or SERVICE_ACCOUNT is None\n",
-        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-        "):\n",
-        "    # Get your GCP project id from gcloud\n",
-        "    shell_output = !gcloud auth list 2>/dev/null\n",
-        "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
-        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "source": [
-        "#### Set service account access for Vertex AI Pipelines\n",
-        "\n",
-        "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "set_service_account:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
-        "\n",
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "setup_vars"
-      },
-      "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "import google.cloud.aiplatform as aip"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "source": [
-        "#### Vertex AI Pipelines constants\n",
-        "\n",
-        "Setup up the following constants for Vertex AI Pipelines:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pipeline_constants"
-      },
-      "outputs": [],
-      "source": [
-        "PIPELINE_ROOT = \"{}/pipeline_root/bikes_weather\".format(BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "additional_imports"
-      },
-      "source": [
-        "Additional imports."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "import_pipelines:min"
-      },
-      "outputs": [],
-      "source": [
-        "import kfp\n",
-        "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
-        "from kfp.v2.dsl import component\n",
-        "from kfp.v2.google import experimental"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "source": [
-        "## Initialize Vertex AI SDK for Python\n",
-        "\n",
-        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "init_aip:mbsdk"
-      },
-      "outputs": [],
-      "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_component:print_op"
-      },
-      "source": [
-        "## Define pipeline components\n",
-        "\n",
-        "The following example define a custom pipeline component for this tutorial:\n",
-        "\n",
-        "-  This component doesn't do anything (but run a print statement)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_component:print_op"
-      },
-      "outputs": [],
-      "source": [
-        "@component\n",
-        "def print_op(input1: str):\n",
-        "    print(\"training task: {}\".format(input1))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "define_pipeline:gcpc,bikes_weather,lrg"
-      },
-      "source": [
-        "## Define custom model pipeline that uses components from `google_cloud_pipeline_components`\n",
-        "\n",
-        "Next, you define the pipeline.\n",
-        "\n",
-        "The `experimental.run_as_aiplatform_custom_job` method takes as arguments the previously defined component, and the list of `worker_pool_specs`— in this case one— with which the custom training job is configured.\n",
-        "\n",
-        "Then, [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) components are used to define the rest of the pipeline: upload the model, create an endpoint, and deploy the model to the endpoint.\n",
-        "\n",
-        "*Note:* While not shown in this example, the model deploy will create an endpoint if one is not provided."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "define_pipeline:gcpc,bikes_weather,lrg"
-      },
-      "outputs": [],
-      "source": [
-        "hp_dict: str = '{\"num_hidden_layers\": 3, \"hidden_size\": 32, \"learning_rate\": 0.01, \"epochs\": 1, \"steps_per_epoch\": -1}'\n",
-        "data_dir: str = \"gs://aju-dev-demos-codelabs/bikes_weather/\"\n",
-        "TRAINER_ARGS = [\"--data-dir\", data_dir, \"--hptune-dict\", hp_dict]\n",
-        "\n",
-        "# create working dir to pass to job spec\n",
-        "WORKING_DIR = f\"{PIPELINE_ROOT}/{TIMESTAMP}\"\n",
-        "\n",
-        "MODEL_DISPLAY_NAME = f\"train_deploy{TIMESTAMP}\"\n",
-        "print(TRAINER_ARGS, WORKING_DIR, MODEL_DISPLAY_NAME)\n",
-        "\n",
-        "\n",
-        "@kfp.dsl.pipeline(name=\"train-endpoint-deploy\" + TIMESTAMP)\n",
-        "def pipeline(\n",
-        "    project: str = PROJECT_ID,\n",
-        "    model_display_name: str = MODEL_DISPLAY_NAME,\n",
-        "    serving_container_image_uri: str = \"us-docker.pkg.dev/cloud-aiplatform/prediction/tf2-cpu.2-3:latest\",\n",
-        "):\n",
-        "\n",
-        "    train_task = print_op(\"model training\")\n",
-        "    experimental.run_as_aiplatform_custom_job(\n",
-        "        train_task,\n",
-        "        worker_pool_specs=[\n",
-        "            {\n",
-        "                \"containerSpec\": {\n",
-        "                    \"args\": TRAINER_ARGS,\n",
-        "                    \"env\": [{\"name\": \"AIP_MODEL_DIR\", \"value\": WORKING_DIR}],\n",
-        "                    \"imageUri\": \"gcr.io/google-samples/bw-cc-train:latest\",\n",
-        "                },\n",
-        "                \"replicaCount\": \"1\",\n",
-        "                \"machineSpec\": {\n",
-        "                    \"machineType\": \"n1-standard-16\",\n",
-        "                    \"accelerator_type\": aip.gapic.AcceleratorType.NVIDIA_TESLA_K80,\n",
-        "                    \"accelerator_count\": 2,\n",
-        "                },\n",
-        "            }\n",
-        "        ],\n",
-        "    )\n",
-        "\n",
-        "    model_upload_op = gcc_aip.ModelUploadOp(\n",
-        "        project=project,\n",
-        "        display_name=model_display_name,\n",
-        "        artifact_uri=WORKING_DIR,\n",
-        "        serving_container_image_uri=serving_container_image_uri,\n",
-        "        # serving_container_environment_variables={\"NOT_USED\": \"NO_VALUE\"},\n",
-        "    )\n",
-        "    model_upload_op.after(train_task)\n",
-        "\n",
-        "    endpoint_create_op = gcc_aip.EndpointCreateOp(\n",
-        "        project=project,\n",
-        "        display_name=\"pipelines-created-endpoint\",\n",
-        "    )\n",
-        "\n",
-        "    gcc_aip.ModelDeployOp(\n",
-        "        endpoint=endpoint_create_op.outputs[\"endpoint\"],\n",
-        "        model=model_upload_op.outputs[\"model\"],\n",
-        "        deployed_model_display_name=model_display_name,\n",
-        "        dedicated_resources_machine_type=\"n1-standard-16\",\n",
-        "        dedicated_resources_min_replica_count=1,\n",
-        "        dedicated_resources_max_replica_count=1,\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "source": [
-        "## Compile the pipeline\n",
-        "\n",
-        "Next, compile the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "compile_pipeline"
-      },
-      "outputs": [],
-      "source": [
-        "from kfp.v2 import compiler  # noqa: F811\n",
-        "\n",
-        "compiler.Compiler().compile(\n",
-        "    pipeline_func=pipeline,\n",
-        "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "run_pipeline:custom"
-      },
-      "source": [
-        "## Run the pipeline\n",
-        "\n",
-        "Next, run the pipeline."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "run_pipeline:custom"
-      },
-      "outputs": [],
-      "source": [
-        "DISPLAY_NAME = \"bikes_weather_\" + TIMESTAMP\n",
-        "\n",
-        "job = aip.PipelineJob(\n",
-        "    display_name=DISPLAY_NAME,\n",
-        "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
-        "    pipeline_root=PIPELINE_ROOT,\n",
-        ")\n",
-        "\n",
-        "job.run()\n",
-        "\n",
-        "! rm tabular_regression_pipeline.json"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view_pipeline_run:custom"
-      },
-      "source": [
-        "Click on the generated link to see your run in the Cloud Console.\n",
-        "\n",
-        "<!-- It should look something like this as it is running:\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
-        "\n",
-        "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
-        "\n",
-        "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" width=\"75%\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "source": [
-        "# Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
-        "\n",
-        "- Dataset\n",
-        "- Pipeline\n",
-        "- Model\n",
-        "- Endpoint\n",
-        "- Batch Job\n",
-        "- Custom Job\n",
-        "- Hyperparameter Tuning Job\n",
-        "- Cloud Storage Bucket"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cleanup:pipelines"
-      },
-      "outputs": [],
-      "source": [
-        "delete_dataset = True\n",
-        "delete_pipeline = True\n",
-        "delete_model = True\n",
-        "delete_endpoint = True\n",
-        "delete_batchjob = True\n",
-        "delete_customjob = True\n",
-        "delete_hptjob = True\n",
-        "delete_bucket = True\n",
-        "\n",
-        "try:\n",
-        "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
-        "        models = aip.Model.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        model = models[0]\n",
-        "        aip.Model.delete(model)\n",
-        "        print(\"Deleted model:\", model)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
-        "        endpoints = aip.Endpoint.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        endpoint = endpoints[0]\n",
-        "        endpoint.undeploy_all()\n",
-        "        aip.Endpoint.delete(endpoint.resource_name)\n",
-        "        print(\"Deleted endpoint:\", endpoint)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
-        "    if \"tabular\" == \"tabular\":\n",
-        "        try:\n",
-        "            datasets = aip.TabularDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TabularDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"image\":\n",
-        "        try:\n",
-        "            datasets = aip.ImageDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.ImageDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"text\":\n",
-        "        try:\n",
-        "            datasets = aip.TextDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.TextDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "    if \"tabular\" == \"video\":\n",
-        "        try:\n",
-        "            datasets = aip.VideoDataset.list(\n",
-        "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "            )\n",
-        "            dataset = datasets[0]\n",
-        "            aip.VideoDataset.delete(dataset.resource_name)\n",
-        "            print(\"Deleted dataset:\", dataset)\n",
-        "        except Exception as e:\n",
-        "            print(e)\n",
-        "\n",
-        "try:\n",
-        "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
-        "        pipelines = aip.PipelineJob.list(\n",
-        "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
-        "        )\n",
-        "        pipeline = pipelines[0]\n",
-        "        aip.PipelineJob.delete(pipeline.resource_name)\n",
-        "        print(\"Deleted pipeline:\", pipeline)\n",
-        "except Exception as e:\n",
-        "    print(e)\n",
-        "\n",
-        "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
-        "    ! gsutil rm -r $BUCKET_NAME"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "google_cloud_pipeline_components_model_train_upload_deploy.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "copyright"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "title:generic"
+   },
+   "source": [
+    "# Vertex AI Pipelines:  model train, upload, and deploy using google-cloud-pipeline-components\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/master/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/ai/platform/notebooks/deploy-notebook?download_url=https://github.com/GoogleCloudPlatform/vertex-ai-samples/notebooks/blob/master/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>\n",
+    "<br/><br/><br/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "overview:pipelines,custom"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook shows how to use the components defined in [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) in conjunction with an experimental `run_as_aiplatform_custom_job` method, to build a [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines) workflow that trains a [custom model](https://cloud.google.com/vertex-ai/docs/training/containers-overview), uploads the model as a `Model` resource, creates an `Endpoint` resource, and deploys the `Model` resource to the `Endpoint` resource."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dataset:bikes_weather,lrg"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for this tutorial is [Cloud Public Dataset Program](https://cloud.google.com/bigquery/public-data/) [London Bikes Rental](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=london_bicycles&page=dataset&_ga=2.122237643.-1779725180.1624895157) combined with [NOAA weather data ](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=noaa_gsod&page=dataset&_ga=2.179861860.-1779725180.1624895157)\n",
+    "\n",
+    "The dataset predicts the duration of the bike rental."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "objective:pipelines,custom"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you create an custom model using a pipeline with components from `google_cloud_pipeline_components` and a custom pipeline component you build.\n",
+    "\n",
+    "In addition, you'll use the `kfp.v2.google.experimental.run_as_aiplatform_custom_job` method to train a custom model.\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Train a custom model.\n",
+    "- Uploads the trained model as a `Model` resource.\n",
+    "- Creates an `Endpoint` resource.\n",
+    "- Deploys the `Model` resource to the `Endpoint` resource.\n",
+    "\n",
+    "The components are [documented here](https://google-cloud-pipeline-components.readthedocs.io/en/latest/google_cloud_pipeline_components.aiplatform.html#module-google_cloud_pipeline_components.aiplatform).\n",
+    "(From that page, see also the `CustomPythonPackageTrainingJobRunOp` and `CustomContainerTrainingJobRunOp` components, which similarly run 'custom' training, but as with the related `google.cloud.aiplatform.CustomContainerTrainingJob` and `google.cloud.aiplatform.CustomPythonPackageTrainingJob` methods from the [Vertex AI SDK](https://googleapis.dev/python/aiplatform/latest/aiplatform.html), also upload the trained model)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "costs"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "\n",
+    "Learn about [Vertex AI\n",
+    "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+    "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+    "Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_local"
+   },
+   "source": [
+    "### Set up your local development environment\n",
+    "\n",
+    "If you are using Colab or Google Cloud Notebook, your environment already meets all the requirements to run this notebook. You can skip this step.\n",
+    "\n",
+    "Otherwise, make sure your environment meets this notebook's requirements. You need the following:\n",
+    "\n",
+    "- The Cloud Storage SDK\n",
+    "- Git\n",
+    "- Python 3\n",
+    "- virtualenv\n",
+    "- Jupyter notebook running in a virtual environment with Python 3\n",
+    "\n",
+    "The Cloud Storage guide to [Setting up a Python development environment](https://cloud.google.com/python/setup) and the [Jupyter installation guide](https://jupyter.org/install) provide detailed instructions for meeting these requirements. The following steps provide a condensed set of instructions:\n",
+    "\n",
+    "1. [Install and initialize the SDK](https://cloud.google.com/sdk/docs/).\n",
+    "\n",
+    "2. [Install Python 3](https://cloud.google.com/python/setup#installing_python).\n",
+    "\n",
+    "3. [Install virtualenv](Ihttps://cloud.google.com/python/setup#installing_and_using_virtualenv) and create a virtual environment that uses Python 3.\n",
+    "\n",
+    "4. Activate that environment and run `pip3 install Jupyter` in a terminal shell to install Jupyter.\n",
+    "\n",
+    "5. Run `jupyter notebook` on the command line in a terminal shell to launch Jupyter.\n",
+    "\n",
+    "6. Open this notebook in the Jupyter Notebook Dashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the latest version of Vertex SDK for Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Google Cloud Notebook\n",
+    "if os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    USER_FLAG = \"--user\"\n",
+    "else:\n",
+    "    USER_FLAG = \"\"\n",
+    "\n",
+    "! pip3 install --upgrade google-cloud-aiplatform $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_storage"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-storage* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_storage"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install -U google-cloud-storage $USER_FLAG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "source": [
+    "Install the latest GA version of *google-cloud-pipeline-components* library as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install_gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "restart"
+   },
+   "source": [
+    "### Restart the kernel\n",
+    "\n",
+    "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "restart"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    # Automatically restart kernel after installs\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "check_versions"
+   },
+   "source": [
+    "Check the versions of the packages you installed.  The KFP SDK version should be >=1.6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "check_versions:kfp,gcpc"
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"import kfp; print('KFP SDK version: {}'.format(kfp.__version__))\"\n",
+    "! python3 -c \"import google_cloud_pipeline_components; print('google_cloud_pipeline_components version: {}'.format(google_cloud_pipeline_components.__version__))\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "before_you_begin:nogpu"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### GPU runtime\n",
+    "\n",
+    "This tutorial does not require a GPU runtime.\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project.](https://cloud.google.com/billing/docs/how-to/modify-project)\n",
+    "\n",
+    "3. [Enable the Vertex AI APIs, Compute Engine APIs, and Cloud Storage.](https://console.cloud.google.com/flows/enableapi?apiid=ml.googleapis.com,compute_component,storage-component.googleapis.com)\n",
+    "\n",
+    "4. [The Google Cloud SDK](https://cloud.google.com/sdk) is already installed in Google Cloud Notebook.\n",
+    "\n",
+    "5. Enter your project ID in the cell below. Then run the  cell to make sure the\n",
+    "Cloud SDK uses the right project for all the commands in this notebook.\n",
+    "\n",
+    "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "if PROJECT_ID == \"\" or PROJECT_ID is None or PROJECT_ID == \"[your-project-id]\":\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
+    "    PROJECT_ID = shell_output[0]\n",
+    "    print(\"Project ID:\", PROJECT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_gcloud_project_id"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable, which is used for operations\n",
+    "throughout the rest of this notebook.  Below are regions supported for Vertex AI. We recommend that you choose the region closest to you.\n",
+    "\n",
+    "- Americas: `us-central1`\n",
+    "- Europe: `europe-west4`\n",
+    "- Asia Pacific: `asia-east1`\n",
+    "\n",
+    "You may not use a multi-regional bucket for training with Vertex AI. Not all regions provide support for all Vertex AI services.\n",
+    "\n",
+    "Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "region"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "timestamp"
+   },
+   "source": [
+    "#### Timestamp\n",
+    "\n",
+    "If you are in a live tutorial session, you might be using a shared test account or project. To avoid name collisions between users on resources created, you create a timestamp for each instance session, and append the timestamp onto the name of resources you create in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "timestamp"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "TIMESTAMP = datetime.now().strftime(\"%Y%m%d%H%M%S\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "**If you are using Google Cloud Notebook**, your environment is already authenticated. Skip this step.\n",
+    "\n",
+    "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
+    "\n",
+    "**Otherwise**, follow these steps:\n",
+    "\n",
+    "In the Cloud Console, go to the [Create service account key](https://console.cloud.google.com/apis/credentials/serviceaccountkey) page.\n",
+    "\n",
+    "**Click Create service account**.\n",
+    "\n",
+    "In the **Service account name** field, enter a name, and click **Create**.\n",
+    "\n",
+    "In the **Grant this service account access to project** section, click the Role drop-down list. Type \"Vertex\" into the filter box, and select **Vertex Administrator**. Type \"Storage Object Admin\" into the filter box, and select **Storage Object Admin**.\n",
+    "\n",
+    "Click Create. A JSON file that contains your key downloads to your local environment.\n",
+    "\n",
+    "Enter the path to your service account key as the GOOGLE_APPLICATION_CREDENTIALS variable in the cell below and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gcp_authenticate"
+   },
+   "outputs": [],
+   "source": [
+    "# If you are running this notebook in Colab, run this cell and follow the\n",
+    "# instructions to authenticate your GCP account. This provides access to your\n",
+    "# Cloud Storage bucket and lets you submit training jobs and prediction\n",
+    "# requests.\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# If on Google Cloud Notebook, then don't execute this code\n",
+    "if not os.path.exists(\"/opt/deeplearning/metadata/env_version\"):\n",
+    "    if \"google.colab\" in sys.modules:\n",
+    "        from google.colab import auth as google_auth\n",
+    "\n",
+    "        google_auth.authenticate_user()\n",
+    "\n",
+    "    # If you are running this notebook locally, replace the string below with the\n",
+    "    # path to your service account key and run this cell to authenticate your GCP\n",
+    "    # account.\n",
+    "    elif not os.getenv(\"IS_TESTING\"):\n",
+    "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bucket:mbsdk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "When you initialize the Vertex AI SDK for Python, you specify a Cloud Storage staging bucket. The staging bucket is where all the data associated with your dataset and model resources are retained across sessions.\n",
+    "\n",
+    "Set the name of your Cloud Storage bucket below. Bucket names must be globally unique across all Google Cloud projects, including those outside of your organization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bucket"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"gs://[your-bucket-name]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "if BUCKET_NAME == \"\" or BUCKET_NAME is None or BUCKET_NAME == \"gs://[your-bucket-name]\":\n",
+    "    BUCKET_NAME = \"gs://\" + PROJECT_ID + \"aip-\" + TIMESTAMP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "create_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "source": [
+    "Finally, validate access to your Cloud Storage bucket by examining its contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "validate_bucket"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil ls -al $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "#### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your GCP project id from gcloud\n",
+    "    shell_output = !gcloud auth list 2>/dev/null\n",
+    "    SERVICE_ACCOUNT = shell_output[2].strip()\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "source": [
+    "#### Set service account access for Vertex AI Pipelines\n",
+    "\n",
+    "Run the following commands to grant your service account access to read and write pipeline artifacts in the bucket that you created in the previous step -- you only need to run these once per service account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "set_service_account:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectCreator $BUCKET_NAME\n",
+    "\n",
+    "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.objectViewer $BUCKET_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "setup_vars"
+   },
+   "source": [
+    "### Set up variables\n",
+    "\n",
+    "Next, set up some variables used throughout the tutorial.\n",
+    "### Import libraries and define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "import google.cloud.aiplatform as aip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "source": [
+    "#### Vertex AI Pipelines constants\n",
+    "\n",
+    "Setup up the following constants for Vertex AI Pipelines:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pipeline_constants"
+   },
+   "outputs": [],
+   "source": [
+    "PIPELINE_ROOT = \"{}/pipeline_root/bikes_weather\".format(BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "additional_imports"
+   },
+   "source": [
+    "Additional imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "import_pipelines:min"
+   },
+   "outputs": [],
+   "source": [
+    "import kfp\n",
+    "from google_cloud_pipeline_components import aiplatform as gcc_aip\n",
+    "from kfp.v2.dsl import component\n",
+    "from kfp.v2.google import experimental"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "source": [
+    "## Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "init_aip:mbsdk"
+   },
+   "outputs": [],
+   "source": [
+    "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_component:print_op"
+   },
+   "source": [
+    "## Define pipeline components\n",
+    "\n",
+    "The following example define a custom pipeline component for this tutorial:\n",
+    "\n",
+    "-  This component doesn't do anything (but run a print statement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_component:print_op"
+   },
+   "outputs": [],
+   "source": [
+    "@component\n",
+    "def print_op(input1: str):\n",
+    "    print(\"training task: {}\".format(input1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "define_pipeline:gcpc,bikes_weather,lrg"
+   },
+   "source": [
+    "## Define custom model pipeline that uses components from `google_cloud_pipeline_components`\n",
+    "\n",
+    "Next, you define the pipeline.\n",
+    "\n",
+    "The `experimental.run_as_aiplatform_custom_job` method takes as arguments the previously defined component, and the list of `worker_pool_specs`— in this case one— with which the custom training job is configured.\n",
+    "\n",
+    "Then, [`google_cloud_pipeline_components`](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud) components are used to define the rest of the pipeline: upload the model, create an endpoint, and deploy the model to the endpoint.\n",
+    "\n",
+    "*Note:* While not shown in this example, the model deploy will create an endpoint if one is not provided."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "define_pipeline:gcpc,bikes_weather,lrg"
+   },
+   "outputs": [],
+   "source": [
+    "hp_dict: str = '{\"num_hidden_layers\": 3, \"hidden_size\": 32, \"learning_rate\": 0.01, \"epochs\": 1, \"steps_per_epoch\": -1}'\n",
+    "data_dir: str = \"gs://aju-dev-demos-codelabs/bikes_weather/\"\n",
+    "TRAINER_ARGS = [\"--data-dir\", data_dir, \"--hptune-dict\", hp_dict]\n",
+    "\n",
+    "# create working dir to pass to job spec\n",
+    "WORKING_DIR = f\"{PIPELINE_ROOT}/{TIMESTAMP}\"\n",
+    "\n",
+    "MODEL_DISPLAY_NAME = f\"train_deploy{TIMESTAMP}\"\n",
+    "print(TRAINER_ARGS, WORKING_DIR, MODEL_DISPLAY_NAME)\n",
+    "\n",
+    "\n",
+    "@kfp.dsl.pipeline(name=\"train-endpoint-deploy\" + TIMESTAMP)\n",
+    "def pipeline(\n",
+    "    project: str = PROJECT_ID,\n",
+    "    model_display_name: str = MODEL_DISPLAY_NAME,\n",
+    "    serving_container_image_uri: str = \"us-docker.pkg.dev/cloud-aiplatform/prediction/tf2-cpu.2-3:latest\",\n",
+    "):\n",
+    "\n",
+    "    train_task = print_op(\"model training\")\n",
+    "    experimental.run_as_aiplatform_custom_job(\n",
+    "        train_task,\n",
+    "        worker_pool_specs=[\n",
+    "            {\n",
+    "                \"containerSpec\": {\n",
+    "                    \"args\": TRAINER_ARGS,\n",
+    "                    \"env\": [{\"name\": \"AIP_MODEL_DIR\", \"value\": WORKING_DIR}],\n",
+    "                    \"imageUri\": \"gcr.io/google-samples/bw-cc-train:latest\",\n",
+    "                },\n",
+    "                \"replicaCount\": \"1\",\n",
+    "                \"machineSpec\": {\n",
+    "                    \"machineType\": \"n1-standard-16\",\n",
+    "                    \"accelerator_type\": aip.gapic.AcceleratorType.NVIDIA_TESLA_K80,\n",
+    "                    \"accelerator_count\": 2,\n",
+    "                },\n",
+    "            }\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    model_upload_op = gcc_aip.ModelUploadOp(\n",
+    "        project=project,\n",
+    "        display_name=model_display_name,\n",
+    "        artifact_uri=WORKING_DIR,\n",
+    "        serving_container_image_uri=serving_container_image_uri,\n",
+    "        # serving_container_environment_variables={\"NOT_USED\": \"NO_VALUE\"},\n",
+    "    )\n",
+    "    model_upload_op.after(train_task)\n",
+    "\n",
+    "    endpoint_create_op = gcc_aip.EndpointCreateOp(\n",
+    "        project=project,\n",
+    "        display_name=\"pipelines-created-endpoint\",\n",
+    "    )\n",
+    "\n",
+    "    gcc_aip.ModelDeployOp(\n",
+    "        endpoint=endpoint_create_op.outputs[\"endpoint\"],\n",
+    "        model=model_upload_op.outputs[\"model\"],\n",
+    "        deployed_model_display_name=model_display_name,\n",
+    "        dedicated_resources_machine_type=\"n1-standard-16\",\n",
+    "        dedicated_resources_min_replica_count=1,\n",
+    "        dedicated_resources_max_replica_count=1,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "source": [
+    "## Compile the pipeline\n",
+    "\n",
+    "Next, compile the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "compile_pipeline"
+   },
+   "outputs": [],
+   "source": [
+    "from kfp.v2 import compiler  # noqa: F811\n",
+    "\n",
+    "compiler.Compiler().compile(\n",
+    "    pipeline_func=pipeline,\n",
+    "    package_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "run_pipeline:custom"
+   },
+   "source": [
+    "## Run the pipeline\n",
+    "\n",
+    "Next, run the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "run_pipeline:custom"
+   },
+   "outputs": [],
+   "source": [
+    "DISPLAY_NAME = \"bikes_weather_\" + TIMESTAMP\n",
+    "\n",
+    "job = aip.PipelineJob(\n",
+    "    display_name=DISPLAY_NAME,\n",
+    "    template_path=\"tabular regression_pipeline.json\".replace(\" \", \"_\"),\n",
+    "    pipeline_root=PIPELINE_ROOT,\n",
+    "    enable_caching=False\n",
+    ")\n",
+    "\n",
+    "job.run()\n",
+    "\n",
+    "! rm tabular_regression_pipeline.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view_pipeline_run:custom"
+   },
+   "source": [
+    "Click on the generated link to see your run in the Cloud Console.\n",
+    "\n",
+    "<!-- It should look something like this as it is running:\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/automl_tabular_classif.png\" width=\"40%\"/></a> -->\n",
+    "\n",
+    "In the UI, many of the pipeline DAG nodes will expand or collapse when you click on them. Here is a partially-expanded view of the DAG (click image to see larger version).\n",
+    "\n",
+    "<a href=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" target=\"_blank\"><img src=\"https://storage.googleapis.com/amy-jo/images/mp/train_endpoint_deploy.png\" width=\"75%\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "source": [
+    "# Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial -- *Note:* this is auto-generated and not all resources may be applicable for this tutorial:\n",
+    "\n",
+    "- Dataset\n",
+    "- Pipeline\n",
+    "- Model\n",
+    "- Endpoint\n",
+    "- Batch Job\n",
+    "- Custom Job\n",
+    "- Hyperparameter Tuning Job\n",
+    "- Cloud Storage Bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cleanup:pipelines"
+   },
+   "outputs": [],
+   "source": [
+    "delete_dataset = True\n",
+    "delete_pipeline = True\n",
+    "delete_model = True\n",
+    "delete_endpoint = True\n",
+    "delete_batchjob = True\n",
+    "delete_customjob = True\n",
+    "delete_hptjob = True\n",
+    "delete_bucket = True\n",
+    "\n",
+    "try:\n",
+    "    if delete_model and \"DISPLAY_NAME\" in globals():\n",
+    "        models = aip.Model.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        model = models[0]\n",
+    "        aip.Model.delete(model)\n",
+    "        print(\"Deleted model:\", model)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_endpoint and \"DISPLAY_NAME\" in globals():\n",
+    "        endpoints = aip.Endpoint.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}_endpoint\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        endpoint = endpoints[0]\n",
+    "        endpoint.undeploy_all()\n",
+    "        aip.Endpoint.delete(endpoint.resource_name)\n",
+    "        print(\"Deleted endpoint:\", endpoint)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_dataset and \"DISPLAY_NAME\" in globals():\n",
+    "    if \"tabular\" == \"tabular\":\n",
+    "        try:\n",
+    "            datasets = aip.TabularDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TabularDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"image\":\n",
+    "        try:\n",
+    "            datasets = aip.ImageDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.ImageDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"text\":\n",
+    "        try:\n",
+    "            datasets = aip.TextDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.TextDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    if \"tabular\" == \"video\":\n",
+    "        try:\n",
+    "            datasets = aip.VideoDataset.list(\n",
+    "                filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "            )\n",
+    "            dataset = datasets[0]\n",
+    "            aip.VideoDataset.delete(dataset.resource_name)\n",
+    "            print(\"Deleted dataset:\", dataset)\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "\n",
+    "try:\n",
+    "    if delete_pipeline and \"DISPLAY_NAME\" in globals():\n",
+    "        pipelines = aip.PipelineJob.list(\n",
+    "            filter=f\"display_name={DISPLAY_NAME}\", order_by=\"create_time\"\n",
+    "        )\n",
+    "        pipeline = pipelines[0]\n",
+    "        aip.PipelineJob.delete(pipeline.resource_name)\n",
+    "        print(\"Deleted pipeline:\", pipeline)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "if delete_bucket and \"BUCKET_NAME\" in globals():\n",
+    "    ! gsutil rm -r $BUCKET_NAME"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "google_cloud_pipeline_components_model_train_upload_deploy.ipynb",
+   "toc_visible": true
+  },
+  "environment": {
+   "name": "common-cu110.m71",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cu110:m71"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR fixes the problems with these notebooks being auto-tested. When ran, they leave behind orphaned artifacts and on subsequent runs, the orphan artifacts was causing the pipeline to reuse (cache) past generated resources (endpoint), that have since been deleted. By setting caching to false, it forces all components to be re-ran.

