### PR TITLE
Fixed broken markdown in matching engine notebooks

### DIFF
--- a/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings.ipynb
+++ b/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings.ipynb
@@ -629,6 +629,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ba45d58bf96e"
@@ -638,7 +639,7 @@
         "\n",
         "Encode a subset of data and see if the embeddings and distance metrics make sense.\n",
         "\n",
-        "According to (sentence-T5 research paper)[https://arxiv.org/pdf/2108.08877.pdf], the similarity of embeddings is calculated using the dot-product. "
+        "According to the [sentence-T5 research paper](https://arxiv.org/pdf/2108.08877.pdf), the similarity of embeddings is calculated using the dot-product. "
       ]
     },
     {

--- a/notebooks/official/matching_engine/sdk_matching_engine_create_text_to_image_embeddings.ipynb
+++ b/notebooks/official/matching_engine/sdk_matching_engine_create_text_to_image_embeddings.ipynb
@@ -614,6 +614,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ba45d58bf96e"
@@ -623,7 +624,7 @@
         "\n",
         "Encode a subset of data and see if the embeddings and distance metrics make sense.\n",
         "\n",
-        "According to the (CLIP research paper)[https://arxiv.org/pdf/2103.00020.pdf], the similarities of embeddings are calculated using the cosine similarity."
+        "According to the [CLIP research paper](https://arxiv.org/pdf/2103.00020.pdf), the similarities of embeddings are calculated using the cosine similarity."
       ]
     },
     {
@@ -933,22 +934,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 29,
+      "execution_count": null,
       "metadata": {
         "id": "17jrQi501QyX"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "'projects/1012616486416/locations/us-central1/indexes/1027779489179893760'"
-            ]
-          },
-          "execution_count": 29,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "INDEX_RESOURCE_NAME = tree_ah_index.resource_name\n",
         "INDEX_RESOURCE_NAME"


### PR DESCRIPTION
Fixed broken markdown in matching engine notebooks in the link to papers.