### PR TITLE
Added Dockerfile for building a linting image

### DIFF
--- a/.github/workflows/linter/Dockerfile
+++ b/.github/workflows/linter/Dockerfile
@@ -1,0 +1,20 @@
+# To use this image, run this command with the desired notebook args from the top-level vertex-ai-samples directory:
+# 1. To lint all changed notebooks:
+# docker run -v ${PWD}:/setup/app gcr.io/python-docs-samples-tests/notebook_linter:latest
+# 2. To lint specific notebooks:
+# docker run -v ${PWD}:/setup/app gcr.io/python-docs-samples-tests/notebook_linter:latest notebooks/1.ipynb notebooks/2.ipynb
+
+FROM python:3.9
+
+WORKDIR setup
+
+COPY ./requirements.txt .
+COPY ./run_linter.sh .
+
+# Install dependencies.
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+WORKDIR app
+
+ENTRYPOINT ["/setup/run_linter.sh"]

--- a/.github/workflows/linter/run_linter.sh
+++ b/.github/workflows/linter/run_linter.sh
@@ -47,12 +47,22 @@ done
 
 echo "Test mode: $is_test"
 
+# Read in user-provided notebooks
+notebooks=()
+for arg in "$@"; do
+    if [[ $arg == *.ipynb ]]; then
+        notebooks+=("$arg")
+    fi
+done
+
 # Only check notebooks in test folders modified in this pull request.
 # Note: Use process substitution to persist the data in the array
-notebooks=()
-while read -r file || [ -n "$line" ]; do
-    notebooks+=("$file")
-done < <(git diff --name-only main... | grep '\.ipynb$')
+if [ ${#notebooks[@]} -eq 0 ]; then
+    echo "Checking for changed notebooked using git"
+    while read -r file || [ -n "$line" ]; do
+        notebooks+=("$file")
+    done < <(git diff --name-only main... | grep '\.ipynb$')
+fi
 
 problematic_notebooks=()
 if [ ${#notebooks[@]} -gt 0 ]; then


### PR DESCRIPTION
The linting dependencies that each user needs to install cause a lot of friction for users.

This image makes it easier to run the linter.

```
# To use this image, run this command with the desired notebook args from the top-level vertex-ai-samples directory:
# 1. To lint all changed notebooks:
# docker run -v ${PWD}:/setup/app gcr.io/python-docs-samples-tests/notebook_linter:latest
# 2. To lint specific notebooks:
# docker run -v ${PWD}:/setup/app gcr.io/python-docs-samples-tests/notebook_linter:latest notebooks/1.ipynb notebooks/2.ipynb
```