### PR TITLE
Add SDK support for Dask dashboard to Training

### DIFF
--- a/notebooks/official/training/xgboost_data_parallel_training_on_cpu_using_dask.ipynb
+++ b/notebooks/official/training/xgboost_data_parallel_training_on_cpu_using_dask.ipynb
@@ -833,10 +833,19 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "41ZgDYPNfEvt"
+      },
+      "source": [
+        "## Run training job with SDK (Option 1) or with gcloud (Option 2)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "PtUycdZhCJvQ"
       },
       "source": [
-        "### Initialize Vertex AI SDK"
+        "### 1.1 Initialize Vertex AI SDK"
       ]
     },
     {
@@ -860,7 +869,16 @@
         "id": "_GB2j39BCXiy"
       },
       "source": [
-        "### Run a Vertex AI SDK CustomContainerTrainingJob"
+        "### 1.2 Run a Vertex AI SDK CustomContainerTrainingJob"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7udaU3jxfKs8"
+      },
+      "source": [
+        "You can specify the fields enable_web_access and enable_dashboard_access. enable_web_access enables the interactive shell for the job and enable_dashboard_access allows the dask dashboard to be accessed."
       ]
     },
     {
@@ -887,6 +905,8 @@
         "    base_output_dir=gcs_output_uri_prefix,\n",
         "    replica_count=replica_count,\n",
         "    machine_type=machine_type,\n",
+        "    enable_dashboard_access=True,\n",
+        "    enable_web_access=True,\n",
         ")"
       ]
     },
@@ -908,7 +928,7 @@
         "id": "tVktIbToRpmR"
       },
       "source": [
-        "### Access the Dask dashboard"
+        "### 2. Run a CustomContainerTraining Job with gcloud"
       ]
     },
     {
@@ -975,10 +995,30 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "HAYihHT9ff9q"
+      },
+      "source": [
+        "### Access the dashboard and interactive shell (with option 1 or option 2)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "onb40Ge0SVKh"
       },
       "source": [
-        "Once the job is created. You can use the output `gcloud ai custom-jobs describe` command to print the field webAccessUris. The interactive shell has the key with the format \"workerpool0-0\", while the dashboard uri has the key with the format \"workerpool0-0:\" + port number. Note: You have to access the links while the job is running."
+        "Once the job is created (either with the SDK or with gcloud command), you can access the web access URI and dashboard access URI by using the `gcloud ai custom-jobs describe` command to print the field webAccessUris. The interactive shell has the key with the format \"workerpool0-0\", while the dashboard uri has the key with the format \"workerpool0-0:\" + port number (workerpool0-0:8888 in this example)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3OaiNHG5fcw0"
+      },
+      "source": [
+        "You also can find the links in the Google Cloud console UI. In the Google Cloud console, in the Vertex AI section, go to Training and then Custom Jobs. Click the name of your custom training job. On the page for your job, click \"Launch web terminal\" for \"workerpool0-0\" for web access, or click \"Launch web terminal\" for \"workerpool0-0:\" + port number for dashboard access.\n",
+        "\n",
+        "Note that you can only access an interactive shell and dashboard while the job is running. If you don't see Launch web terminal in the UI or the URIs in the output of the gcloud command, this might be because Vertex AI hasn't started running your job yet, or because the job has already finished or failed. If the job's Status is Queued or Pending, wait a minute; then try refreshing the page, or trying the gcloud command again."
       ]
     },
     {

--- a/notebooks/official/training/xgboost_data_parallel_training_on_cpu_using_dask.ipynb
+++ b/notebooks/official/training/xgboost_data_parallel_training_on_cpu_using_dask.ipynb
@@ -878,7 +878,7 @@
         "id": "7udaU3jxfKs8"
       },
       "source": [
-        "You can specify the fields enable_web_access and enable_dashboard_access. enable_web_access enables the interactive shell for the job and enable_dashboard_access allows the dask dashboard to be accessed."
+        "You can specify the fields enable_web_access and enable_dashboard_access. The enable_web_access enables the interactive shell for the job and enable_dashboard_access allows the dask dashboard to be accessed."
       ]
     },
     {
@@ -937,7 +937,7 @@
         "id": "uVvxLj8GRsM6"
       },
       "source": [
-        "You can also create a training job with gcloud command.  With gcloud command, you can specify the field enableWebAccess and enableDashboardAccess. enableWebAccess enables the interactive shell for the job and enableDashboardAccess allows the dask dashboard to be accessed."
+        "You can also create a training job with the gcloud command.  With the gcloud command, you can specify the field enableWebAccess and enableDashboardAccess. The enableWebAccess enables the interactive shell for the job and enableDashboardAccess allows the dask dashboard to be accessed."
       ]
     },
     {
@@ -998,25 +998,11 @@
         "id": "HAYihHT9ff9q"
       },
       "source": [
-        "### Access the dashboard and interactive shell (with option 1 or option 2)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "onb40Ge0SVKh"
-      },
-      "source": [
-        "Once the job is created (either with the SDK or with gcloud command), you can access the web access URI and dashboard access URI by using the `gcloud ai custom-jobs describe` command to print the field webAccessUris. The interactive shell has the key with the format \"workerpool0-0\", while the dashboard uri has the key with the format \"workerpool0-0:\" + port number (workerpool0-0:8888 in this example)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3OaiNHG5fcw0"
-      },
-      "source": [
-        "You also can find the links in the Google Cloud console UI. In the Google Cloud console, in the Vertex AI section, go to Training and then Custom Jobs. Click the name of your custom training job. On the page for your job, click \"Launch web terminal\" for \"workerpool0-0\" for web access, or click \"Launch web terminal\" for \"workerpool0-0:\" + port number for dashboard access.\n",
+        "### Access the dashboard and interactive shell\n",
+	"\n",
+        "Once the job is created, you can access the web access URI and dashboard access URI by using the `gcloud ai custom-jobs describe` command to print the field webAccessUris. The interactive shell has the key with the format \"workerpool0-0\", while the dashboard uri has the key with the format \"workerpool0-0:\" + port number (workerpool0-0:8888 in this example).\n",
+	"\n",
+        "You also can find the links in the Cloud Console UI. In the Cloud Console UI, in the Vertex AI section, go to Training and then Custom Jobs. Click on the name of your custom training job. On the page for your job, click \"Launch web terminal\" for \"workerpool0-0\" for web access, or click \"Launch web terminal\" for \"workerpool0-0:\" + port number for dashboard access.\n",
         "\n",
         "Note that you can only access an interactive shell and dashboard while the job is running. If you don't see Launch web terminal in the UI or the URIs in the output of the gcloud command, this might be because Vertex AI hasn't started running your job yet, or because the job has already finished or failed. If the job's Status is Queued or Pending, wait a minute; then try refreshing the page, or trying the gcloud command again."
       ]

