### PR TITLE
Update sdk_matching_engine_for_indexing.ipynb

### DIFF
--- a/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
+++ b/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
@@ -730,7 +730,7 @@
       "source": [
         "Create the ANN index configuration:\n",
         "\n",
-        "Please read the documentation to understand the various configuration parameters that can be used to tune the index\n"
+        "To learn more about configuring the index, see [Input data format and structure](https://cloud.google.com/vertex-ai/docs/matching-engine/match-eng-setup#input-data-format).\n"
       ]
     },
     {


### PR DESCRIPTION
Adding a link to the documentation.

<br>
Adding a link to the notebook to direct customers to the index config doc. 
Related to a bug from Andrew Moore - https://buganizer.corp.google.com/issues/258825045
<br><br><br>