### PR TITLE
Fix prediction routes for pytorch notebooks

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_blip_image_captioning.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_blip_image_captioning.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_blip_vqa.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_blip_vqa.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_clip.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_clip.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_layoutml_document_qa.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_layoutml_document_qa.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_owlvit.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_owlvit.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_vilt_vqa.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_vilt_vqa.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_vit_gpt2_image_captioning.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_vit_gpt2_image_captioning.ipynb
@@ -282,7 +282,7 @@
         "        display_name=model_name,\n",
         "        serving_container_image_uri=SERVE_DOCKER_URI,\n",
         "        serving_container_ports=[7080],\n",
-        "        serving_container_predict_route=\"/predictions/diffusers_serving\",\n",
+        "        serving_container_predict_route=\"/predictions/transformers_serving\",\n",
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "        artifact_uri=artifact_uri,\n",


### PR DESCRIPTION
**REQUIRED:** Fix prediction routes for pytorch notebooks

**REQUIRED:** Fill out the below checklists or remove if irrelevant
2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [y ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ y] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

