### PR TITLE
pin GCPC and KFP SDK versions in official pipelines notebooks

### DIFF
--- a/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
+++ b/notebooks/official/pipelines/automl_tabular_classification_beans.ipynb
@@ -201,8 +201,8 @@
         "\n",
         "! pip3 install --upgrade {USER_FLAG} google-cloud-aiplatform \\\n",
         "                                    google-cloud-storage \\\n",
-        "                                    kfp \\\n",
-        "                                    google-cloud-pipeline-components -q"
+        "                                    'kfp<2' \\\n",
+        "                                    'google-cloud-pipeline-components<2' -q"
       ]
     },
     {
@@ -1162,6 +1162,10 @@
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.7.12"
     }
   },
   "nbformat": 4,

--- a/notebooks/official/pipelines/challenger_vs_blessed_deployment_method.ipynb
+++ b/notebooks/official/pipelines/challenger_vs_blessed_deployment_method.ipynb
@@ -165,11 +165,11 @@
         "# Install the packages\n",
         "USER=''\n",
         "! pip3 install {USER} --upgrade google-cloud-aiplatform \\\n",
-        "                                google-cloud-pipeline-components\n",
+        "                                'google-cloud-pipeline-components<2'\n",
         "! pip3 install {USER}           tensorflow==2.5 \\\n",
         "                                tensorflow_hub\n",
         "  \n",
-        "! pip3 install {USER} --upgrade kfp"
+        "! pip3 install {USER} --upgrade 'kfp<2'"
       ]
     },
     {

--- a/notebooks/official/pipelines/control_flow_kfp.ipynb
+++ b/notebooks/official/pipelines/control_flow_kfp.ipynb
@@ -175,7 +175,7 @@
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
         "! pip3 install -U google-cloud-storage {USER_FLAG} -q\n",
-        "! pip3 install {USER_FLAG} kfp google-cloud-pipeline-components --upgrade -q"
+        "! pip3 install {USER_FLAG} 'kfp<2' 'google-cloud-pipeline-components<2' --upgrade -q"
       ]
     },
     {

--- a/notebooks/official/pipelines/custom_model_training_and_batch_prediction.ipynb
+++ b/notebooks/official/pipelines/custom_model_training_and_batch_prediction.ipynb
@@ -197,10 +197,10 @@
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
         "! pip3 install -U google-cloud-storage {USER_FLAG} -q\n",
-        "! pip3 install {USER_FLAG} kfp google-cloud-pipeline-components --upgrade -q\n",
+        "! pip3 install {USER_FLAG} 'kfp<2' 'google-cloud-pipeline-components<2' --upgrade -q\n",
         "\n",
         "\n",
-        "! pip3 install --upgrade --force-reinstall $USER_FLAG tensorflow kfp google-cloud-aiplatform google-cloud-storage google-cloud-pipeline-components -q"
+        "! pip3 install --upgrade --force-reinstall $USER_FLAG tensorflow 'kfp<2' google-cloud-aiplatform google-cloud-storage 'google-cloud-pipeline-components<2' -q"
       ]
     },
     {

--- a/notebooks/official/pipelines/custom_tabular_train_batch_pred_bq_pipeline.ipynb
+++ b/notebooks/official/pipelines/custom_tabular_train_batch_pred_bq_pipeline.ipynb
@@ -224,8 +224,8 @@
         "                            google-cloud-bigquery \\\n",
         "                            pandas \\\n",
         "                            pyarrow \\\n",
-        "                            kfp \\\n",
-        "                            google-cloud-pipeline-components {USER_FLAG} -q \n",
+        "                            'kfp<2' \\\n",
+        "                            'google-cloud-pipeline-components<2' {USER_FLAG} -q \n",
         "! pip3 install db-dtypes {USER_FLAG} -q"
       ]
     },

--- a/notebooks/official/pipelines/get_started_with_hpt_pipeline_components.ipynb
+++ b/notebooks/official/pipelines/get_started_with_hpt_pipeline_components.ipynb
@@ -149,8 +149,8 @@
         "! pip3 install -U tensorflow-transform==1.2  -q\n",
         "! pip3 install -U tensorflow-io==0.18  -q\n",
         "! pip3 install --upgrade google-cloud-aiplatform[tensorboard] -q\n",
-        "! pip3 install --upgrade google-cloud-pipeline-components  -q\n",
-        "! pip3 install --upgrade kfp -q"
+        "! pip3 install --upgrade 'google-cloud-pipeline-components<2'  -q\n",
+        "! pip3 install --upgrade 'kfp<2' -q"
       ]
     },
     {

--- a/notebooks/official/pipelines/get_started_with_machine_management.ipynb
+++ b/notebooks/official/pipelines/get_started_with_machine_management.ipynb
@@ -138,8 +138,8 @@
         "import os\n",
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform \\\n",
-        "                         google-cloud-pipeline-components --quiet\n",
-        "! pip3 install --upgrade kfp --quiet\n",
+        "                         'google-cloud-pipeline-components<2' --quiet\n",
+        "! pip3 install --upgrade 'kfp<2' --quiet\n",
         "! pip3 install --upgrade tensorflow==2.7 --quiet"
       ]
     },

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_images.ipynb
@@ -193,7 +193,7 @@
         "if IS_WORKBENCH_NOTEBOOK:\n",
         "    USER_FLAG = \"--user\"\n",
         "\n",
