### PR TITLE
Add a trailing slash to Model Garden ICN notebook checkpoint destination URI

### DIFF
--- a/notebooks/community/model_garden/model_garden_tfvision_image_classification.ipynb
+++ b/notebooks/community/model_garden/model_garden_tfvision_image_classification.ipynb
@@ -405,7 +405,7 @@
         "                checkpoint_path = os.path.relpath(checkpoint_path, checkpoint_name)\n",
         "                break\n",
         "\n",
-        "    ! gsutil cp -r $checkpoint_name $CHECKPOINT_BUCKET\n",
+        "    ! gsutil cp -r $checkpoint_name $CHECKPOINT_BUCKET/\n",
         "    checkpoint_uri = os.path.join(CHECKPOINT_BUCKET, checkpoint_name, checkpoint_path)\n",
         "    print(\"Checkpoint uploaded to\", checkpoint_uri)\n",
         "    return checkpoint_uri"


### PR DESCRIPTION
This is required due to the inconsistent behavior of `gsutil cp`:

Suppose we have:
```
./a/a/1.txt
```
And we run:
```
gsutil cp -r ./a gs://bucket/dir
```
Then the destination is undeterministic:

- If `gs://bucket/dir` already existed, then 1.txt will be copied to `gs://bucket/dir/a/a/1.txt`.
- If `gs://bucket/dir` does not exist, then 1.txt will be copied to `gs://bucket/dir/a/1.txt`.
By adding a trailing slash to `gs://bucket/dir/`, we enforce the first behavior.
<br><br><br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
