### PR TITLE
chore: remove preview note from CPR notebooks

### DIFF
--- a/notebooks/community/prediction/custom_prediction_routines/SDK_Custom_Predict_SDK_Integration.ipynb
+++ b/notebooks/community/prediction/custom_prediction_routines/SDK_Custom_Predict_SDK_Integration.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a scikit-learn model on Vertex AI Predictions. This is currently a **preview** feature. Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. For more information, see the [launch stage descriptions](https://cloud.google.com/products#product-launch-stages).\n",
+        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a scikit-learn model on Vertex AI Predictions.\n",
         "\n",
         "\n",
         "\n",

--- a/notebooks/community/prediction/custom_prediction_routines/SDK_Custom_Predict_and_Handler_SDK_Integration.ipynb
+++ b/notebooks/community/prediction/custom_prediction_routines/SDK_Custom_Predict_and_Handler_SDK_Integration.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a scikit-learn model on Vertex AI Predictions. This is currently a **preview** feature. Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. For more information, see the [launch stage descriptions](https://cloud.google.com/products#product-launch-stages).\n",
+        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a scikit-learn model on Vertex AI Predictions.\n",
         "\n",
         "\n",
         "\n",

--- a/notebooks/community/prediction/custom_prediction_routines/SDK_Custom_Preprocess.ipynb
+++ b/notebooks/community/prediction/custom_prediction_routines/SDK_Custom_Preprocess.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a scikit-learn model on Vertex AI Predictions. This is currently a **preview** feature. Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. For more information, see the [launch stage descriptions](https://cloud.google.com/products#product-launch-stages).\n",
+        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a scikit-learn model on Vertex AI Predictions.\n",
         "\n",
         "\n",
         "\n",

--- a/notebooks/community/prediction/custom_prediction_routines/SDK_Pytorch_Custom_Predict.ipynb
+++ b/notebooks/community/prediction/custom_prediction_routines/SDK_Pytorch_Custom_Predict.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a PyTorch model on Vertex AI Predictions. This is currently a **preview** feature. Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. For more information, see the [launch stage descriptions](https://cloud.google.com/products#product-launch-stages).\n",
+        "This tutorial demonstrates how to use Vertex AI SDK to build a custom container that uses the Custom Prediction Routine model server to serve a PyTorch model on Vertex AI Predictions.\n",
         "\n",
         "\n",
         "\n",

--- a/notebooks/community/prediction/custom_prediction_routines/SDK_Triton_PyTorch_Local_Prediction.ipynb
+++ b/notebooks/community/prediction/custom_prediction_routines/SDK_Triton_PyTorch_Local_Prediction.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates how to use Vertex AI SDK to locally test [NVIDIA Triton inference server](https://developer.nvidia.com/nvidia-triton-inference-server) to serve a PyTorch model and deploy it to Vertex AI Predictions. This is currently a **preview** feature. Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. For more information, see the [launch stage descriptions](https://cloud.google.com/products#product-launch-stages).\n",
+        "This tutorial demonstrates how to use Vertex AI SDK to locally test [NVIDIA Triton inference server](https://developer.nvidia.com/nvidia-triton-inference-server) to serve a PyTorch model and deploy it to Vertex AI Predictions.\n",
         "\n",
         "\n",
         "### Dataset\n",


### PR DESCRIPTION
Remove preview launch state note from CPR notebooks in preparation for GA launch.
