### PR TITLE
Fix: Hardcode gcpc version in model eval custom classification notebook

### DIFF
--- a/notebooks/official/model_evaluation/custom_tabular_classification_model_evaluation.ipynb
+++ b/notebooks/official/model_evaluation/custom_tabular_classification_model_evaluation.ipynb
@@ -666,7 +666,7 @@
       "source": [
         "# Create a bigquery dataset\n",
         "bq_dataset = bigquery.Dataset(f\"{PROJECT_ID}.{PREDICTION_INPUT_DATASET_ID}\")\n",
-        "bq_dataset = bq_client.create_dataset(bq_dataset)\n",
+        "bq_dataset = bq_client.create_dataset(bq_dataset, exists_ok=True)\n",
         "print(f\"Created dataset {bq_client.project}.{bq_dataset.dataset_id}\")"
       ]
     },

--- a/notebooks/official/model_evaluation/custom_tabular_classification_model_evaluation.ipynb
+++ b/notebooks/official/model_evaluation/custom_tabular_classification_model_evaluation.ipynb
@@ -150,7 +150,7 @@
       "source": [
         "# Install the latest versions of the following packages\n",
         "! pip3 install --upgrade google-cloud-aiplatform \\\n",
-        "                            google-cloud-pipeline-components \\\n",
+        "                            google-cloud-pipeline-components==1.0.26 \\\n",
         "                            matplotlib \\\n",
         "                            pyarrow -q\n",
         "# Install the specified versions of the following packages\n",
@@ -1163,7 +1163,7 @@
         "    location: str,\n",
         "    root_dir: str,\n",
         "    model_name: str,\n",
-        "    target_column_name: str,\n",
+        "    target_field_name: str,\n",
         "    bigquery_source_input_uri: str,\n",
         "    bigquery_destination_output_uri: str,\n",
         "    batch_predict_instances_format: str,\n",
@@ -1203,7 +1203,7 @@
         "        root_dir=root_dir,\n",
         "        bigquery_source_uri=data_sampler_task.outputs[\"bigquery_output_table\"],\n",
         "        instances_format=batch_predict_instances_format,\n",
-        "        target_field_name=target_column_name,\n",
+        "        target_field_name=target_field_name,\n",
         "    )\n",
         "\n",
         "    # Run the batch prediction task\n",
@@ -1229,7 +1229,7 @@
         "        class_labels=evaluation_class_names,\n",
         "        prediction_label_column=evaluation_prediction_label_column,\n",
         "        prediction_score_column=evaluation_prediction_score_column,\n",
-        "        target_field_name=target_column_name,\n",
+        "        target_field_name=target_field_name,\n",
         "        ground_truth_format=batch_predict_instances_format,\n",
         "        ground_truth_bigquery_source=data_sampler_task.outputs[\"bigquery_output_table\"],\n",
         "        predictions_format=batch_predict_predictions_format,\n",
@@ -1283,7 +1283,7 @@
         "- `location`: Region where the pipeline needs to be run. If not set, the pipeline defaults to the region that Vertex AI SDK is configured with.\n",
         "- `root_dir`: The Cloud Storage directory for keeping the staged files and artifacts. A random subdirectory is created under the directory to keep the job information for resuming the job in case of a failure.\n",
         "- `model_name`: Resource name of the trained custom tabular classification model.\n",
-        "- `target_column_name`: Name of the column to be used as the ground truth for evaluation.\n",
+        "- `target_field_name`: Name of the column to be used as the ground truth for evaluation.\n",
         "- `bigquery_source_input_uri`: BigQuery table URI where the test input is stored.\n",
         "- `bigquery_destination_output_uri`: BigQuery dataset URI for exporting predictions on the test set.\n",
         "- `batch_predict_instances_format`: Format of the input for batch prediction and evaluation.\n",
@@ -1305,7 +1305,7 @@
         "    \"location\": REGION,\n",
         "    \"root_dir\": PIPELINE_ROOT,\n",
         "    \"model_name\": aip_model.resource_name,\n",
-        "    \"target_column_name\": TARGET,\n",
+        "    \"target_field_name\": TARGET,\n",
         "    \"bigquery_source_input_uri\": f\"bq://{PROJECT_ID}.{table_ref.dataset_id}.{table_ref.table_id}\",\n",
         "    \"bigquery_destination_output_uri\": f\"bq://{PROJECT_ID}.{table_ref.dataset_id}\",\n",
         "    \"batch_predict_instances_format\": \"bigquery\",\n",
@@ -1484,8 +1484,18 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "Python 3.10.5 ('ai-venv': venv)",
+      "language": "python",
       "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.5"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "81f33b13dce1585a584b9fde14ef93b2a78187773b65cd92b5d4e4d45dca3c3f"
+      }
     }
   },
   "nbformat": 4,

--- a/notebooks/official/model_evaluation/custom_tabular_classification_model_evaluation.ipynb
+++ b/notebooks/official/model_evaluation/custom_tabular_classification_model_evaluation.ipynb
@@ -1484,18 +1484,8 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 3.10.5 ('ai-venv': venv)",
-      "language": "python",
+      "display_name": "Python 3",
       "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.10.5"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "81f33b13dce1585a584b9fde14ef93b2a78187773b65cd92b5d4e4d45dca3c3f"
-      }
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

Hardcode gcpc version and variable renaming.

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [x] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>

