### PR TITLE
Run commands in quiet mode

### DIFF
--- a/.cloud-build/notebook-execution-test-cloudbuild-single.yaml
+++ b/.cloud-build/notebook-execution-test-cloudbuild-single.yaml
@@ -4,13 +4,13 @@ steps:
     entrypoint: /bin/sh
     args:
     - -c
-    - 'gcloud config list'
+    - 'gcloud config list --quiet'
   # Check the Python version
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
     args:
     - -c
-    - python3 .cloud-build/CheckPythonVersion.py
+    - python3 .cloud-build/CheckPythonVersion.py -q
   # Create a virtual environment
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
@@ -21,24 +21,16 @@ steps:
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
     args:
-    - -c 
-    - . workspace/env/bin/activate &&
-      python3 -m pip install -U pip &&
-      python3 -m pip install -U -r .cloud-build/requirements.txt
-  # pip freeze
-  - name: ${_PYTHON_IMAGE}
-    entrypoint: /bin/sh
-    args:
     - -c
-    - |
-      . workspace/env/bin/activate &&
-      python3 -m pip freeze    
+    - . workspace/env/bin/activate &&
+      python3 -m pip -q install -U pip &&
+      python3 -m pip -q install -U -r .cloud-build/requirements.txt
   # Install Python dependencies and run testing script
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
     args:
     - -c
-    - | 
+    - |
       . workspace/env/bin/activate &&
       python3 .cloud-build/execute_notebook_cli.py --notebook_source "${_NOTEBOOK_GCS_URI}" --output_file_or_uri "${_NOTEBOOK_OUTPUT_GCS_URI}"
     env:

--- a/.cloud-build/notebook-execution-test-cloudbuild.yaml
+++ b/.cloud-build/notebook-execution-test-cloudbuild.yaml
@@ -28,14 +28,6 @@ steps:
     - . workspace/env/bin/activate &&
       python3 -m pip -q install -U pip &&
       python3 -m pip -q install -U -r .cloud-build/requirements.txt
-  # pip freeze
-  - name: ${_PYTHON_IMAGE}
-    entrypoint: /bin/sh
-    args:
-    - -c
-    - |
-      . workspace/env/bin/activate &&
-      python3 -m pip freeze
   # Install Python dependencies and run testing script
   # TODO: Only pass in private_pool_id if it is set
   - name: ${_PYTHON_IMAGE}

--- a/.cloud-build/notebook-execution-test-cloudbuild.yaml
+++ b/.cloud-build/notebook-execution-test-cloudbuild.yaml
@@ -4,16 +4,16 @@ steps:
     entrypoint: /bin/sh
     args:
     - -c
-    - gcloud config list
+    - gcloud config list --quiet
   # Check the Python version
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
     args:
     - -c
-    - python3 .cloud-build/CheckPythonVersion.py
+    - python3 .cloud-build/CheckPythonVersion.py -q
   # Fetch full repo for diff purposes
   - name: gcr.io/cloud-builders/git
-    args: [fetch, --unshallow]
+    args: [fetch, --unshallow, --quiet]
   # Create a virtual environment
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
@@ -24,10 +24,10 @@ steps:
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
     args:
-    - -c 
+    - -c
     - . workspace/env/bin/activate &&
-      python3 -m pip install -U pip &&
-      python3 -m pip install -U -r .cloud-build/requirements.txt
+      python3 -m pip -q install -U pip &&
+      python3 -m pip -q install -U -r .cloud-build/requirements.txt
   # pip freeze
   - name: ${_PYTHON_IMAGE}
     entrypoint: /bin/sh
@@ -42,7 +42,7 @@ steps:
     entrypoint: /bin/sh
     args:
     - -c
-    - | 
+    - |
       . workspace/env/bin/activate &&
       python3 .cloud-build/execute_changed_notebooks_cli.py --test_paths_file "${_TEST_PATHS_FILE}" --base_branch "${_FORCED_BASE_BRANCH}" --container_uri ${_PYTHON_IMAGE} --staging_bucket ${_GCS_STAGING_BUCKET}  --artifacts_bucket ${_GCS_STAGING_BUCKET}/executed_notebooks/PR_${_PR_NUMBER}/BUILD_${BUILD_ID} --variable_project_id ${PROJECT_ID} --variable_region ${_GCP_REGION} --variable_service_account ${_GCP_SERVICE_ACCOUNT} `if [ ! -z "${_PRIVATE_POOL_NAME}" ]; then echo "--private_pool_id ${_PRIVATE_POOL_NAME}"; fi`
     env:


### PR DESCRIPTION
The logs shown on Github are long which makes useful information like download links to appear at the very bottom. We changes the yaml files so the commands run in quiet mode which makes the log file shorter.
