### PR TITLE
Fixed timeout value in notebook CI

### DIFF
--- a/.cloud-build/execute_changed_notebooks_helper.py
+++ b/.cloud-build/execute_changed_notebooks_helper.py
@@ -245,7 +245,7 @@ def process_and_execute_notebook(
         result.logs_bucket = operation_metadata.build.logs_bucket
 
         # Block and wait for the result
-        operation_result = operation.result(timeout=86400)
+        operation_result = operation.result(timeout=timeout_in_seconds)
 
         result.duration = datetime.datetime.now() - time_start
         result.is_pass = True


### PR DESCRIPTION
Set timeout value according to correct calculation. Instead of hardcoding (which would be out of date if the desired Cloud Build timeout changes to something larger than 86400), this uses the Cloud Build job's timeout as the request timeout.