### PR TITLE
Update Tabular Workflows notebooks with Feature Transform Engine's new features

### DIFF
--- a/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
@@ -170,7 +170,7 @@
       "source": [
         "## Installation\n",
         "\n",
-        "Install the following packages required to execute this notebook. "
+        "Install the following packages required to execute this notebook."
       ]
     },
     {
@@ -376,7 +376,7 @@
         "### Authenticate your Google Cloud account\n",
         "\n",
         "**If you are using Vertex AI Workbench Notebooks**, your environment is already\n",
-        "authenticated. \n",
+        "authenticated.\n",
         "\n",
         "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
         "\n",
@@ -735,7 +735,9 @@
         "You define either of the following parameters:\n",
         "\n",
         "- `data_source_csv_filenames`: The CSV data source.\n",
-        "- `data_source_bigquery_table_path`: The BigQuery data source.\n"
+        "- `data_source_bigquery_table_path`: The BigQuery data source.\n",
+        "\n",
+        "***Notes***: Please note that the dataset's location has to be the same as the same as the service location (i.e., `REGION`) set for launching the training pipeline.\n"
       ]
     },
     {
@@ -760,9 +762,20 @@
       "source": [
         "### Configure feature transformation\n",
         "\n",
-        "Transformations can be specified using Feature Transform Engine (FTE) specific configurations. Below, you configure full auto transformations (i.e., `auto_transform_config`). FTE automatically configures a set of built-in transformations for each input column based on its data statistics. \n",
+        "Transformations can be specified using Feature Transform Engine (FTE) specific configurations. FTE supports both TensorFlow-based row-level and BigQuery-based dataset-level transformations.\n",
         "\n",
-        "For a complete list of supported feature transformation configs and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.15/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+        "* TensorFlow-based row-level transformations:\n",
+        "  * Full auto transformations: FTE automatically configures a set of built-in transformations for each input column based on its data statistics. This can be set via `tf_auto_transform_features` in the training pipeline.\n",
+        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. Chaining of multiple transformations on a single column is also supported. These transformations can be saved to JSON config file and specified via `tf_transformations_path` argument of the training pipeline.\n",
+        "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `tf_custom_transformation_definitions` argument of the training pipeline.\n",
+        "\n",
+        "* BigQuery-based dataset-level transformations:\n",
+        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. These transformations can be specified as an array of JSON objects via `dataset_level_transformations` argument of the training pipeline.\n",
+        "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `dataset_level_custom_transformation_definitions` argument of the training pipeline.\n",
+        "\n",
+        "Below, you configure full auto transformations by specifying a list of input features to pass to the `tf_auto_transform_features` argument of the training pipeline.\n",
+        "\n",
+        "For a complete list of supported feature transformation configs and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
       ]
     },
     {
@@ -773,7 +786,7 @@
       },
       "outputs": [],
       "source": [
-        "features = [\n",
+        "auto_transform_features = [\n",
         "    \"age\",\n",
         "    \"job\",\n",
         "    \"marital\",\n",
@@ -790,10 +803,40 @@
         "    \"pdays\",\n",
         "    \"previous\",\n",
         "    \"poutcome\",\n",
-        "]\n",
-        "\n",
-        "auto_transform_config = {\"auto_transforms\": features}"
+        "]"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Configure feature selection\n",
+        "\n",
+        "In addition to transformation, you can also apply feature selection via Feature Transform Engine to use only highly ranked features, evaluated by supported algorithms. If enabled, it will be applied right after dataset level transformations, and exclude any feature that's not selected.\n",
+        "\n",
+        "To enable it, you will need to set `run_feature_selection` to True.\n",
+        "\n",
+        "To configure the algorihtm to use, and number of features to be selected, you need to configure both `feature_selection_algorithm` and `max_selected_features` parameter.\n",
+        "\n",
+        "For a complete list of supported feature selection algorithms and configs, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+      ],
+      "metadata": {
+        "id": "-t1fAaCFs8Os"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "RUN_FEATURE_SELECTION = True #@param {type:\"boolean\"}\n",
+        "\n",
+        "FEATURE_SELECTION_ALGORITHM = \"AMI\" #@param {type:\"string\"}\n",
+        "\n",
+        "MAX_SELECTED_FEATURES = 10 #@param {type:\"integer\"}"
+      ],
+      "metadata": {
+        "id": "YroYjOTJwytk"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -808,7 +851,6 @@
         "- `target_column`: The target column name.\n",
         "- `prediction_type`: The type of prediction the model is to produce.\n",
         "  'classification' or 'regression'.\n",
-        "- `transform_config`: The path to a GCS file containing the transformations to apply.\n",
         "- `predefined_split_key`: The predefined_split column name.\n",
         "- `timestamp_split_key`: The timestamp_split column name.\n",
         "- `stratified_split_key`: The stratified_split column name.\n",
@@ -848,9 +890,7 @@
         "    validation_fraction = None\n",
         "    test_fraction = None\n",
         "\n",
-        "weight_column = None\n",
-        "\n",
-        "transform_config = auto_transform_config"
+        "weight_column = None"
       ]
     },
     {
@@ -902,7 +942,7 @@
       "source": [
         "## Customize TabNet CustomJob configuration and create pipeline\n",
         "\n",
-        "This is best choice if you know exactly which hyperparameter values to use for model training. It uses fewer training resources than a HyperparameterTuningJob. \n",
+        "This is best choice if you know exactly which hyperparameter values to use for model training. It uses fewer training resources than a HyperparameterTuningJob.\n",
         "\n",
         "In the example below, you configure the following:\n",
         "\n",
@@ -934,9 +974,6 @@
         "\n",
         "learning_rate = 0.01\n",
         "\n",
-        "transform_config_path = os.path.join(pipeline_job_root_dir, \"transform_config.json\")\n",
-        "write_to_gcs(transform_config_path, json.dumps(transform_config))\n",
-        "\n",
         "worker_pool_specs_override = [\n",
         "    {\"machine_spec\": {\"machine_type\": \"c2-standard-16\"}}  # Override for TF chief node\n",
         "]\n",
@@ -965,7 +1002,10 @@
         "    learning_rate=learning_rate,\n",
         "    target_column=target_column,\n",
         "    prediction_type=prediction_type,\n",
-        "    transform_config=transform_config_path,\n",
+        "    tf_auto_transform_features=auto_transform_features,\n",
+        "    run_feature_selection=RUN_FEATURE_SELECTION,\n",
+        "    feature_selection_algorithm=FEATURE_SELECTION_ALGORITHM,\n",
+        "    max_selected_features=MAX_SELECTED_FEATURES,\n",
         "    training_fraction=training_fraction,\n",
         "    validation_fraction=validation_fraction,\n",
         "    test_fraction=test_fraction,\n",
@@ -1047,7 +1087,7 @@
         "\n",
         "For a full list of HyperparameterTuningJob parameters, see [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.23/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.utils.get_tabnet_hyperparameter_tuning_job_pipeline_and_parameters).\n",
         "\n",
-        "Multiple trials can be configured. The pipeline returns the best trial based on the metric configured in `study_spec_metrics`. In the example below, you return the trial with the lowest loss value. "
+        "Multiple trials can be configured. The pipeline returns the best trial based on the metric configured in `study_spec_metrics`. In the example below, you return the trial with the lowest loss value."
       ]
     },
     {
@@ -1101,7 +1141,10 @@
         "    root_dir=pipeline_job_root_dir,\n",
         "    target_column=target_column,\n",
         "    prediction_type=prediction_type,\n",
-        "    transform_config=transform_config_path,\n",
+        "    tf_auto_transform_features=auto_transform_features,\n",
+        "    run_feature_selection=RUN_FEATURE_SELECTION,\n",
+        "    feature_selection_algorithm=FEATURE_SELECTION_ALGORITHM,\n",
+        "    max_selected_features=MAX_SELECTED_FEATURES,\n",
         "    training_fraction=training_fraction,\n",
         "    validation_fraction=validation_fraction,\n",
         "    test_fraction=test_fraction,\n",

--- a/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
@@ -825,11 +825,11 @@
     {
       "cell_type": "code",
       "source": [
-        "RUN_FEATURE_SELECTION = True  #@param {type:\"boolean\"}\n",
+        "RUN_FEATURE_SELECTION = True  # @param {type:\"boolean\"}\n",
         "\n",
-        "FEATURE_SELECTION_ALGORITHM = \"AMI\"  #@param {type:\"string\"}\n",
+        "FEATURE_SELECTION_ALGORITHM = \"AMI\"  # @param {type:\"string\"}\n",
         "\n",
-        "MAX_SELECTED_FEATURES = 10  #@param {type:\"integer\"}"
+        "MAX_SELECTED_FEATURES = 10  # @param {type:\"integer\"}"
       ],
       "metadata": {
         "id": "YroYjOTJwytk"

--- a/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
@@ -601,7 +601,6 @@
       "outputs": [],
       "source": [
         "# Import required modules\n",
-        "import json\n",
         "from typing import Any, Dict, List\n",
         "\n",
         "from google.cloud import aiplatform, storage\n",
@@ -826,11 +825,11 @@
     {
       "cell_type": "code",
       "source": [
-        "RUN_FEATURE_SELECTION = True #@param {type:\"boolean\"}\n",
+        "RUN_FEATURE_SELECTION = True  #@param {type:\"boolean\"}\n",
         "\n",
-        "FEATURE_SELECTION_ALGORITHM = \"AMI\" #@param {type:\"string\"}\n",
+        "FEATURE_SELECTION_ALGORITHM = \"AMI\"  #@param {type:\"string\"}\n",
         "\n",
-        "MAX_SELECTED_FEATURES = 10 #@param {type:\"integer\"}"
+        "MAX_SELECTED_FEATURES = 10  #@param {type:\"integer\"}"
       ],
       "metadata": {
         "id": "YroYjOTJwytk"

--- a/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
@@ -128,7 +128,7 @@
       "source": [
         "### Set up your local development environment\n",
         "\n",
-        "**If you are using Colab or Vertex AI SDK Workbench Notebooks**, your environment already meets\n",
+        "**If you are using Colab or Vertex AI Workbench Notebooks**, your environment already meets\n",
         "all the requirements to run this notebook. You can skip this step.\n",
         "\n",
         "**Otherwise**, make sure your environment meets this notebook's requirements.\n",
@@ -194,8 +194,7 @@
         "if IS_WORKBENCH_NOTEBOOK:\n",
         "    USER_FLAG = \"--user\"\n",
         "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
-        "! pip3 install --upgrade google-cloud-pipeline-components -q"
+        "! pip3 install --upgrade google-cloud-aiplatform google-cloud-pipeline-components {USER_FLAG} -q\n"
       ]
     },
     {
@@ -614,9 +613,9 @@
         "id": "c0423f260423"
       },
       "source": [
-        "## Initialize Vertex SDK for Python\n",
+        "## Initialize Vertex AI SDK for Python\n",
         "\n",
-        "Initialize the Vertex SDK for Python for your project."
+        "Initialize the Vertex AI SDK for Python for your project."
       ]
     },
     {
@@ -636,7 +635,18 @@
         "id": "3LWH3PRF5o2v"
       },
       "source": [
-        "### Define helper functions"
+        "### Define helper functions",
+        "\n",
+        "Define the following helper functions:\n",
+        "\n",
+        "- `get_model_artifacts_path`: Get the model artifacts path from task details.\n",
+        "- `get_model_uri`: Get the model uri from the task details..\n",
+        "- `get_bucket_name_and_path`: Get the bucket name and path.\n",
+        "- `download_from_gcs`: Download the content from the bucket.\n",
+        "- `write_to_gcs`: Upload content into the bucket.\n",
+        "- `get_task_detail`: Get the task details by using task name.\n",
+        "- `get_model_name`: Get the model name from pipeline job ID.\n",
+        "- `get_evaluation_metrics`: Get the evaluation metrics from pipeline task details.\n"
       ]
     },
     {
@@ -647,7 +657,7 @@
       },
       "outputs": [],
       "source": [
-        "# Get the mdoel artifacts path from task details.\n",
+        "# Get the model artifacts path from task details.\n",
         "def get_model_artifacts_path(task_details: List[Dict[str, Any]], task_name: str) -> str:\n",
         "    task = get_task_detail(task_details, task_name)\n",
         "    return task.outputs[\"unmanaged_container_model\"].artifacts[0].uri\n",
@@ -677,7 +687,7 @@
         "    return blob.download_as_string()\n",
         "\n",
         "\n",
-        "# Upload content in to the bucket.\n",
+        "# Upload content into the bucket.\n",
         "def write_to_gcs(uri: str, content: str):\n",
         "    bucket_name, path = get_bucket_name_and_path(uri)\n",
         "    storage_client = storage.Client()\n",
@@ -695,7 +705,7 @@
         "            return task_detail\n",
         "\n",
         "\n",
-        "# Get the model name from pipeline task details.\n",
+        "# Get the model name from pipeline job ID.\n",
         "def get_model_name(job_id: str) -> str:\n",
         "    pipeline_task_details = aiplatform.PipelineJob.get(\n",
         "        job_id\n",
@@ -720,7 +730,7 @@
         "id": "gvNFMRmBegZq"
       },
       "source": [
-        "## Define training specification"
+        "## Define the training specification"
       ]
     },
     {
@@ -729,7 +739,7 @@
         "id": "7a7332a3f8e2"
       },
       "source": [
-        "### Configure dataset\n",
+        "### Configure the dataset\n",
         "\n",
         "You define either of the following parameters:\n",
         "\n",
@@ -764,17 +774,17 @@
         "Transformations can be specified using Feature Transform Engine (FTE) specific configurations. FTE supports both TensorFlow-based row-level and BigQuery-based dataset-level transformations.\n",
         "\n",
         "* TensorFlow-based row-level transformations:\n",
-        "  * Full auto transformations: FTE automatically configures a set of built-in transformations for each input column based on its data statistics. This can be set via `tf_auto_transform_features` in the training pipeline.\n",
-        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. Chaining of multiple transformations on a single column is also supported. These transformations can be saved to JSON config file and specified via `tf_transformations_path` argument of the training pipeline.\n",
+        "  * Full automatic transformations: FTE automatically configures a set of built-in transformations for each input column based on its data statistics. This can be set via `tf_auto_transform_features` in the training pipeline.\n",
+        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. Chaining of multiple transformations on a single column is also supported. These transformations can be saved to JSON configuration file and specified via `tf_transformations_path` argument of the training pipeline.\n",
         "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `tf_custom_transformation_definitions` argument of the training pipeline.\n",
         "\n",
         "* BigQuery-based dataset-level transformations:\n",
         "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. These transformations can be specified as an array of JSON objects via `dataset_level_transformations` argument of the training pipeline.\n",
         "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `dataset_level_custom_transformation_definitions` argument of the training pipeline.\n",
         "\n",
-        "Below, you configure full auto transformations by specifying a list of input features to pass to the `tf_auto_transform_features` argument of the training pipeline.\n",
+        "Below, you configure full automatic transformations by specifying a list of input features to pass to the `tf_auto_transform_features` argument of the training pipeline.\n",
         "\n",
-        "For a complete list of supported feature transformation configs and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+        "For a complete list of supported feature transformation configurations and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
       ]
     },
     {
@@ -813,13 +823,13 @@
       "source": [
         "### Configure feature selection\n",
         "\n",
-        "In addition to transformation, you can also apply feature selection via Feature Transform Engine to use only highly ranked features, evaluated by supported algorithms. If enabled, it will be applied right after dataset level transformations, and exclude any feature that's not selected.\n",
+        "In addition to transformations, you can also apply feature selection via Feature Transform Engine to use only highly ranked features, evaluated by supported algorithms. If enabled, it will be applied right after dataset level transformations, and exclude any feature that's not selected.\n",
         "\n",
-        "To enable it, you will need to set `run_feature_selection` to True.\n",
+        "To enable it, you need to set `run_feature_selection` to True.\n",
         "\n",
         "To configure the algorihtm to use, and number of features to be selected, you need to configure both `feature_selection_algorithm` and `max_selected_features` parameter.\n",
         "\n",
-        "For a complete list of supported feature selection algorithms and configs, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+        "For a complete list of supported feature selection algorithms and configurations, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
       ]
     },
     {
@@ -1068,7 +1078,7 @@
       "source": [
         "## Customize TabNet HyperparameterTuningJob configuration and create pipeline\n",
         "\n",
-        "To get the best set of hyperparameters for your dataset, you recommend running a HyperparameterTuningJob.\n",
+        "To get the best set of hyperparameters for your dataset, it is recommended to run a HyperparameterTuningJob.\n",
         "\n",
         "Hyperparameters that can be tuned are set in the optional `study_spec_parameters_override` parameter. you provide a helper function called `get_tabnet_study_spec_parameters_override` to get these hyperparameters. You provide `dataset_size_bucket` (one of 'small' (< 1M rows), 'medium' (1M - 100M rows), or 'large' (> 100M rows)), `training_budget_bucket` (one of 'small' (< \\\\$600), 'medium' (\\\\$600 - \\\\$2400), or 'large' (> \\\\$2400)), and `prediction_type` and Vertex AI returns a list of hyperparameters and ranges. `study_spec_parameters_override` can be empty or one or more of these hyperparameters can be specified. For hyperparameters not specified in `study_spec_parameters_override`, you set ranges in the pipeline. For a full list of hyperparameters available for tuning, see [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.23/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.utils.get_tabnet_trainer_pipeline_and_parameters).\n",
         "\n",

--- a/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/tabnet_on_vertex_pipelines.ipynb
@@ -807,6 +807,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "-t1fAaCFs8Os"
+      },
       "source": [
         "### Configure feature selection\n",
         "\n",
@@ -817,25 +820,22 @@
         "To configure the algorihtm to use, and number of features to be selected, you need to configure both `feature_selection_algorithm` and `max_selected_features` parameter.\n",
         "\n",
         "For a complete list of supported feature selection algorithms and configs, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
-      ],
-      "metadata": {
-        "id": "-t1fAaCFs8Os"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YroYjOTJwytk"
+      },
+      "outputs": [],
       "source": [
         "RUN_FEATURE_SELECTION = True  # @param {type:\"boolean\"}\n",
         "\n",
         "FEATURE_SELECTION_ALGORITHM = \"AMI\"  # @param {type:\"string\"}\n",
         "\n",
         "MAX_SELECTED_FEATURES = 10  # @param {type:\"integer\"}"
-      ],
-      "metadata": {
-        "id": "YroYjOTJwytk"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",

--- a/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
@@ -746,11 +746,11 @@
     {
       "cell_type": "code",
       "source": [
-        "RUN_FEATURE_SELECTION = True  #@param {type:\"boolean\"}\n",
+        "RUN_FEATURE_SELECTION = True  # @param {type:\"boolean\"}\n",
         "\n",
-        "FEATURE_SELECTION_ALGORITHM = \"AMI\"  #@param {type:\"string\"}\n",
+        "FEATURE_SELECTION_ALGORITHM = \"AMI\"  # @param {type:\"string\"}\n",
         "\n",
-        "MAX_SELECTED_FEATURES = 10  #@param {type:\"integer\"}"
+        "MAX_SELECTED_FEATURES = 10  # @param {type:\"integer\"}"
       ],
       "metadata": {
         "id": "drdGfJ4824pZ"

--- a/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
@@ -530,7 +530,6 @@
       "outputs": [],
       "source": [
         "# Import required modules\n",
-        "import json\n",
         "from typing import Any, Dict, List\n",
         "\n",
         "from google.cloud import aiplatform, storage\n",
@@ -747,11 +746,11 @@
     {
       "cell_type": "code",
       "source": [
-        "RUN_FEATURE_SELECTION = True #@param {type:\"boolean\"}\n",
+        "RUN_FEATURE_SELECTION = True  #@param {type:\"boolean\"}\n",
         "\n",
-        "FEATURE_SELECTION_ALGORITHM = \"AMI\" #@param {type:\"string\"}\n",
+        "FEATURE_SELECTION_ALGORITHM = \"AMI\"  #@param {type:\"string\"}\n",
         "\n",
-        "MAX_SELECTED_FEATURES = 10 #@param {type:\"integer\"}"
+        "MAX_SELECTED_FEATURES = 10  #@param {type:\"integer\"}"
       ],
       "metadata": {
         "id": "drdGfJ4824pZ"

--- a/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
@@ -194,8 +194,7 @@
         "if IS_WORKBENCH_NOTEBOOK:\n",
         "    USER_FLAG = \"--user\"\n",
         "\n",
-        "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
-        "! pip3 install --upgrade google-cloud-pipeline-components -q"
+        "! pip3 install --upgrade google-cloud-aiplatform google-cloud-pipeline-components {USER_FLAG} -q\n"
       ]
     },
     {
@@ -543,9 +542,9 @@
         "id": "c0423f260423"
       },
       "source": [
-        "## Initialize Vertex SDK for Python\n",
+        "## Initialize Vertex AI SDK for Python\n",
         "\n",
-        "Initialize the Vertex SDK for Python for your project."
+        "Initialize the Vertex AI SDK for Python for your project."
       ]
     },
     {
@@ -565,7 +564,18 @@
         "id": "3LWH3PRF5o2v"
       },
       "source": [
-        "### Define helper functions"
+        "### Define helper functions",
+        "\n",
+        "Define the following helper functions:\n",
+        "\n",
+        "- `get_model_artifacts_path`: Get the model artifacts path from task details.\n",
+        "- `get_model_uri`: Get the model uri from the task details..\n",
+        "- `get_bucket_name_and_path`: Get the bucket name and path.\n",
+        "- `download_from_gcs`: Download the content from the bucket.\n",
+        "- `write_to_gcs`: Upload content into the bucket.\n",
+        "- `get_task_detail`: Get the task details by using task name.\n",
+        "- `get_model_name`: Get the model name from pipeline job ID.\n",
+        "- `get_evaluation_metrics`: Get the evaluation metrics from pipeline task details.\n"
       ]
     },
     {
@@ -641,7 +651,7 @@
         "id": "gvNFMRmBegZq"
       },
       "source": [
-        "## Define training specification"
+        "## Define the training specification"
       ]
     },
     {
@@ -650,7 +660,7 @@
         "id": "7a7332a3f8e2"
       },
       "source": [
-        "### Configure dataset\n",
+        "### Configure the dataset\n",
         "\n",
         "You define either of the following parameters:\n",
         "\n",
@@ -685,17 +695,17 @@
         "Transformations can be specified using Feature Transform Engine (FTE) specific configurations. FTE supports both TensorFlow-based row-level and BigQuery-based dataset-level transformations.\n",
         "\n",
         "* TensorFlow-based row-level transformations:\n",
-        "  * Full auto transformations: FTE automatically configures a set of built-in transformations for each input column based on its data statistics. This can be set via `tf_auto_transform_features` in the training pipeline.\n",
-        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. Chaining of multiple transformations on a single column is also supported. These transformations can be saved to JSON config file and specified via `tf_transformations_path` argument of the training pipeline.\n",
+        "  * Full automatic transformations: FTE automatically configures a set of built-in transformations for each input column based on its data statistics. This can be set via `tf_auto_transform_features` in the training pipeline.\n",
+        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. Chaining of multiple transformations on a single column is also supported. These transformations can be saved to JSON configuration file and specified via `tf_transformations_path` argument of the training pipeline.\n",
         "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `tf_custom_transformation_definitions` argument of the training pipeline.\n",
         "\n",
         "* BigQuery-based dataset-level transformations:\n",
         "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. These transformations can be specified as an array of JSON objects via `dataset_level_transformations` argument of the training pipeline.\n",
         "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `dataset_level_custom_transformation_definitions` argument of the training pipeline.\n",
         "\n",
-        "Below, you configure full auto transformations by specifying a list of input features to pass to the `tf_auto_transform_features` argument of the training pipeline.\n",
+        "Below, you configure full automatic transformations by specifying a list of input features to pass to the `tf_auto_transform_features` argument of the training pipeline.\n",
         "\n",
-        "For a complete list of supported feature transformation configs and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+        "For a complete list of supported feature transformation configurations and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
       ]
     },
     {
@@ -734,9 +744,9 @@
       "source": [
         "### Configure feature selection\n",
         "\n",
-        "In addition to transformation, you can also apply feature selection via Feature Transform Engine to use only highly ranked features, evaluated by supported algorithms. If enabled, it will be applied right after dataset level transformations, and exclude any feature that's not selected.\n",
+        "In addition to transformations, you can also apply feature selection via Feature Transform Engine to use only highly ranked features, evaluated by supported algorithms. If enabled, it will be applied right after dataset level transformations, and exclude any feature that's not selected.\n",
         "\n",
-        "To enable it, you will need to set `run_feature_selection` to True.\n",
+        "To enable it, you need to set `run_feature_selection` to True.\n",
         "\n",
         "To configure the algorihtm to use, and number of features to be selected, you need to configure both `feature_selection_algorithm` and `max_selected_features` parameter.\n",
         "\n",
@@ -995,7 +1005,7 @@
       "source": [
         "## Customize Wide & Deep HyperparameterTuningJob configuration and create pipeline\n",
         "\n",
-        "To get the best set of hyperparameters for your dataset, we recommend running a HyperparameterTuningJob.\n",
+        "To get the best set of hyperparameters for your dataset, it isrecommended to run a HyperparameterTuningJob.\n",
         "\n",
         "Hyperparameters that can be tuned are set in the optional `study_spec_parameters_override` parameter. We provide a helper function called `get_wide_and_deep_study_spec_parameters_override` to get these hyperparameters. The function returns a list of hyperparameters and ranges. `study_spec_parameters_override` can be empty or one or more of these hyperparameters can be specified. For hyperparameters not specified in `study_spec_parameters_override`, we set ranges in the pipeline. For a full list of hyperparameters available for tuning, see [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.23/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.utils.get_wide_and_deep_trainer_pipeline_and_parameters).\n",
         "\n",

--- a/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
@@ -170,7 +170,7 @@
       "source": [
         "## Installation\n",
         "\n",
-        "Install the following packages required to execute this notebook. "
+        "Install the following packages required to execute this notebook."
       ]
     },
     {
@@ -376,7 +376,7 @@
         "### Authenticate your Google Cloud account\n",
         "\n",
         "**If you are using Vertex AI Workbench Notebooks**, your environment is already\n",
-        "authenticated. \n",
+        "authenticated.\n",
         "\n",
         "**If you are using Colab**, run the cell below and follow the instructions when prompted to authenticate your account via oAuth.\n",
         "\n",
@@ -656,7 +656,9 @@
         "You define either of the following parameters:\n",
         "\n",
         "- `data_source_csv_filenames`: The CSV data source.\n",
-        "- `data_source_bigquery_table_path`: The BigQuery data source.\n"
+        "- `data_source_bigquery_table_path`: The BigQuery data source.\n",
+        "\n",
+        "***Notes***: Please note that the dataset's location has to be the same as the same as the service location (i.e., `REGION`) set for launching the training pipeline.\n"
       ]
     },
     {
@@ -681,9 +683,20 @@
       "source": [
         "### Configure feature transformation\n",
         "\n",
-        "Transformations can be specified using Feature Transform Engine (FTE) specific configurations. Below, we configure full auto transformations (i.e., `auto_transform_config`). FTE automatically configures a set of built-in transformations for each input column based on its data statistics. \n",
+        "Transformations can be specified using Feature Transform Engine (FTE) specific configurations. FTE supports both TensorFlow-based row-level and BigQuery-based dataset-level transformations.\n",
         "\n",
-        "For a complete list of supported feature transformation configs and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.15/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+        "* TensorFlow-based row-level transformations:\n",
+        "  * Full auto transformations: FTE automatically configures a set of built-in transformations for each input column based on its data statistics. This can be set via `tf_auto_transform_features` in the training pipeline.\n",
+        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. Chaining of multiple transformations on a single column is also supported. These transformations can be saved to JSON config file and specified via `tf_transformations_path` argument of the training pipeline.\n",
+        "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `tf_custom_transformation_definitions` argument of the training pipeline.\n",
+        "\n",
+        "* BigQuery-based dataset-level transformations:\n",
+        "  * Fully specified transformations: All transformations on input columns are explicitly specified with FTE's built-in transformations. These transformations can be specified as an array of JSON objects via `dataset_level_transformations` argument of the training pipeline.\n",
+        "  * Custom transformations: Custom, bring-your-own transform function, where you can define and import your own transform function and use it with other FTE's built-in transformations. You can specify custom transformations as an array of JSON object and pass through the `dataset_level_custom_transformation_definitions` argument of the training pipeline.\n",
+        "\n",
+        "Below, you configure full auto transformations by specifying a list of input features to pass to the `tf_auto_transform_features` argument of the training pipeline.\n",
+        "\n",
+        "For a complete list of supported feature transformation configs and examples, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
       ]
     },
     {
@@ -694,7 +707,7 @@
       },
       "outputs": [],
       "source": [
-        "features = [\n",
+        "auto_transform_features = [\n",
         "    \"age\",\n",
         "    \"job\",\n",
         "    \"marital\",\n",
@@ -711,10 +724,40 @@
         "    \"pdays\",\n",
         "    \"previous\",\n",
         "    \"poutcome\",\n",
-        "]\n",
-        "\n",
-        "auto_transform_config = {\"auto_transforms\": features}"
+        "]"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Configure feature selection\n",
+        "\n",
+        "In addition to transformation, you can also apply feature selection via Feature Transform Engine to use only highly ranked features, evaluated by supported algorithms. If enabled, it will be applied right after dataset level transformations, and exclude any feature that's not selected.\n",
+        "\n",
+        "To enable it, you will need to set `run_feature_selection` to True.\n",
+        "\n",
+        "To configure the algorihtm to use, and number of features to be selected, you need to configure both `feature_selection_algorithm` and `max_selected_features` parameter.\n",
+        "\n",
+        "For a complete list of supported feature selection algorithms and configs, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
+      ],
+      "metadata": {
+        "id": "dgmd7dHi21Sb"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "RUN_FEATURE_SELECTION = True #@param {type:\"boolean\"}\n",
+        "\n",
+        "FEATURE_SELECTION_ALGORITHM = \"AMI\" #@param {type:\"string\"}\n",
+        "\n",
+        "MAX_SELECTED_FEATURES = 10 #@param {type:\"integer\"}"
+      ],
+      "metadata": {
+        "id": "drdGfJ4824pZ"
+      },
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -729,7 +772,6 @@
         "- `target_column`: The target column name.\n",
         "- `prediction_type`: The type of prediction the model is to produce.\n",
         "  'classification' or 'regression'.\n",
-        "- `transform_config`: The path to a GCS file containing the transformations to apply.\n",
         "- `predefined_split_key`: The predefined_split column name.\n",
         "- `timestamp_split_key`: The timestamp_split column name.\n",
         "- `stratified_split_key`: The stratified_split column name.\n",
@@ -769,9 +811,7 @@
         "    validation_fraction = None\n",
         "    test_fraction = None\n",
         "\n",
-        "weight_column = None\n",
-        "\n",
-        "transform_config = auto_transform_config"
+        "weight_column = None"
       ]
     },
     {
@@ -823,7 +863,7 @@
       "source": [
         "## Customize Wide & Deep CustomJob configuration and create pipeline\n",
         "\n",
-        "This is best choice if you know exactly which hyperparameter values to use for model training. It uses fewer training resources than a HyperparameterTuningJob. \n",
+        "This is best choice if you know exactly which hyperparameter values to use for model training. It uses fewer training resources than a HyperparameterTuningJob.\n",
         "\n",
         "In the example below, you configure the following:\n",
         "\n",
@@ -858,9 +898,6 @@
         "learning_rate = 0.01\n",
         "dnn_learning_rate = 0.01\n",
         "\n",
-        "transform_config_path = os.path.join(pipeline_job_root_dir, \"transform_config.json\")\n",
-        "write_to_gcs(transform_config_path, json.dumps(transform_config))\n",
-        "\n",
         "worker_pool_specs_override = [\n",
         "    {\"machine_spec\": {\"machine_type\": \"c2-standard-16\"}}  # Override for TF chief node\n",
         "]\n",
@@ -890,7 +927,10 @@
         "    dnn_learning_rate=dnn_learning_rate,\n",
         "    target_column=target_column,\n",
         "    prediction_type=prediction_type,\n",
-        "    transform_config=transform_config_path,\n",
+        "    tf_auto_transform_features=auto_transform_features,\n",
+        "    run_feature_selection=RUN_FEATURE_SELECTION,\n",
+        "    feature_selection_algorithm=FEATURE_SELECTION_ALGORITHM,\n",
+        "    max_selected_features=MAX_SELECTED_FEATURES,\n",
         "    training_fraction=training_fraction,\n",
         "    validation_fraction=validation_fraction,\n",
         "    test_fraction=test_fraction,\n",
@@ -974,7 +1014,7 @@
         "\n",
         "For a full list of HyperparameterTuningJob parameters, see [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.23/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.utils.get_wide_and_deep_hyperparameter_tuning_job_pipeline_and_parameters).\n",
         "\n",
-        "Multiple trials can be configured. The pipeline returns the best trial based on the metric configured in `study_spec_metrics`. In the example below, we return the trial with the lowest loss value. "
+        "Multiple trials can be configured. The pipeline returns the best trial based on the metric configured in `study_spec_metrics`. In the example below, we return the trial with the lowest loss value."
       ]
     },
     {
@@ -1026,7 +1066,10 @@
         "    root_dir=pipeline_job_root_dir,\n",
         "    target_column=target_column,\n",
         "    prediction_type=prediction_type,\n",
-        "    transform_config=transform_config_path,\n",
+        "    tf_auto_transform_features=auto_transform_features,\n",
+        "    run_feature_selection=RUN_FEATURE_SELECTION,\n",
+        "    feature_selection_algorithm=FEATURE_SELECTION_ALGORITHM,\n",
+        "    max_selected_features=MAX_SELECTED_FEATURES,\n",
         "    training_fraction=training_fraction,\n",
         "    validation_fraction=validation_fraction,\n",
         "    test_fraction=test_fraction,\n",

--- a/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
+++ b/notebooks/official/tabular_workflows/wide_and_deep_on_vertex_pipelines.ipynb
@@ -728,6 +728,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "dgmd7dHi21Sb"
+      },
       "source": [
         "### Configure feature selection\n",
         "\n",
@@ -738,25 +741,22 @@
         "To configure the algorihtm to use, and number of features to be selected, you need to configure both `feature_selection_algorithm` and `max_selected_features` parameter.\n",
         "\n",
         "For a complete list of supported feature selection algorithms and configs, please go [here](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.31/google_cloud_pipeline_components.experimental.automl.tabular.html#google_cloud_pipeline_components.experimental.automl.tabular.FeatureTransformEngineOp)."
-      ],
-      "metadata": {
-        "id": "dgmd7dHi21Sb"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "drdGfJ4824pZ"
+      },
+      "outputs": [],
       "source": [
         "RUN_FEATURE_SELECTION = True  # @param {type:\"boolean\"}\n",
         "\n",
         "FEATURE_SELECTION_ALGORITHM = \"AMI\"  # @param {type:\"string\"}\n",
         "\n",
         "MAX_SELECTED_FEATURES = 10  # @param {type:\"integer\"}"
-      ],
-      "metadata": {
-        "id": "drdGfJ4824pZ"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Update Tabular Workflows notebooks with Feature Transform Engine's new features from GCPC 1.0.31 release

**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Update Tabular Workflows notebooks with Feature Transform Engine's new features from GCPC 1.0.31 release, including BigQuery-based dataset-level transformations and feature selection support.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [ ] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [X] Follow the style and grammar rules outlined in the above notebook template.
- [X] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.