### PR TITLE
Add a local inference section to model_garden_pytorch_timm.ipynb

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
@@ -127,7 +127,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "ad1f36f4b5c3"
+      },
       "source": [
         "### Install libraries"
       ]
@@ -135,7 +137,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "cb041d87f50a"
+      },
       "outputs": [],
       "source": [
         "! pip3 install timm"
@@ -231,7 +235,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "14a500024b7b"
+      },
       "source": [
         "## Run local inference\n",
         "\n",
@@ -241,7 +247,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "54859170c1ad"
+      },
       "source": [
         "### Import libraries\n"
       ]
@@ -249,12 +257,13 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "7505a2bf3897"
+      },
       "outputs": [],
       "source": [
         "import timm\n",
         "import torch\n",
-        "\n",
         "from PIL import Image\n",
         "from timm.data import resolve_data_config\n",
         "from timm.data.transforms_factory import create_transform"
@@ -263,7 +272,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "17e6d8a0dac3"
+      },
       "source": [
         "### Load a pretrained model"
       ]
@@ -271,7 +282,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "8b6bbe928998"
+      },
       "outputs": [],
       "source": [
         "model = timm.create_model(MODEL_NAME, pretrained=True)\n",
@@ -281,7 +294,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "0f2ce8fa5439"
+      },
       "source": [
         "### Load and preprocess the image"
       ]
@@ -289,7 +304,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "6390302c9761"
+      },
       "outputs": [],
       "source": [
         "config = resolve_data_config({}, model=model)\n",
@@ -298,20 +315,22 @@
         "# The example downloads a test image. You can upload and use your own images\n",
         "# by changing IMAGE_FILENAME.\n",
         "! wget https://github.com/pytorch/hub/raw/master/images/dog.jpg -O test.jpg\n",
-        "IMAGE_FILENAME = 'test.jpg'  # @param {type:\"string\"}\n",
+        "IMAGE_FILENAME = \"test.jpg\"  # @param {type:\"string\"}\n",
         "\n",
         "# You can also copy over images stored in a GCS bucket with the line below.\n",
         "# ! gsutil cp \"gs://path/to/image\" \"test.jpg\"\n",
         "\n",
-        "img = Image.open(IMAGE_FILENAME).convert('RGB')\n",
-        "tensor = transform(img).unsqueeze(0) # transform and add batch dimension\n",
+        "img = Image.open(IMAGE_FILENAME).convert(\"RGB\")\n",
+        "tensor = transform(img).unsqueeze(0)  # transform and add batch dimension\n",
         "display(img)"
       ]
     },
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "8a6e2ea460ad"
+      },
       "source": [
         "### Get the model predictions"
       ]
@@ -319,7 +338,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "0a7a666a0aef"
+      },
       "outputs": [],
       "source": [
         "with torch.no_grad():\n",
@@ -331,7 +352,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "691139fc5789"
+      },
       "source": [
         "### Get the top-5 predictions class names"
       ]
@@ -339,20 +362,27 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "147249af5dec"
+      },
       "outputs": [],
       "source": [
         "# Get imagenet class mappings\n",
-        "url, filename = (\"https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt\", \"imagenet_classes.txt\") \n",
-        "urllib.request.urlretrieve(url, filename) \n",
-        "with open(\"imagenet_classes.txt\", \"r\") as f:\n",
+        "url, filename = (\n",
+        "    \"https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt\",\n",
+        "    \"imagenet_classes.txt\",\n",
+        ")\n",
+        "urllib.request.urlretrieve(url, filename)\n",
+        "with open(\"imagenet_classes.txt\") as f:\n",
         "    categories = [s.strip() for s in f.readlines()]"
       ]
     },
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "a8740b668da6"
+      },
       "source": [
         "### Print top categories per image"
       ]
