### PR TITLE
Replace gsutil with cloud API in pytorch notebooks

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_stable_diffusion.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_stable_diffusion.ipynb
@@ -142,9 +142,7 @@
       "outputs": [],
       "source": [
         "# Install gdown for downloading example training images.\n",
-        "!pip install gdown\n",
-        "# Install gsutil for downloading/uploading data from/to Cloud Storage buckets.\n",
-        "!pip install gsutil"
+        "!pip install gdown"
       ]
     },
     {
@@ -278,12 +276,13 @@
       "outputs": [],
       "source": [
         "import base64\n",
+        "import glob\n",
         "import os\n",
         "from datetime import datetime\n",
         "from io import BytesIO\n",
         "\n",
         "import requests\n",
-        "from google.cloud import aiplatform\n",
+        "from google.cloud import aiplatform, storage\n",
         "from PIL import Image\n",
         "\n",
         "\n",
@@ -344,7 +343,29 @@
         "        accelerator_count=1,\n",
         "        deploy_request_timeout=1800,\n",
         "    )\n",
-        "    return model, endpoint"
+        "    return model, endpoint\n",
+        "\n",
+        "\n",
+        "def get_bucket_and_blob_name(filepath):\n",
+        "    # The gcs path is of the form gs://<bucket-name>/<blob-name>\n",
+        "    gs_suffix = filepath.split(\"gs://\", 1)[1]\n",
+        "    return tuple(gs_suffix.split(\"/\", 1))\n",
+        "\n",
+        "\n",
+        "def upload_local_dir_to_gcs(local_dir_path, gcs_dir_path):\n",
+        "    \"\"\"Uploads files in a local directory to a GCS directory.\"\"\"\n",
+        "    client = storage.Client()\n",
+        "    bucket_name = gcs_dir_path.split(\"/\")[2]\n",
+        "    bucket = client.get_bucket(bucket_name)\n",
+        "    for local_file in glob.glob(local_dir_path + \"/**\"):\n",
+        "        if not os.path.isfile(local_file):\n",
+        "            continue\n",
+        "        filename = local_file[1 + len(local_dir_path) :]\n",
+        "        gcs_file_path = os.path.join(gcs_dir_path, filename)\n",
+        "        _, blob_name = get_bucket_and_blob_name(gcs_file_path)\n",
+        "        blob = bucket.blob(blob_name)\n",
+        "        blob.upload_from_filename(local_file)\n",
+        "        print(\"Copied {} to {}.\".format(local_file, gcs_file_path))"
       ]
     },
     {
@@ -381,8 +402,8 @@
         "!gdown --folder https://drive.google.com/drive/folders/1BO_dyz-p65qhBRRMRA4TbZ8qW4rB99JZ\n",
         "\n",
         "# Upload data to Cloud Storage bucket.\n",
-        "!gsutil -m cp -r dog/* gs://{GCS_BUCKET}/dreambooth/dog/\n",
-        "!gsutil -m cp -r dog/* gs://{GCS_BUCKET}/dreambooth/dog_class/"
+        "upload_local_dir_to_gcs(\"dog\", f\"gs://{GCS_BUCKET}/dreambooth/dog\")\n",
+        "upload_local_dir_to_gcs(\"dog\", f\"gs://{GCS_BUCKET}/dreambooth/dog_class\")"
       ]
     },
     {

--- a/notebooks/community/model_garden/model_garden_pytorch_stable_diffusion_inpainting.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_stable_diffusion_inpainting.ipynb
@@ -142,9 +142,7 @@
       "outputs": [],
       "source": [
         "# Install gdown for downloading example training images.\n",
-        "!pip install gdown\n",
-        "# Install gsutil for downloading/uploading data from/to Cloud Storage buckets.\n",
-        "!pip install gsutil"
+        "!pip install gdown"
       ]
     },
     {
@@ -278,12 +276,13 @@
       "outputs": [],
       "source": [
         "import base64\n",
+        "import glob\n",
         "import os\n",
         "from datetime import datetime\n",
         "from io import BytesIO\n",
         "\n",
         "import requests\n",
-        "from google.cloud import aiplatform\n",
+        "from google.cloud import aiplatform, storage\n",
         "from PIL import Image\n",
         "\n",
         "\n",
@@ -344,7 +343,29 @@
         "        accelerator_count=1,\n",
         "        deploy_request_timeout=1800,\n",
         "    )\n",
-        "    return model, endpoint"
+        "    return model, endpoint\n",
+        "\n",
+        "\n",
+        "def get_bucket_and_blob_name(filepath):\n",
+        "    # The gcs path is of the form gs://<bucket-name>/<blob-name>\n",
+        "    gs_suffix = filepath.split(\"gs://\", 1)[1]\n",
+        "    return tuple(gs_suffix.split(\"/\", 1))\n",
+        "\n",
+        "\n",
+        "def upload_local_dir_to_gcs(local_dir_path, gcs_dir_path):\n",
+        "    \"\"\"Uploads files in a local directory to a GCS directory.\"\"\"\n",
+        "    client = storage.Client()\n",
+        "    bucket_name = gcs_dir_path.split(\"/\")[2]\n",
+        "    bucket = client.get_bucket(bucket_name)\n",
+        "    for local_file in glob.glob(local_dir_path + \"/**\"):\n",
+        "        if not os.path.isfile(local_file):\n",
+        "            continue\n",
+        "        filename = local_file[1 + len(local_dir_path) :]\n",
+        "        gcs_file_path = os.path.join(gcs_dir_path, filename)\n",
+        "        _, blob_name = get_bucket_and_blob_name(gcs_file_path)\n",
+        "        blob = bucket.blob(blob_name)\n",
+        "        blob.upload_from_filename(local_file)\n",
+        "        print(\"Copied {} to {}.\".format(local_file, gcs_file_path))"
       ]
     },
     {
@@ -381,8 +402,8 @@
         "!gdown --folder https://drive.google.com/drive/folders/1BO_dyz-p65qhBRRMRA4TbZ8qW4rB99JZ\n",
         "\n",
         "# Upload data to Cloud Storage bucket.\n",
-        "!gsutil -m cp -r dog/* gs://{GCS_BUCKET}/dreambooth/dog/\n",
-        "!gsutil -m cp -r dog/* gs://{GCS_BUCKET}/dreambooth/dog_class/"
+        "upload_local_dir_to_gcs(\"dog\", f\"gs://{GCS_BUCKET}/dreambooth/dog\")\n",
+        "upload_local_dir_to_gcs(\"dog\", f\"gs://{GCS_BUCKET}/dreambooth/dog_class\")"
       ]
     },
     {


### PR DESCRIPTION
Replace gsutil with cloud API in pytorch notebooks

**REQUIRED:** Fill out the below checklists or remove if irrelevant

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [y ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ y] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

