### PR TITLE
Fixed typo in sdk_matching_engine_for_indexing.ipynb

### DIFF
--- a/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
+++ b/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
@@ -544,7 +544,7 @@
         "        json.dumps(\n",
         "            {\n",
         "                \"id\": str(index),\n",
-        "                \"embedding\": [str(value) for value in train[index]],\n",
+        "                \"embedding\": [str(value) for value in embedding],\n",
         "                \"restricts\": [\n",
         "                    {\n",
         "                        \"namespace\": \"class\",\n",

--- a/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
+++ b/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
@@ -539,7 +539,7 @@
       "source": [
         "import json\n",
         "\n",
-        "with open(\"glove100.json\", \"w\") as f:\n",
+        "with open(\"glove100.jsonl\", \"w\") as f:\n",
         "    embeddings_formatted = [\n",
         "        json.dumps(\n",
         "            {\n",
@@ -577,7 +577,7 @@
       "outputs": [],
       "source": [
         "EMBEDDINGS_INITIAL_URI = f\"{BUCKET_URI}/matching_engine/initial/\"\n",
-        "! gsutil cp glove100.json {EMBEDDINGS_INITIAL_URI}"
+        "! gsutil cp glove100.jsonl {EMBEDDINGS_INITIAL_URI}"
       ]
     },
     {
@@ -765,7 +765,7 @@
       },
       "outputs": [],
       "source": [
-        "with open(\"glove100_incremental.json\", \"w\") as f:\n",
+        "with open(\"glove100_incremental.jsonl\", \"w\") as f:\n",
         "    index = 0\n",
         "    f.write(\n",
         "        json.dumps(\n",
@@ -812,7 +812,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil cp glove100_incremental.json {EMBEDDINGS_UPDATE_URI}"
+        "! gsutil cp glove100_incremental.jsonl {EMBEDDINGS_UPDATE_URI}"
       ]
     },
     {

--- a/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
+++ b/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb
@@ -292,8 +292,7 @@
       },
       "outputs": [],
       "source": [
-        "# VPC_NETWORK = \"[your-vpc-network-name]\"  # @param {type:\"string\"}\n",
-        "VPC_NETWORK = \"matching-engine-test\"  # @param {type:\"string\"}\n",
+        "VPC_NETWORK = \"[your-vpc-network-name]\"  # @param {type:\"string\"}\n",
         "\n",
         "PEERING_RANGE_NAME = \"ann-haystack-range\""
       ]
@@ -539,7 +538,7 @@
       "source": [
         "import json\n",
         "\n",
-        "with open(\"glove100.jsonl\", \"w\") as f:\n",
+        "with open(\"glove100.json\", \"w\") as f:\n",
         "    embeddings_formatted = [\n",
         "        json.dumps(\n",
         "            {\n",
@@ -577,7 +576,7 @@
       "outputs": [],
       "source": [
         "EMBEDDINGS_INITIAL_URI = f\"{BUCKET_URI}/matching_engine/initial/\"\n",
-        "! gsutil cp glove100.jsonl {EMBEDDINGS_INITIAL_URI}"
+        "! gsutil cp glove100.json {EMBEDDINGS_INITIAL_URI}"
       ]
     },
     {
@@ -646,7 +645,7 @@
       "outputs": [],
       "source": [
         "tree_ah_index = aiplatform.MatchingEngineIndex.create_tree_ah_index(\n",
-        "    display_name=DISPLAY_NAME_BRUTE_FORCE,\n",
+        "    display_name=DISPLAY_NAME,\n",
         "    contents_delta_uri=EMBEDDINGS_INITIAL_URI,\n",
         "    dimensions=DIMENSIONS,\n",
         "    approximate_neighbors_count=150,\n",
@@ -712,7 +711,7 @@
       "outputs": [],
       "source": [
         "brute_force_index = aiplatform.MatchingEngineIndex.create_brute_force_index(\n",
-        "    display_name=DISPLAY_NAME,\n",
+        "    display_name=DISPLAY_NAME_BRUTE_FORCE,\n",
         "    contents_delta_uri=EMBEDDINGS_INITIAL_URI,\n",
         "    dimensions=DIMENSIONS,\n",
         "    distance_measure_type=\"DOT_PRODUCT_DISTANCE\",\n",
@@ -765,7 +764,7 @@
       },
       "outputs": [],
       "source": [
-        "with open(\"glove100_incremental.jsonl\", \"w\") as f:\n",
+        "with open(\"glove100_incremental.json\", \"w\") as f:\n",
         "    index = 0\n",
         "    f.write(\n",
         "        json.dumps(\n",
@@ -812,7 +811,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil cp glove100_incremental.jsonl {EMBEDDINGS_UPDATE_URI}"
+        "! gsutil cp glove100_incremental.json {EMBEDDINGS_UPDATE_URI}"
       ]
     },
     {


### PR DESCRIPTION
Fixed typo in notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb which is functionally equivalent but unnecessary.