### PR TITLE
moving REGION up

### DIFF
--- a/notebooks/community/feature_store/sdk-feature-store.ipynb
+++ b/notebooks/community/feature_store/sdk-feature-store.ipynb
@@ -386,7 +386,7 @@
         "\n",
         "REGION = \"[your-region]\"  # @param {type:\"string\"}\n",
         "FEATURESTORE_ID = \"movie_prediction\"\n",
-        "INPUT_CSV_FILE = \"gs://cloud-samples-data-us-central1/vertex-ai/feature-store/datasets/movie_prediction_sdk.csv\"\n",
+        "INPUT_CSV_FILE = \"gs://cloud-samples-data-us-central1/vertex-ai/feature-store/datasets/movie_prediction.csv\"\n",
         "ONLINE_STORE_FIXED_NODE_COUNT = 1\n",
         "\n",
         "aiplatform.init(project=PROJECT_ID, location=REGION)"

--- a/notebooks/community/feature_store/sdk-feature-store.ipynb
+++ b/notebooks/community/feature_store/sdk-feature-store.ipynb
@@ -384,6 +384,7 @@
         "from google.cloud import aiplatform\n",
         "from google.cloud.aiplatform import Feature, Featurestore\n",
         "\n",
+        "REGION = \"[your-region]\"  # @param {type:\"string\"}\n",
         "FEATURESTORE_ID = \"movie_prediction\"\n",
         "INPUT_CSV_FILE = \"gs://cloud-samples-data-us-central1/vertex-ai/feature-store/datasets/movie_prediction_sdk.csv\"\n",
         "ONLINE_STORE_FIXED_NODE_COUNT = 1\n",
@@ -1126,7 +1127,6 @@
       "outputs": [],
       "source": [
         "# Create dataset\n",
-        "REGION = \"[your-region]\"  # @param {type:\"string\"}\n",
         "client = bigquery.Client(project=PROJECT_ID)\n",
         "dataset_id = \"{}.{}\".format(client.project, DESTINATION_DATA_SET)\n",
         "dataset = bigquery.Dataset(dataset_id)\n",


### PR DESCRIPTION
Moved "Creating BQ dataset" down but need to move `REGION` variable up because previous code cells are dependent.

If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [X] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/docs/CODEOWNERS) file under the `# Community Notebooks` section, pointing to the author or the author's team.
- [X] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/docs/contributing.md#code-quality-checks).