### PR TITLE
notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb: Fixed comment about GCS

### DIFF
--- a/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
+++ b/notebooks/official/automl/sdk_automl_tabular_forecasting_batch.ipynb
@@ -833,6 +833,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "99b7a9287ba6"
@@ -840,7 +841,7 @@
       "source": [
         "For AutoML models, manual scaling can be adjusted by setting both min and max nodes i.e., `starting_replica_count` and `max_replica_count` as the same value(in this example, set to 1). The node count can be increased or decreased as required by load.\n",
         " \n",
-        "`batch_predict` can export predictions either to BigQuery or GCS. The BigQuery options are commented out below and the predictions will be exported to the BUCKET_URI."
+        "`batch_predict` can export predictions either to BigQuery or GCS. This example exports to BigQuery."
       ]
     },
     {


### PR DESCRIPTION
Fixed misleading comment about GCS output for batch_predict.

Addresses https://github.com/GoogleCloudPlatform/vertex-ai-samples/issues/1482