--- a/notebooks/official/training/xgboost_data_parallel_training_on_cpu_using_dask.ipynb
+++ b/notebooks/official/training/xgboost_data_parallel_training_on_cpu_using_dask.ipynb
@@ -999,9 +999,9 @@
       },
       "source": [
         "### Access the dashboard and interactive shell\n",
-	"\n",
+        "\n",
         "Once the job is created, you can access the web access URI and dashboard access URI by using the `gcloud ai custom-jobs describe` command to print the field webAccessUris. The interactive shell has the key with the format \"workerpool0-0\", while the dashboard uri has the key with the format \"workerpool0-0:\" + port number (workerpool0-0:8888 in this example).\n",
-	"\n",
+        "\n",
         "You also can find the links in the Cloud Console UI. In the Cloud Console UI, in the Vertex AI section, go to Training and then Custom Jobs. Click on the name of your custom training job. On the page for your job, click \"Launch web terminal\" for \"workerpool0-0\" for web access, or click \"Launch web terminal\" for \"workerpool0-0:\" + port number for dashboard access.\n",
         "\n",
         "Note that you can only access an interactive shell and dashboard while the job is running. If you don't see Launch web terminal in the UI or the URIs in the output of the gcloud command, this might be because Vertex AI hasn't started running your job yet, or because the job has already finished or failed. If the job's Status is Queued or Pending, wait a minute; then try refreshing the page, or trying the gcloud command again."


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Added the option for users to specify the enable_dashboard_access and enable_web_access fields when creating a custom Training job with the SDK for Dask. We provide an example for the user to specify these fields using the SDK or using the gcloud command to create the custom Training job, and additionally provide instructions on how to access the dashboard and interactive shell. 
<br><br><br>
