### PR TITLE
Fix google-api-core version to last known working version

### DIFF
--- a/.cloud-build/requirements.txt
+++ b/.cloud-build/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-storage
 google-cloud-build
 ratemate
 GitPython
+google-api-core<2.11.0


### PR DESCRIPTION
There is a breaking change with google-api-core that causes early timeouts.

Temporary workaround is to downgrade google-api-core<2.11.0

This should be reverted after google-api-core is fixed.