@@ -360,7 +390,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "9f18bcd806f2"
+      },
       "outputs": [],
       "source": [
         "top5_prob, top5_catid = torch.topk(probabilities, 5)\n",
@@ -373,7 +405,9 @@
     {
       "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "4120d1585355"
+      },
       "source": [
         "## Run training jobs\n",
         "\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
@@ -54,6 +54,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "76BCoQcm2AMJ"
@@ -61,11 +62,12 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This notebook demonstrates finetuning the PyTorch [timm](https://github.com/rwightman/pytorch-image-models) models and deploying the models on [Vertex AI](https://cloud.google.com/vertex-ai).\n",
+        "This notebook demonstrates running local inference using the [timm](https://github.com/rwightman/pytorch-image-models) library, finetuning the PyTorch [timm models](https://github.com/huggingface/pytorch-image-models#models), and deploying the models on [Vertex AI](https://cloud.google.com/vertex-ai).\n",
         "\n",
         "### Objective\n",
         "\n",
         "- Setup environment.\n",
+        "- Run inference locally using the timm library.\n",
         "- Create a custom training job on Vertex AI to train or finetune a model.\n",
         "- Deploy the model on Vertex AI for online prediction.\n",
         "\n",
@@ -120,6 +122,23 @@
         "It's highly recommended to run this notebook on [Vertex AI workbench](https://cloud.google.com/vertex-ai-workbench), where you don't need to manually install any additional libraries.\n",
         "\n",
         "If you are running this notebook locally, you will need to install the [Cloud SDK](https://cloud.google.com/sdk) and [gsutil](https://cloud.google.com/storage/docs/gsutil_install)."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Install libraries"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "! pip3 install timm"
       ]
     },
     {
@@ -210,10 +229,151 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {
-        "id": "JlutYfxH2AMK"
-      },
+      "metadata": {},
+      "source": [
+        "## Run local inference\n",
+        "\n",
+        "This section runs local inference on an image using the model chosen in above section."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Import libraries\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import timm\n",
+        "import torch\n",
+        "\n",
+        "from PIL import Image\n",
+        "from timm.data import resolve_data_config\n",
+        "from timm.data.transforms_factory import create_transform"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load a pretrained model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = timm.create_model(MODEL_NAME, pretrained=True)\n",
+        "model.eval()"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load and preprocess the image"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "config = resolve_data_config({}, model=model)\n",
+        "transform = create_transform(**config)\n",
+        "\n",
+        "# The example downloads a test image. You can upload and use your own images\n",
+        "# by changing IMAGE_FILENAME.\n",
+        "! wget https://github.com/pytorch/hub/raw/master/images/dog.jpg -O test.jpg\n",
+        "IMAGE_FILENAME = 'test.jpg'  # @param {type:\"string\"}\n",
+        "\n",
+        "# You can also copy over images stored in a GCS bucket with the line below.\n",
+        "# ! gsutil cp \"gs://path/to/image\" \"test.jpg\"\n",
+        "\n",
+        "img = Image.open(IMAGE_FILENAME).convert('RGB')\n",
+        "tensor = transform(img).unsqueeze(0) # transform and add batch dimension\n",
+        "display(img)"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Get the model predictions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "with torch.no_grad():\n",
+        "    out = model(tensor)\n",
+        "probabilities = torch.nn.functional.softmax(out[0], dim=0)\n",
+        "print(probabilities.shape)"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Get the top-5 predictions class names"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Get imagenet class mappings\n",
+        "url, filename = (\"https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt\", \"imagenet_classes.txt\") \n",
+        "urllib.request.urlretrieve(url, filename) \n",
+        "with open(\"imagenet_classes.txt\", \"r\") as f:\n",
+        "    categories = [s.strip() for s in f.readlines()]"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Print top categories per image"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "top5_prob, top5_catid = torch.topk(probabilities, 5)\n",
+        "for i in range(top5_prob.size(0)):\n",
+        "    print(categories[top5_catid[i]], top5_prob[i].item())\n",
+        "# prints class names and probabilities like:\n",
+        "# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
       "source": [
         "## Run training jobs\n",
         "\n",


### PR DESCRIPTION
Add a local inference section to  model_garden_pytorch_timm.ipynb



2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
