### PR TITLE
Notebook CI: Fixed variable replacement to handle numbers

### DIFF
--- a/.cloud-build/utils/UpdateNotebookVariables.py
+++ b/.cloud-build/utils/UpdateNotebookVariables.py
@@ -36,7 +36,7 @@ Variables in conditionals can also be replaced:
 def get_updated_value(content: str, variable_name: str, variable_value: str) -> str:
     return re.sub(
         rf"({variable_name}.*? = .*?[\",\'])\[.+?\]([\",\'].*?)",
-        rf"\1{variable_value}\2",
+        rf"\g<1>{variable_value}\g<2>",
         content,
         flags=re.M,
     )
@@ -80,6 +80,7 @@ def test_region():
     )
     assert new_content == 'REGION = "us-central1"  # @param {type:"string"}'
 
+
 def test_region_equal_equals_ignore():
     # Tests that == is ignored
     new_content = get_updated_value(
@@ -88,3 +89,16 @@ def test_region_equal_equals_ignore():
         variable_value="us-central1",
     )
     assert new_content == 'REGION == "[your-region]"  # @param {type:"string"}'
+
+
+def test_service_account():
+    # Tests that == is ignored
+    new_content = get_updated_value(
+        content='SERVICE_ACCOUNT = "[your-service-account]"  # @param {type:"string"}',
+        variable_name="SERVICE_ACCOUNT",
+        variable_value="12345-compute@developer.gserviceaccount.com",
+    )
+    assert (
+        new_content
+        == 'SERVICE_ACCOUNT = "12345-compute@developer.gserviceaccount.com"  # @param {type:"string"}'
+    )


### PR DESCRIPTION
Currently, if the target replacement content starts with a number, the replacement fails.
This PR fixes it and unblocks the service agent injection.

Reference: https://stackoverflow.com/questions/5984633/python-re-sub-group-number-after-number