-        "! pip3 install --upgrade --quiet {USER_FLAG} google-cloud-aiplatform kfp google-cloud-pipeline-components google-cloud-storage"
+        "! pip3 install --upgrade --quiet {USER_FLAG} google-cloud-aiplatform 'kfp<2' 'google-cloud-pipeline-components<2' google-cloud-storage"
       ]
     },
     {

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
@@ -198,7 +198,7 @@
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform \\\n",
         "                        google-cloud-storage \\\n",
-        "                        $USER kfp google-cloud-pipeline-components -q "
+        "                        $USER 'kfp<2' 'google-cloud-pipeline-components<2' -q "
       ]
     },
     {

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_text.ipynb
@@ -196,7 +196,7 @@
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
         "! pip3 install -U google-cloud-storage $USER_FLAG -q\n",
-        "! pip3 install $USER kfp google-cloud-pipeline-components --upgrade -q"
+        "! pip3 install $USER 'kfp<2' 'google-cloud-pipeline-components<2' --upgrade -q"
       ]
     },
     {

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
@@ -198,8 +198,8 @@
         "\n",
         "! pip3 install --upgrade {USER_FLAG} -q google-cloud-aiplatform \\\n",
         "                                        google-cloud-storage {USER_FLAG} \\\n",
-        "                                        kfp \\\n",
-        "                                        google-cloud-pipeline-components"
+        "                                        'kfp<2' \\\n",
+        "                                        'google-cloud-pipeline-components<2'"
       ]
     },
     {

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_model_upload_predict_evaluate.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_model_upload_predict_evaluate.ipynb
@@ -199,8 +199,8 @@
         "\n",
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform \\\n",
-        "                        google-cloud-pipeline-components \\\n",
-        "                        kfp $USER_FLAG -q"
+        "                        'google-cloud-pipeline-components<2' \\\n",
+        "                        'kfp<2' $USER_FLAG -q"
       ]
     },
     {

--- a/notebooks/official/pipelines/lightweight_functions_component_io_kfp.ipynb
+++ b/notebooks/official/pipelines/lightweight_functions_component_io_kfp.ipynb
@@ -203,7 +203,7 @@
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
         "! pip3 install -U google-cloud-storage {USER_FLAG} -q\n",
-        "! pip3 install {USER_FLAG} kfp google-cloud-pipeline-components --upgrade -q"
+        "! pip3 install {USER_FLAG} 'kfp<2' 'google-cloud-pipeline-components<2' --upgrade -q"
       ]
     },
     {

--- a/notebooks/official/pipelines/metrics_viz_run_compare_kfp.ipynb
+++ b/notebooks/official/pipelines/metrics_viz_run_compare_kfp.ipynb
@@ -201,7 +201,7 @@
         "\n",
         "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
         "! pip3 install -U google-cloud-storage {USER_FLAG} -q\n",
-        "! pip3 install {USER_FLAG} kfp google-cloud-pipeline-components --upgrade -q\n",
+        "! pip3 install {USER_FLAG} 'kfp<2' 'google-cloud-pipeline-components<2' --upgrade -q\n",
         "\n",
         "if os.getenv(\"IS_TESTING\"):\n",
         "    ! pip3 install --upgrade matplotlib $USER_FLAG -q"

--- a/notebooks/official/pipelines/multicontender_vs_champion_deployment_method.ipynb
+++ b/notebooks/official/pipelines/multicontender_vs_champion_deployment_method.ipynb
@@ -168,11 +168,11 @@
         "# Install the packages\n",
         "USER=''\n",
         "! pip3 install {USER} --upgrade google-cloud-aiplatform \\\n",
-        "                                google-cloud-pipeline-components\n",
+        "                                'google-cloud-pipeline-components<2'\n",
         "! pip3 install {USER}           tensorflow==2.5 \\\n",
         "                                tensorflow_hub\n",
         "\n",
-        "! pip3 install {USER} --upgrade kfp"
+        "! pip3 install {USER} --upgrade 'kfp<2'"
       ]
     },
     {

--- a/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
+++ b/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
@@ -128,8 +128,8 @@
         "# Install the packages\n",
         "! pip3 install --upgrade google-cloud-aiplatform \\\n",
         "                        google-cloud-storage \\\n",
-        "                        kfp \\\n",
-        "                        google-cloud-pipeline-components"
+        "                        'kfp<2' \\\n",
+        "                        'google-cloud-pipeline-components<2'"
       ]
     },
     {

--- a/notebooks/official/pipelines/rapid_prototyping_bqml_automl.ipynb
+++ b/notebooks/official/pipelines/rapid_prototyping_bqml_automl.ipynb
@@ -265,7 +265,7 @@
       "source": [
         "# Install Python package dependencies.\n",
         "print(\"Installing libraries\")\n",
-        "! pip3 install {USER_FLAG} --quiet google-cloud-pipeline-components kfp\n",
+        "! pip3 install {USER_FLAG} --quiet 'google-cloud-pipeline-components<2' 'kfp<2'\n",
         "! pip3 install {USER_FLAG} --quiet --upgrade google-cloud-aiplatform google-cloud-bigquery"
       ]
     },


### PR DESCRIPTION
Pins `kfp` and `google-cloud-pipeline-components` both to `<2` to prevent an accidental major version upgrade when `kfp` and `google-cloud-pipeline-components` major versions 2 GA.
