### PR TITLE
[Community] Added image classification pipeline components from the Ready-to-Go Vertex project

### DIFF
--- a/community-content/CODEOWNERS
+++ b/community-content/CODEOWNERS
@@ -8,3 +8,4 @@
 /cpr-examples @samthrasher
 /Train_tabular_models_with_many_frameworks_and_import_to_Vertex_AI_using_Pipelines @Ark-kun
 /pipeline_components @Ark-kun
+/pipeline_components/image_ml_model_training @lakeyk

--- a/community-content/pipeline_components/image_ml_model_training/load_image_classification_model/component.yaml
+++ b/community-content/pipeline_components/image_ml_model_training/load_image_classification_model/component.yaml
@@ -1,0 +1,112 @@
+name: Load image classification model from tfhub
+description: |
+  Loads specified model from TFHub, creates layer to receive additional (3 channel) imagery data.
+  Args:
+    class_names (Sequence[str]):
+        Sequence of strings of categories for classification corresponding to input data.
+    loaded_model_path (str):
+        Output path for the loaded model.
+    image_size_path (str):
+        Output path for the model expected image size.
+    model_name (Optional[str]):
+        Name of the pre-trained image classification model to load from TFHub.
+        Eligible model_name:
+        - efficientnetv2-s
+        - efficientnetv2-m
+        - efficientnetv2-l
+        - efficientnetv2-s-21k
+        - efficientnetv2-m-21k
+        - efficientnetv2-l-21k
+        - efficientnetv2-xl-21k
+        - efficientnetv2-b0-21k
+        - efficientnetv2-b1-21k
+        - efficientnetv2-b2-21k
+        - efficientnetv2-b3-21k
+        - efficientnetv2-s-21k-ft1k
+        - efficientnetv2-m-21k-ft1k
+        - efficientnetv2-l-21k-ft1k
+        - efficientnetv2-xl-21k-ft1k
+        - efficientnetv2-b0-21k-ft1k
+        - efficientnetv2-b1-21k-ft1k
+        - efficientnetv2-b2-21k-ft1k
+        - efficientnetv2-b3-21k-ft1k
+        - efficientnetv2-b0
+        - efficientnetv2-b1
+        - efficientnetv2-b2
+        - efficientnetv2-b3
+        - efficientnet_b0
+        - efficientnet_b1
+        - efficientnet_b2
+        - efficientnet_b3
+        - efficientnet_b4
+        - efficientnet_b5
+        - efficientnet_b6
+        - efficientnet_b7
+        - bit_s-r50x1
+        - inception_v3
+        - inception_resnet_v2
+        - resnet_v1_50
+        - resnet_v1_101
+        - resnet_v1_152
+        - resnet_v2_50
+        - resnet_v2_101
+        - resnet_v2_152
+        - nasnet_large
+        - nasnet_mobile
+        - pnasnet_large
+        - mobilenet_v2_100_224
+        - mobilenet_v2_130_224
+        - mobilenet_v2_140_224
+        - mobilenet_v3_small_100_224
+        - mobilenet_v3_small_075_224
+        - mobilenet_v3_large_100_224
+        - mobilenet_v3_large_075_224
+    dropout_rate (Optional[float]):
+        Fraction of input units to drop in the last layer. Value should be between 0.0 and 1.0.
+    trainable (Optional[bool]):
+        If true fine tuning will be performed on entire Hub model. If false only additional
+        layers will be trained.
+    l2_regularization_penalty (Optional[float]):
+        l2 regularization penalty.
+inputs:
+- {name: class_names, type: 'typing.List[str]', description: List of class names corresponding
+    to the input image data}
+- {name: model_name, type: String, description: Name of the TFHub model to load, default: efficientnetv2-xl-21k,
+  optional: true}
+- {name: dropout_rate, type: Float, description: Dropout rate, default: '0.2', optional: true}
+- name: trainable
+  type: Boolean
+  description: True if fine tuning should be performed
+  default: "True"
+  optional: true
+- {name: l2_regularization_penalty, type: Float, description: Regularization penalty,
+  default: '0.0001', optional: true}
+outputs:
+- {name: loaded_model_path, type: TensorflowSavedModel, description: Output path for
+    the loaded model}
+- {name: image_size_path, type: HeightWidth}
+implementation:
+  container:
+    image: us-docker.pkg.dev/vertex-ai/ready-to-go-image-classification/image-components:v0.1
+    # command is a list of strings (command-line arguments).
+    # The YAML language has two syntaxes for lists and you can use either of them.
+    # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+    command: [
+      python3,
+      # Path of the program inside the container
+      /pipelines/component/src/loading_component.py,
+      --loaded-model-path,
+      {outputPath: loaded_model_path},
+      --class-names,
+      {inputValue: class_names},
+      --model-name,
+      {inputValue: model_name},
+      --dropout-rate,
+      {inputValue: dropout_rate},
+      --trainable,
+      {inputValue: trainable},
+      --l2-regularization-penalty,
+      {inputValue: l2_regularization_penalty},
+      --image-size-path,
+      {outputPath: image_size_path},
+    ]

