### PR TITLE
Revert "ci: Apply filter to format_and_lint_job"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,5 @@
 name: ci
-on:
-  pull_request:
-    paths:
-      - '**.ipynb'
-
+on: pull_request
 
 jobs:
   format_and_lint:


### PR DESCRIPTION
This change only runs the lint job when notebooks are in the PR. However, it doesn't return any status if notebooks aren't found. We may need to look into an alternate approach, such as exiting early with a success code in the workflow if no notebooks are found.