### PR TITLE
Fix export_additional_model_without_custom_ops argument in AutoML Tab…

### DIFF
--- a/notebooks/official/automl/automl_tabular_on_vertex_pipelines.ipynb
+++ b/notebooks/official/automl/automl_tabular_on_vertex_pipelines.ipynb
@@ -855,6 +855,7 @@
         "    run_distillation=run_distillation,\n",
         "    dataflow_subnetwork=dataflow_subnetwork,\n",
         "    dataflow_use_public_ips=dataflow_use_public_ips,\n",
+        "    export_additional_model_without_custom_ops=export_additional_model_without_custom_ops,\n",
         ")\n",
         "\n",
         "job_id = \"automl-tabular-{}\".format(uuid.uuid4())\n",


### PR DESCRIPTION
…ular Workflows notebook

**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Previously the notebook only defined `export_additional_model_without_custom_ops`. But `export_additional_model_without_custom_ops` was not passed into the pipeline as an argument.
<br><br><br>
