### PR TITLE
Fix: Hardcode gcpc version in model eval automl classification notebook 

### DIFF
--- a/notebooks/official/model_evaluation/automl_tabular_classification_model_evaluation.ipynb
+++ b/notebooks/official/model_evaluation/automl_tabular_classification_model_evaluation.ipynb
@@ -216,7 +216,7 @@
         "    USER_FLAG = \"--user\"\n",
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform \\\n",
-        "                         google-cloud-pipeline-components \\\n",
+        "                         google-cloud-pipeline-components==1.0.26 \\\n",
         "                         kfp \\\n",
         "                         matplotlib {USER_FLAG} -q"
       ]
@@ -940,7 +940,7 @@
         "    location: str,\n",
         "    root_dir: str,\n",
         "    model_name: str,\n",
-        "    target_column_name: str,\n",
+        "    target_field_name: str,\n",
         "    class_names: list,\n",
         "    batch_predict_gcs_source_uris: list,\n",
         "    batch_predict_instances_format: str,\n",
@@ -977,7 +977,7 @@
         "        root_dir=root_dir,\n",
         "        gcs_source_uris=data_sampler_task.outputs[\"gcs_output_directory\"],\n",
         "        instances_format=batch_predict_instances_format,\n",
-        "        target_field_name=target_column_name,\n",
+        "        target_field_name=target_field_name,\n",
         "    )\n",
         "\n",
         "    # Run Batch Explanations\n",
@@ -1003,7 +1003,7 @@
         "        project=project,\n",
         "        location=location,\n",
         "        root_dir=root_dir,\n",
-        "        target_field_name=target_column_name,\n",
+        "        target_field_name=target_field_name,\n",
         "        predictions_gcs_source=batch_explain_task.outputs[\"gcs_output_directory\"],\n",
         "        predictions_format=batch_predict_predictions_format,\n",
         "        prediction_label_column=\"prediction.classes\",\n",
@@ -1109,7 +1109,7 @@
         "- `location`: Region where the pipeline is run.\n",
         "- `root_dir`: The GCS directory for keeping staging files and artifacts. A random subdirectory is created under the directory to keep job info for resuming the job in case of failure.\n",
         "- `model_name`: Resource name of the trained AutoML Tabular classification model.\n",
-        "- `target_column_name`: Name of the column to be used as the target for classification.\n",
+        "- `target_field_name`: Name of the column to be used as the target for classification.\n",
         "- `batch_predict_gcs_source_uris`: List of the Cloud Storage bucket uris of input instances for batch prediction.\n",
         "- `batch_predict_instances_format`: Format of the input instances for batch prediction. Can be '**jsonl**' or '**bigquery**' or '**csv**'.\n",
         "- `class_names`: List of class labels in the target column.\n",
@@ -1130,7 +1130,7 @@
         "    \"location\": REGION,\n",
         "    \"root_dir\": PIPELINE_ROOT,\n",
         "    \"model_name\": model.resource_name,\n",
-        "    \"target_column_name\": target_column,\n",
+        "    \"target_field_name\": target_column,\n",
         "    \"class_names\": [\"No\", \"Yes\"],\n",
         "    \"batch_predict_gcs_source_uris\": [DATA_SOURCE],\n",
         "    \"batch_predict_instances_format\": \"csv\",\n",
@@ -1392,8 +1392,26 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "Python 3.10.5 ('ai-venv': venv)",
+      "language": "python",
       "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.8"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "81f33b13dce1585a584b9fde14ef93b2a78187773b65cd92b5d4e4d45dca3c3f"
+      }
     }
   },
   "nbformat": 4,

--- a/notebooks/official/model_evaluation/automl_tabular_classification_model_evaluation.ipynb
+++ b/notebooks/official/model_evaluation/automl_tabular_classification_model_evaluation.ipynb
@@ -1392,26 +1392,8 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 3.10.5 ('ai-venv': venv)",
-      "language": "python",
+      "display_name": "Python 3",
       "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.8"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "81f33b13dce1585a584b9fde14ef93b2a78187773b65cd92b5d4e4d45dca3c3f"
-      }
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

Hardcoded gcpc version because it fails in newer versions. And this is a request from the model eval SWE team to hardcode the version. Also renamed a variable for consistency! 

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [ ] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [x] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.
