### PR TITLE
fix: copy CPR model server to users project before using

### DIFF
--- a/notebooks/community/prediction/feature_store_integration/prediction_feature_store_integration.ipynb
+++ b/notebooks/community/prediction/feature_store_integration/prediction_feature_store_integration.ipynb
@@ -1470,7 +1470,79 @@
         "id": "46c332abbe7a"
       },
       "source": [
-        "Using the same feature fetch config file as in the previous example, let's now use it with the Identity model server to debug it."
+        "Using the same feature fetch config file as in the previous example, deploy it with the Identity model server to debug.\n",
+        "\n",
+        "First copy the image to Artifacts Registry."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "962c1cfe1588"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud services enable artifactregistry.googleapis.com"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "639b2d067827"
+      },
+      "outputs": [],
+      "source": [
+        "REPOSITORY = \"feature-store-prediction-sample\"\n",
+        "IMAGE = \"cpr-identity-server\"\n",
+        "CONTAINER_URI = f\"{REGION}-docker.pkg.dev/{PROJECT_ID}/{REPOSITORY}/{IMAGE}\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6523af67c1ab"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud artifacts repositories create {REPOSITORY} \\\n",
+        "    --repository-format=docker \\\n",
+        "    --location=$REGION"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "b3b939dc0b25"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud auth configure-docker {REGION}-docker.pkg.dev --quiet"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "34c1cec95124"
+      },
+      "outputs": [],
+      "source": [
+        "!docker pull us-docker.pkg.dev/vertex-ai/sample-model-servers/cpr-identity-server:latest\n",
+        "!docker tag us-docker.pkg.dev/vertex-ai/sample-model-servers/cpr-identity-server:latest $CONTAINER_URI\n",
+        "!docker push $CONTAINER_URI"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d4c81e1eb726"
+      },
+      "source": [
+        "Now upload and deploy the identity model to Vertex Prediction for debugging."
       ]
     },
     {
@@ -1486,7 +1558,7 @@
         "identity_model = aiplatform.Model.upload(\n",
         "    display_name=IDENTITY_MODEL_DISPLAY_NAME,\n",
         "    artifact_uri=ARTIFACT_URI,\n",
-        "    serving_container_image_uri=\"us-docker.pkg.dev/vertex-ai/sample-model-servers/cpr-identity-server:latest\",\n",
+        "    serving_container_image_uri=CONTAINER_URI,\n",
         "    sync=False,\n",
         ")\n",
         "\n",


### PR DESCRIPTION
CPR model server in feature store and prediction integration notebook sample must be copied to the user's project before using with the Prediction service.