### PR TITLE
Add service account config to TIMM notebook

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
@@ -104,7 +104,9 @@
         "\n",
         "1. [Create a Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets) for storing experiment outputs.\n",
         "\n",
-        "1. [Enable the Vertex AI API and Compute Engine API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com,compute_component)."
+        "1. [Enable the Vertex AI API and Compute Engine API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com,compute_component).\n",
+        "\n",
+        "1. [Create a service account](https://cloud.google.com/iam/docs/service-accounts-create#iam-service-accounts-create-console) with `Vertex AI User` and `Storage Object Admin` roles for deploying fine tuned model to Vertex AI endpoint."
       ]
     },
     {
@@ -193,13 +195,18 @@
         "# The region for running jobs.\n",
         "REGION = \"us-central1\"  # @param {type:\"string\"}\n",
         "\n",
-        "# The model you want to train and serve.\n",
+        "# The model you want to train and serve. Please select a model from the verified model list above.\n",
         "# We use a ViT model as the example.\n",
         "MODEL_NAME = \"vit_tiny_patch16_224\"  # @param {type:\"string\"}\n",
         "\n",
         "# The Cloud Storage bucket name without gs:// prefix for training outputs.\n",
         "# For example: test_bucket\n",
-        "GCS_BUCKET = \"\"  # @param {type:\"string\"}"
+        "GCS_BUCKET = \"\"  # @param {type:\"string\"}\n",
+        "\n",
+        "# The service account for deploying fine tuned model. It looks like:\n",
+        "# '<account_name>@<project>.iam.gserviceaccount.com'\n",
+        "# Follow step 6 above to create this account.\n",
+        "SERVICE_ACCOUNT = \"\"  # @param {type:\"string\"}"
       ]
     },
     {
@@ -225,7 +232,7 @@
       },
       "outputs": [],
       "source": [
-        "# The training docker uri.\n",
+        "# The prebuilt training docker uri.\n",
         "TRAIN_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/pytorch-timm-train\"\n",
         "\n",
         "# The path to data directory on Cloud Storage without gs:// prefix.\n",
@@ -265,8 +272,8 @@
         "# Single node with multiple GPUs.\n",
         "machine_type = \"n1-highmem-32\"\n",
         "num_nodes = 1\n",
-        "gpu_type = \"NVIDIA_TESLA_P100\"\n",
-        "num_gpus = 4\n",
+        "gpu_type = \"NVIDIA_TESLA_P100\"  # @param {type:\"string\"}\n",
+        "num_gpus = 4  # @param {type:\"integer\"}\n",
         "\n",
         "# Model specific config.\n",
         "job_name = f\"pytorch-{MODEL_NAME}\"\n",
@@ -336,8 +343,8 @@
         "# Worker pool spec.\n",
         "machine_type = \"n1-highmem-16\"\n",
         "num_nodes = 1\n",
-        "gpu_type = \"NVIDIA_TESLA_V100\"\n",
-        "num_gpus = 2\n",
+        "gpu_type = \"NVIDIA_TESLA_V100\"  # @param {type:\"string\"}\n",
+        "num_gpus = 2  # @param {type:\"integer\"}\n",
         "worker_pool_specs = [\n",
         "    {\n",
         "        \"machine_spec\": {\n",
@@ -408,19 +415,14 @@
       },
       "outputs": [],
       "source": [
-        "# The serve docker uri.\n",
+        "# The prebuilt serving docker uri.\n",
         "SERVE_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/pytorch-timm-serve\"\n",
         "# The port number used by torchserve traffic.\n",
         "SERVE_PORT = 7080\n",
         "# The path to model checkpoint file, including gs:// prefix.\n",
         "MODEL_PT_PATH = \"gs://path_to_model_best.pth.tar\"  # @param {type:\"string\"}\n",
         "# [Optional] the path to index_to_name.json, including gs:// prefix.\n",
-        "INDEX_TO_NAME_FILE = \"gs://path_to_index_to_name.json\"  # @param {type:\"string\"}\n",
-        "\n",
-        "# Converts gs:// uris to /gcs/ to use GCS Fuse.\n",
-        "# See https://github.com/GoogleCloudPlatform/gcsfuse.\n",
-        "MODEL_PT_PATH = MODEL_PT_PATH.replace(\"gs://\", \"/gcs/\")\n",
-        "INDEX_TO_NAME_FILE = INDEX_TO_NAME_FILE.replace(\"gs://\", \"/gcs/\")"
+        "INDEX_TO_NAME_FILE = \"gs://path_to_index_to_name.json\"  # @param {type:\"string\"}"
       ]
     },
     {
@@ -469,6 +471,7 @@
         "    accelerator_type=\"NVIDIA_TESLA_T4\",\n",
         "    accelerator_count=1,\n",
         "    traffic_percentage=100,\n",
+        "    service_account=SERVICE_ACCOUNT,\n",
         ")"
       ]
     },
@@ -506,10 +509,10 @@
         "# endpoint = aiplatform.Endpoint('projects/816369962409/locations/us-central1/endpoints/8809168414485512192')\n",
         "\n",
         "# Please upload an image and enter its filename below.\n",
-        "IMAGE_FILENAME = \"cat.jpg\"  # @param {type:\"string\"}\n",
+        "IMAGE_FILENAME = \"test.jpg\"  # @param {type:\"string\"}\n",
         "\n",
-        "# Alternatively, uncomment the follow line to download a cat image for demonstration.\n",
-        "# ! wget http://images.cocodataset.org/val2017/000000039769.jpg -O cat.jpg\n",
+        "# Alternatively, uncomment the following line to download a cat image for demonstration.\n",
+        "# ! wget http://images.cocodataset.org/val2017/000000039769.jpg -O test.jpg\n",
         "\n",
         "with open(IMAGE_FILENAME, \"rb\") as f:\n",
         "    image_b64 = base64.b64encode(f.read()).decode(\"utf-8\")\n",


### PR DESCRIPTION
Add service account config to TIMM notebook to resolve a GCS Fuse issue with the serving docker. Also polished the notebook.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
<br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
