### PR TITLE
Added ability to test a single notebook

### DIFF
--- a/.cloud-build/execute_changed_notebooks_helper.py
+++ b/.cloud-build/execute_changed_notebooks_helper.py
@@ -353,10 +353,11 @@ def process_and_execute_notebooks(
                         "PASSED" if result.is_pass else "FAILED",
                         format_timedelta(result.duration),
                         result.log_url,
+                        result.output_uri,
                     ]
                     for result in results_sorted
                 ],
-                headers=["build_tag", "status", "duration", "log_url"],
+                headers=["build_tag", "status", "duration", "log_url", "output_url"],
             )
         )
 
@@ -380,7 +381,7 @@ def process_and_execute_notebooks(
         notebook = notebooks[0]
         execute_notebook_helper.execute_notebook(
             notebook_source=notebook,
-            notebook_output_uri="/".join(
+            output_file_or_uri="/".join(
                 [artifacts_bucket, pathlib.Path(notebook).name]
             ),
             should_log_output=True,

--- a/.cloud-build/execute_changed_notebooks_helper.py
+++ b/.cloud-build/execute_changed_notebooks_helper.py
@@ -24,6 +24,7 @@ import re
 import subprocess
 from typing import List, Optional
 
+import execute_notebook_helper
 import execute_notebook_remote
 import nbformat
 from google.cloud.devtools.cloudbuild_v1.types import BuildOperationMetadata
@@ -287,14 +288,15 @@ def process_and_execute_notebooks(
         timeout (str):
             Required. Timeout string according to https://cloud.google.com/build/docs/build-config-file-schema#timeout.
     """
-    notebook_execution_results: List[NotebookExecutionResult] = []
 
     # Calculate deadline
     deadline = datetime.datetime.now() + datetime.timedelta(
         seconds=max(timeout - WORKER_TIMEOUT_BUFFER_IN_SECONDS, 0)
     )
 
-    if len(notebooks) > 0:
+    if len(notebooks) > 1:
+        notebook_execution_results: List[NotebookExecutionResult] = []
+
         print(f"Found {len(notebooks)} modified notebooks: {notebooks}")
 
         if should_parallelize and len(notebooks) > 1:
@@ -333,43 +335,55 @@ def process_and_execute_notebooks(
                 )
                 for notebook in notebooks
             ]
+
+        print("\n=== RESULTS ===\n")
+
+        results_sorted = sorted(
+            notebook_execution_results,
+            key=lambda result: result.is_pass,
+            reverse=True,
+        )
+
+        # Print results
+        print(
+            tabulate(
+                [
+                    [
+                        result.name,
+                        "PASSED" if result.is_pass else "FAILED",
+                        format_timedelta(result.duration),
+                        result.log_url,
+                    ]
+                    for result in results_sorted
+                ],
+                headers=["build_tag", "status", "duration", "log_url"],
+            )
+        )
+
+        print("\n=== END RESULTS===\n")
+
+        total_notebook_duration = functools.reduce(
+            operator.add,
+            [datetime.timedelta(seconds=0)]
+            + [result.duration for result in results_sorted],
+        )
+
+        print(
+            f"Cumulative notebook duration: {format_timedelta(total_notebook_duration)}"
+        )
+
+        # Raise error if any notebooks failed
+        if not all([result.is_pass for result in results_sorted]):
+            raise RuntimeError("Notebook failures detected. See logs for details")
+
+    elif len(notebooks) == 1:
+        notebook = notebooks[0]
+        execute_notebook_helper.execute_notebook(
+            notebook_source=notebook,
+            notebook_output_uri="/".join(
+                [artifacts_bucket, pathlib.Path(notebook).name]
+            ),
+            should_log_output=True,
+        )
     else:
         print("No notebooks modified in this pull request.")
-
-    print("\n=== RESULTS ===\n")
-
-    results_sorted = sorted(
-        notebook_execution_results,
-        key=lambda result: result.is_pass,
-        reverse=True,
-    )
-
-    # Print results
-    print(
-        tabulate(
-            [
-                [
-                    result.name,
-                    "PASSED" if result.is_pass else "FAILED",
-                    format_timedelta(result.duration),
-                    result.log_url,
-                ]
-                for result in results_sorted
-            ],
-            headers=["build_tag", "status", "duration", "log_url"],
-        )
-    )
-
-    print("\n=== END RESULTS===\n")
-
-    total_notebook_duration = functools.reduce(
-        operator.add,
-        [datetime.timedelta(seconds=0)]
-        + [result.duration for result in results_sorted],
-    )
-
-    print(f"Cumulative notebook duration: {format_timedelta(total_notebook_duration)}")
-
-    # Raise error if any notebooks failed
-    if not all([result.is_pass for result in results_sorted]):
-        raise RuntimeError("Notebook failures detected. See logs for details")

--- a/.cloud-build/test_folders.txt
+++ b/.cloud-build/test_folders.txt
@@ -1,3 +1,2 @@
 notebooks/official
 notebooks/notebook_template.ipynb
-notebooks/community/ml_ops


### PR DESCRIPTION
Added ability to test a single notebook. The notebook will run directly in the first Cloud Build instead of a child one. This allows the public logs to work for single notebooks, which is the common case.