### PR TITLE
Add location parameter to BigQuery client initialization so datasets …

### DIFF
--- a/notebooks/official/bigquery_ml/bqml-online-prediction.ipynb
+++ b/notebooks/official/bigquery_ml/bqml-online-prediction.ipynb
@@ -569,7 +569,7 @@
       },
       "outputs": [],
       "source": [
-        "bq_client = bigquery.Client(project=PROJECT_ID)"
+        "bq_client = bigquery.Client(project=PROJECT_ID, location=REGION)"
       ]
     },
     {


### PR DESCRIPTION
…and models are created in the user-specified region

**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Added the location parameter in the bigquery client initialization for the sample BigQueryML notebook. Otherwise, regardless of the region the user choses (in the REGION variable), the BigQuery client will default to us-central1 and will create the dataset and the ML model in that region instead.
<br><br><br>