--- a/community-content/pipeline_components/image_ml_model_training/preprocess_image_data/component.yaml
+++ b/community-content/pipeline_components/image_ml_model_training/preprocess_image_data/component.yaml
@@ -1,0 +1,57 @@
+name: Preprocess image data
+description: |
+  Preprocess the image data and split between train and validation.
+  Args:
+    input_data_path (str):
+        Input path for the TFRecord image data. Data will be formatted as 'label' (encoded image
+        label), and 'image_raw' (the binary string of the image data).
+    height_width_path (str):
+        Path to square height and width to resize images to. File should contain single float value.
+        Value is dependent on training model.
+    preprocessed_training_data_path (str):
+        Output path for the TFRecord training data. Data will be formatted as 'label' (encoded image
+        label), and 'image_raw' (the binary string of the image data).
+    preprocessed_validation_data_path (str):
+        Output path for the TFRecord validation data. Data will be formatted as 'label' (encoded
+        image label), and 'image_raw' (the binary string of the image data).
+    validation_split (Optional[float]):
+        Fraction of data that will make up validation dataset. Value should be between 0.0 and 1.0.
+    seed (Optional[int]):
+        The global random seed to ensure the system gets a unique random sequence
+        that is deterministic (https://www.tensorflow.org/api_docs/python/tf/random/set_seed).
+inputs:
+- {name: input_data_path, type: ImageDatasetTFRecord, description: 'Input path for
+    the TFRecord image data,'}
+- {name: height_width_path, type: HeightWidth, description: 'Path to square height and width to
+    resize images to,'}
+- {name: validation_split, type: Float, description: 'Fraction of data that will make
+    up validation dataset,', default: '0.2', optional: true}
+- {name: seed, type: Integer, description: Random seed, default: '0', optional: true}
+outputs:
+- {name: preprocessed_training_data_path, type: ImageDatasetTFRecord, description: 'Output
+    path for the training data,'}
+- {name: preprocessed_validation_data_path, type: ImageDatasetTFRecord, description: 'Output
+    path for the validation data,'}
+implementation:
+  container:
+    image: us-docker.pkg.dev/vertex-ai/ready-to-go-image-classification/image-components:v0.1
+    # command is a list of strings (command-line arguments).
+    # The YAML language has two syntaxes for lists and you can use either of them.
+    # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+    command: [
+      python3,
+      # Path of the program inside the container
+      /pipelines/component/src/preprocessing_component.py,
+      --input-data-path,
+      {inputPath: input_data_path},
+      --height-width-path,
+      {inputPath: height_width_path},
+      --validation-split,
+      {inputValue: validation_split},
+      --seed,
+      {inputValue: seed},
+      --preprocessed-training-data-path,
+      {outputPath: preprocessed_training_data_path},
+      --preprocessed-validation-data-path,
+      {outputPath: preprocessed_validation_data_path},
+    ]

--- a/community-content/pipeline_components/image_ml_model_training/train_image_classification_model/component.yaml
+++ b/community-content/pipeline_components/image_ml_model_training/train_image_classification_model/component.yaml
@@ -1,0 +1,90 @@
+name: Train tensorflow image classification model
+description: |
+  Creates a trained image classification TensorFlow model.
+  Args:
+    preprocessed_training_data_path (str):
+        Input path to the TFRecord training data. Data will be formatted as 'label' (encoded image
+        label), and 'image_raw' (the binary string of the image data).
+    preprocessed_validation_data_path (str):
+        Input path to the TFRecord validation data. Data will be formatted as 'label' (encoded
+        image label), and 'image_raw' (the binary string of the image data).
+    model_path (str):
+        Input path to the loaded pre-trained model.
+    trained_model_path (str):
+        Output path to save the trained model to.
+    optimizer_name (Optional[str]):
+        Name of the tf.keras optimizer. Available optimizers are listed at
+        https://keras.io/api/optimizers/
+    optimizer_parameters (Optional[Dict[str, str]]):
+        Optimizer parameters.
+    loss_function_name (Optional[str]):
+        Name of the loss function.
+    loss_function_parameters (Optional[Dict[str, str]]):
+        Loss function parameters.
+    number_of_epochs (Optional[int]):
+        Number of training iterations over data.
+    metric_names (Optional[Sequence[str]]):
+        List of tf.keras.metrics to be evaluated by the model during training and testing. Available
+        metrics are listed at https://keras.io/api/metrics/.
+    seed Optional(int):
+        The global random seed to ensure the system gets a unique random sequence
+        that is deterministic (https://www.tensorflow.org/api_docs/python/tf/random/set_seed).
+inputs:
+- {name: preprocessed_training_data_path, type: ImageDatasetTFRecord, description: 'Input
+    path for the training data,'}
+- {name: preprocessed_validation_data_path, type: ImageDatasetTFRecord, description: 'Input
+    path for the validation data,'}
+- {name: model_path, type: TensorflowSavedModel, description: 'Input path for the
+    model,'}
+- {name: optimizer_name, type: String, description: 'Name of the optimizer,', default: SGD,
+  optional: true}
+- {name: optimizer_parameters, type: 'typing.Dict[str, str]', description: 'Optimizer
+    parameters,', default: '{}', optional: true}
+- {name: loss_function_name, type: String, description: 'Name of the loss function,',
+  default: CategoricalCrossentropy, optional: true}
+- {name: loss_function_parameters, type: 'typing.Dict[str, str]', description: 'Loss
+    function parameters,', default: '{}', optional: true}
+- {name: number_of_epochs, type: Integer, description: 'Number of epochs,', default: '10',
+  optional: true}
+- {name: metric_names, type: 'typing.List[str]', description: 'List of metrics to
+    use,', default: '["accuracy"]', optional: true}
+- {name: seed, type: Integer, description: 'Random seed,', default: '0', optional: true}
+- {name: batch_size, type: Integer, description: Batch size, default: '16', optional: true}
+outputs:
+- {name: trained_model_path, type: TensorflowSavedModel, description: 'Output path
+    for the saved model,'}
+implementation:
+  container:
+    image: us-docker.pkg.dev/vertex-ai/ready-to-go-image-classification/image-components:v0.1
+    # command is a list of strings (command-line arguments).
+    # The YAML language has two syntaxes for lists and you can use either of them.
+    # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+    command: [
+      python3,
+      # Path of the program inside the container
+      /pipelines/component/src/training_component.py,
+      --preprocessed-training-data-path,
+      {inputPath: preprocessed_training_data_path},
+      --preprocessed-validation-data-path,
+      {inputPath: preprocessed_validation_data_path},
+      --model-path,
+      {inputPath: model_path},
+      --trained-model-path,
+      {outputPath: trained_model_path},
+      --optimizer-name,
+      {inputValue: optimizer_name},
+      --loss-function-name,
+      {inputValue: loss_function_name},
+      --number-of-epochs,
+      {inputValue: number_of_epochs},
+      --seed,
+      {inputValue: seed},
+      --batch-size,
+      {inputValue: batch_size},
+      --metric-names,
+      {inputValue: metric_names},
+      --optimizer-parameters,
+      {inputValue: optimizer_parameters},
+      --loss-function-parameters,
+      {inputValue: loss_function_parameters},
+    ]

--- a/community-content/pipeline_components/image_ml_model_training/transcode_tfrecord_image_dataset_from_csv/component.yaml
+++ b/community-content/pipeline_components/image_ml_model_training/transcode_tfrecord_image_dataset_from_csv/component.yaml
@@ -1,0 +1,37 @@
+name: Transcode imagedataset tfrecord from csv
+description: |
+  Transcodes CSV Data into TFRecord file of TFExamples.
+  Args:
+    csv_image_data_path (str):
+        Path to the CSV image data. Data must include 'image_filepath' (Path to image file) and
+        'image_label' (output for a prediction) fields.
+    class_names (Sequence[str]):
+        Sequence of strings of categories for classification corresponding to input data.
+    tfrecord_image_data_path (str):
+        Output path for the TFRecord image data. Data will be formatted as 'label' (encoded image
+        label), and 'image_raw' (the binary string of the image data).
+inputs:
+- {name: csv_image_data_path, type: ImageDatasetCSV, description: Input path for the
+    CSV image data}
+- {name: class_names, type: 'typing.List[str]', description: List of class names corresponding
+    to the input image data}
+outputs:
+- {name: tfrecord_image_data_path, type: ImageDatasetTFRecord, description: Output
+    path for the TFRecord image data}
+implementation:
+  container:
+    image: us-docker.pkg.dev/vertex-ai/ready-to-go-image-classification/image-components:v0.1
+    # command is a list of strings (command-line arguments).
+    # The YAML language has two syntaxes for lists and you can use either of them.
+    # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+    command: [
+      python3,
+      # Path of the program inside the container
+      /pipelines/component/src/transcoding_csv_component.py,
+      --csv-image-data-path,
+      {inputPath: csv_image_data_path},
+      --tfrecord-image-data-path,
+      {outputPath: tfrecord_image_data_path},
+      --class-names,
+      {inputValue: class_names},
+    ]

--- a/community-content/pipeline_components/image_ml_model_training/transcode_tfrecord_image_dataset_from_jsonl/component.yaml
+++ b/community-content/pipeline_components/image_ml_model_training/transcode_tfrecord_image_dataset_from_jsonl/component.yaml
@@ -1,0 +1,39 @@
+name: Transcode imagedataset tfrecord from jsonlines
+description: |
+  Transcodes JSONL Data into TFRecord file of TFExamples.
+  Args:
+    jsonl_image_data_path (str):
+        Input path for the JSONL image data
+        Path to the JSONL image data. Each line corresponds to a JSON input describing an image.
+        Schema follows AutoML image classification JSONL format
+        https://cloud.google.com/vertex-ai/docs/image-data/classification/prepare-data#json-lines.
+    class_names (Sequence[str]):
+        Sequence of strings of categories for classification corresponding to input data.
+    tfrecord_image_data_path (str):
+        Output path for the TFRecord image data. Data will be formatted as 'label' (encoded image
+        label), and 'image_raw' (the binary string of the image data).
+inputs:
+- {name: jsonl_image_data_path, type: ImageDatasetJsonLines, description: Input path
+    for the JSONL image data}
+- {name: class_names, type: 'typing.List[str]', description: List of class names corresponding
+    to the input image data}
+outputs:
+- {name: tfrecord_image_data_path, type: ImageDatasetTFRecord, description: Output
+    path for the TFRecord image data}
+implementation:
+  container:
+    image: us-docker.pkg.dev/vertex-ai/ready-to-go-image-classification/image-components:v0.1
+    # command is a list of strings (command-line arguments).
+    # The YAML language has two syntaxes for lists and you can use either of them.
+    # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+    command: [
+      python3,
+      # Path of the program inside the container
+      /pipelines/component/src/transcoding_jsonl_component.py,
+      --jsonl-image-data-path,
+      {inputPath: jsonl_image_data_path},
+      --tfrecord-image-data-path,
+      {outputPath: tfrecord_image_data_path},
+      --class-names,
+      {inputValue: class_names},
+    ]


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Added image classification pipeline components in support of Ready-to-Go Vertex project.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant

3. If you are opening a PR for `Community Content` under the [community-content](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/community-content) folder:
- [x] Make sure your main `Content Directory Name` is descriptive, informative, and includes some of the key products and attributes of your content, so that it is differentiable from other content
- [x] The main content directory has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/community-content/CODEOWNERS) file under the `Community Content` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
