### PR TITLE
Specifying Python Version and Package Pins for pytorch_image_classification_with_prebuilt_serving_containers.ipynb

### DIFF
--- a/notebooks/official/prediction/pytorch_image_classification_with_prebuilt_serving_containers.ipynb
+++ b/notebooks/official/prediction/pytorch_image_classification_with_prebuilt_serving_containers.ipynb
@@ -55,6 +55,15 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**_NOTE_**: This notebook has been tested in the following environment:\n",
+        "\n",
+        "* Python version = 3.9"
+      ]
+    },
+    {
       "attachments": {},
       "cell_type": "markdown",
       "metadata": {
@@ -147,11 +156,12 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
-        "                                 tensorflow \\\n",
-        "                                 torch \\\n",
-        "                                 torchvision \\\n",
-        "                                 torch-model-archiver"
+        "! pip3 install --upgrade --quiet google-cloud-aiplatform==1.23.0 \\\n",
+        "                                 tensorflow==2.12.0 \\\n",
+        "                                 torch==2.0.0 \\\n",
+        "                                 torchvision==0.15.1 \\\n",
+        "                                 torch-model-archiver==0.7.1 \\\n",
+        "                                 packaging==14.3"
       ]
     },
     {


### PR DESCRIPTION
<br>
Specifying Python Version and Package Pins for pytorch_image_classification_with_prebuilt_serving_containers.ipynb
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [X] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [X] Follow the style and grammar rules outlined in the above notebook template.
- [X] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [X] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [X] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [X] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [X] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.