### PR TITLE
Quick typo update in model_monitoring.ipynb

### DIFF
--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -975,7 +975,7 @@
         "# Sampling rate (optional, default=.8)\n",
         "LOG_SAMPLE_RATE = 0.8  # @param {type:\"number\"}\n",
         "\n",
-        "# Monitoring Interval in seconds (optional, default=1).\n",
+        "# Monitoring Interval in hours (optional, default=1).\n",
         "MONITOR_INTERVAL = 1  # @param {type:\"number\"}\n",
         "\n",
         "# URI to training dataset.\n",


### PR DESCRIPTION
The Monitoring Interval is in hours, not seconds.