### PR TITLE
Add MediaPipe Object Detection Colab to Model Garden

### DIFF
--- a/notebooks/community/CODEOWNERS
+++ b/notebooks/community/CODEOWNERS
@@ -44,6 +44,7 @@
 /notebooks/community/feature_store/get_started_vertex_feature_store.ipynb @junkourata
 /notebooks/community/model_garden/model_garden_huggingface_local_inference.ipynb @dstnluong-google
 /notebooks/community/model_garden/model_garden_mediapipe_image_classification.ipynb @schmidt-sebastian
+/notebooks/community/model_garden/model_garden_mediapipe_object_detection.ipynb @schmidt-sebastian
 /notebooks/community/model_garden/model_garden_proprietary_image_classification.ipynb @weigary
 /notebooks/community/model_garden/model_garden_proprietary_image_object_detection.ipynb @weigary
 /notebooks/community/model_garden/model_garden_tfvision_image_classification.ipynb @genquan9

--- a/notebooks/community/model_garden/model_garden_mediapipe_object_detection.ipynb
+++ b/notebooks/community/model_garden/model_garden_mediapipe_object_detection.ipynb
@@ -1,0 +1,574 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ur8xi4C7S06n"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2023 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TirJ-SGQseby"
+      },
+      "source": [
+        "# Vertex AI Model Garden MediaPipe With Object Detection\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_garden/model_garden_mediapipe_object_detection.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_garden/model_garden_mediapipe_object_detection.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>                                                                                               <td>\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/notebooks/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/community/model_garden/model_garden_mediapipe_object_detection.ipynb\">\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+        "Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dwGLvtIeECLK"
+      },
+      "source": [
+        "**_NOTE_**: This notebook has been tested in the following environment:\n",
+        "\n",
+        "* Python version = 3.9"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tvgnzT1CKxrO"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This notebook demonstrates how to use [MediaPipe ModelMaker](https://developers.google.com/mediapipe/solutions/model_maker) in Vertex AI Model Garden.\n",
+        "\n",
+        "### Objective\n",
+        "\n",
+        "* Train new models\n",
+        "  * Convert input data to training formats\n",
+        "  * Create [custom jobs](https://cloud.google.com/vertex-ai/docs/training/create-custom-job) to train new models\n",
+        "  * Export models\n",
+        "\n",
+        "* Cleanup resources\n",
+        "\n",
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "\n",
+        "Learn about [Vertex AI\n",
+        "pricing](https://cloud.google.com/vertex-ai/pricing) and [Cloud Storage\n",
+        "pricing](https://cloud.google.com/storage/pricing), and use the [Pricing\n",
+        "Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KEukV6uRk_S3"
+      },
+      "source": [
+        "## Before you begin"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "z__i0w0lCAsW"
+      },
+      "source": [
+        "### Colab Only\n",
+        "Run the following commands to install dependencies and to authenticate with Google Cloud if running on Colab."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Jvqs-ehKlaYh"
+      },
+      "outputs": [],
+      "source": [
+        "! pip3 install --upgrade pip\n",
+        "\n",
+        "if \"google.colab\" in str(get_ipython()):\n",
+        "    ! pip3 install --upgrade google-cloud-aiplatform\n",
+        "\n",
+        "    # Automatically restart kernel after installs\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)\n",
+        "\n",
+        "    from google.colab import auth as google_auth\n",
+        "\n",
+        "    google_auth.authenticate_user()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BF1j6f9HApxa"
+      },
+      "source": [
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "1. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
+        "\n",
+        "1. [Enable the Vertex AI API and Compute Engine API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com,compute_component).\n",
+        "1. If you are running this notebook locally, you will need to install the [Cloud SDK](https://cloud.google.com/sdk).\n",
+        "\n",
+        "1. Enter your project ID in the cell below. Then run the cell to make sure the\n",
+        "Cloud SDK uses the right project for all the commands in this notebook.\n",
+        "\n",
+        "**Note**: Jupyter runs lines prefixed with `!` as shell commands, and it interpolates Python variables prefixed with `$` into these commands."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "9wExiMUxFk91"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import os\n",
+        "from datetime import datetime\n",
+        "\n",
+        "import tensorflow\n",
+        "from google.cloud import aiplatform\n",
+        "\n",
+        "now = datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "\n",
+        "# The project and bucket are for experiments below.\n",
+        "PROJECT_ID = \"\"  # @param {type:\"string\"}\n",
+        "# The form for BUCKET_URI is gs://<bucket-name>.\\n\",\n",
+        "BUCKET_URI = \"gs://\"  # @param {type:\"string\"}\n",
+        "\n",
+        "# You can choose a region from https://cloud.google.com/about/locations.\n",
+        "# Only regions prefixed by \"us\", \"asia\", or \"europe\" are supported.\n",
+        "REGION = \"us-central1\"  # @param {type:\"string\"}\n",
+        "REGION_PREFIX = REGION.split(\"-\")[0]\n",
+        "assert REGION_PREFIX in (\n",
+        "    \"us\",\n",
+        "    \"europe\",\n",
+        "    \"asia\",\n",
+        "), f'{REGION} is not supported. It must be prefixed by \"us\", \"asia\", or \"europe\".'\n",
+        "\n",
+        "! gcloud config set project $PROJECT_ID\n",
+        "\n",
+        "STAGING_BUCKET = os.path.join(BUCKET_URI, \"temp/%s\" % now)\n",
+        "\n",
+        "EVALUATION_RESULT_OUTPUT_DIRECTORY = os.path.join(STAGING_BUCKET, \"evaluation\")\n",
+        "EVALUATION_RESULT_OUTPUT_FILE = os.path.join(\n",
+        "    EVALUATION_RESULT_OUTPUT_DIRECTORY, \"evaluation.json\"\n",
+        ")\n",
+        "\n",
+        "EXPORTED_MODEL_OUTPUT_DIRECTORY = os.path.join(STAGING_BUCKET, \"model\")\n",
+        "EXPORTED_MODEL_OUTPUT_FILE = os.path.join(\n",
+        "    EXPORTED_MODEL_OUTPUT_DIRECTORY, \"model.tflite\"\n",
+        ")\n",
+        "\n",
+        "aiplatform.init(project=PROJECT_ID, location=REGION, staging_bucket=STAGING_BUCKET)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "n6IFz75WGCam"
+      },
+      "source": [
+        "### Define training machine specs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "riG_qUokg0XZ"
+      },
+      "outputs": [],
+      "source": [
+        "TRAINING_JOB_DISPLAY_NAME = \"mediapipe_object_detector_%s\" % now\n",
+        "TRAINING_CONTAINER = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/mediapipe-train\"\n",
+        "TRAINING_MACHINE_TYPE = \"n1-highmem-16\"\n",
+        "TRAINING_ACCELARATOR_TYPE = \"NVIDIA_TESLA_V100\"\n",
+        "TRAINING_ACCELERATOR_COUNT = 2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zgPO1eR3CYjk"
+      },
+      "source": [
+        "### Prepare input data for training\n",
+        "\n",
+        "Retraining a model for object detection requires a dataset that includes the items, or classes, that you want the completed model to be able to identify. You can do this by trimming down a public dataset to only the classes that are relevant to your usecase, compiling your own dataset, or some combination of both, The dataset can be significantly smaller than what would be required to train a new model. For example, the [COCO](https://cocodataset.org/) dataset used to train many reference models contains hundreds of thousands of images with 91 classes of objects. Transfer learning with Model Maker can retrain an existing model with a smaller dataset and still perform well, depending on your inference accuracy goals. These instructions use a smaller dataset containing 2 types of android figurines, or 2 classes, with 62 total training images.\n",
+        "\n",
+        "You can re-use an existing dataset such as `gs://mediapipe-tasks/object_detector/android_figurine` to re-train the model. The directory contains two subdirectories for the training and validation datasets, located in android_figurine/train and android_figurine/validation respectively. Each of the train and validation datasets follow the COCO Dataset format described below. If you are using your own dataset, ensure that that it adheres to the format specifications before uploading it to Google Cloud Storage.\n",
+        "\n",
+        "\n",
+        "### Supported dataset formats\n",
+        "Model Maker Object Detection API supports reading the following dataset formats:\n",
+        "\n",
+        "#### COCO format\n",
+        "The COCO dataset format has a `data` directory which stores all of the images and a single `labels.json` file which contains the object annotations for all images.\n",
+        "```\n",
+        "<dataset_dir>/\n",
+        "  data/\n",
+        "    <img0>.<jpg/jpeg>\n",
+        "    <img1>.<jpg/jpeg>\n",
+        "    ...\n",
+        "  labels.json\n",
+        "```\n",
+        "where `labels.json` is formatted as:\n",
+        "```\n",
+        "{\n",
+        "  \"categories\":[\n",
+        "    {\"id\":1, \"name\":<cat1_name>},\n",
+        "    ...\n",
+        "  ],\n",
+        "  \"images\":[\n",
+        "    {\"id\":0, \"file_name\":\"<img0>.<jpg/jpeg>\"},\n",
+        "    ...\n",
+        "  ],\n",
+        "  \"annotations\":[\n",
+        "    {\"id\":0, \"image_id\":0, \"category_id\":1, \"bbox\":[x-top left, y-top left, width, height]},\n",
+        "    ...\n",
+        "  ]\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "#### PASCAL VOC format\n",
+        "\n",
+        "The PASCAL VOC dataset format also has a `data` directory which stores all of the images, however the annotations are split up per image into corresponding xml files in the `Annotations` directory.\n",
+        "```\n",
+        "<dataset_dir>/\n",
+        "  data/\n",
+        "    <file0>.<jpg/jpeg>\n",
+        "    ...\n",
+        "  Annotations/\n",
+        "    <file0>.xml\n",
+        "    ...\n",
+        "```\n",
+        "where the xml files are formatted as:\n",
+        "```\n",
+        "<annotation>\n",
+        "  <filename>file0.jpg</filename>\n",
+        "  <object>\n",
+        "    <name>kangaroo</name>\n",
+        "    <bndbox>\n",
+        "      <xmin>233</xmin>\n",
+        "      <ymin>89</ymin>\n",
+        "      <xmax>386</xmax>\n",
+        "      <ymax>262</ymax>\n",
+        "    </bndbox>\n",
+        "  </object>\n",
+        "  <object>\n",
+        "    ...\n",
+        "  </object>\n",
+        "  ...\n",
+        "</annotation>\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "O32DU5RRGhdV"
+      },
+      "source": [
+        "### Retrain model\n",
+        "\n",
+        "Once you have completed preparing your data, you can begin retraining a model to recognize the new objects, or classes, defined by your training data. The instructions below use the data prepared in the previous section to retrain an object detection model to recognize the two types of android figurines.\n",
+        "\n",
+        "You can leave the path to the test data empty if you do not have a separate test data set."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "IndQ_m6ddUEM"
+      },
+      "outputs": [],
+      "source": [
+        "training_data_path = \"gs://mediapipe-tasks/object_detector/android_figurine/train\"  # @param {type:\"string\"}\n",
+        "validation_data_path = \"gs://mediapipe-tasks/object_detector/android_figurine/validation\"  # @param {type:\"string\"}\n",
+        "test_data_path = \"\"  # @param {type:\"string\"}\n",
+        "data_format = \"coco\"  # @param [\"coco\", \"pascal_voc\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aaff6f5be7f6"
+      },
+      "source": [
+        "### Set retraining options\n",
+        "\n",
+        "There are a few required settings to run retraining aside from your training dataset: output directory for the model, and the model architecture. Use HParams to specify the export_dir parameter for the output directory. Use the SupportedModels class to specify the model architecture. The object detector solution supports the following model architectures:\n",
+        "\n",
+        "*   MobileNet-V2\n",
+        "*   MobileNet-MultiHW-AVG\n",
+        "\n",
+        "To set the parameters, use the following code:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "um_XKbmpTaHx"
+      },
+      "outputs": [],
+      "source": [
+        "model_architecture = \"mobilenet_v2\"  # @param [\"mobilenet_v2\", \"mobilenet_multihw_avg\"]\n",
+        "\n",
+        "# The learning rate to use for gradient descent training.\n",
+        "learning_rate: float = 0.01  # @param {type:\"number\"}\n",
+        "# Batch size for training.\n",
+        "batch_size: int = 2  # @param {type:\"number\"}\n",
+        "# Number of training iterations over the dataset.\n",
+        "epochs: int = 10  # @param {type:\"slider\", min:0, max:100, step:1}\n",
+        "# If true, the base module is trained together with the classification layer on\n",
+        "# top.\n",
+        "do_fine_tuning: bool = False  # @param {type:\"boolean\"}\n",
+        "# A regularizer that applies a L1 regularization penalty.\n",
+        "l1_regularizer: float = 0.0  # @param {type:\"number\"}\n",
+        "# A regularizer that applies a L2 regularization penalty.\n",
+        "l2_regularizer: float = 0.0001  # @param {type:\"number\"}\n",
+        "# A boolean controlling whether the training dataset is augmented by randomly\n",
+        "# distorting input images, including random cropping, flipping, etc. See\n",
+        "# utils.image_preprocessing documentation for details.\n",
+        "do_data_augmentation: bool = True  # @param {type:\"boolean\"}\n",
+        "# Number of training samples used to calculate the decay steps\n",
+        "# and create the training optimizer.\n",
+        "decay_samples: int = 2560000  # @param {type:\"number\"}\n",
+        "# Number of warmup steps for a linear increasing warmup schedule on learning\n",
+        "# rate. Used to set up warmup schedule by model_util.WarmUp.\n",
+        "warmup_epochs: int = 2  # @param {type:\"number\"}\n",
+        "# The number of epochs for cosine decay learning rate.\n",
+        "cosine_decay_epochs: int = 5  # @param {type:\"number\"}\n",
+        "# The alpha value for cosine decay learning rate.\n",
+        "cosine_decay_alpha: float = 5  # @param {type:\"number\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HwcCjwlBTQIz"
+      },
+      "source": [
+        "#### Run retraining\n",
+        "With your training dataset and retraining options prepared, you are ready to start the retraining process. This process is resource intensive and can take a few minutes to a few hours depending on your available compute resources. This process is resource intensive and can take a few minutes to a few hours depending on your available compute resources. On Vertex AI with GPU processing, the example retraining below takes about 3 to 4 minutes.\n",
+        "\n",
+        "To begin the retraining process, use the following code:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aec22792ee84"
+      },
+      "outputs": [],
+      "source": [
+        "model_export_path = EXPORTED_MODEL_OUTPUT_DIRECTORY\n",
+        "evaluation_result_path = EVALUATION_RESULT_OUTPUT_DIRECTORY\n",
+        "\n",
+        "worker_pool_specs = [\n",
+        "    {\n",
+        "        \"machine_spec\": {\n",
+        "            \"machine_type\": TRAINING_MACHINE_TYPE,\n",
+        "            \"accelerator_type\": TRAINING_ACCELARATOR_TYPE,\n",
+        "            \"accelerator_count\": TRAINING_ACCELERATOR_COUNT,\n",
+        "        },\n",
+        "        \"replica_count\": 1,\n",
+        "        \"container_spec\": {\n",
+        "            \"image_uri\": TRAINING_CONTAINER,\n",
+        "            \"command\": [],\n",
+        "            \"args\": [\n",
+        "                \"--task_name=object_detector\",\n",
+        "                \"--training_data_path=%s\" % training_data_path,\n",
+        "                \"--validation_data_path=%s\" % validation_data_path,\n",
+        "                \"--test_data_path=%s\" % test_data_path,\n",
+        "                \"--data_format=%s\" % data_format,\n",
+        "                \"--model_export_path=%s\" % model_export_path,\n",
+        "                \"--evaluation_result_path=%s\" % evaluation_result_path,\n",
+        "                \"--model_architecture=%s\" % model_architecture,\n",
+        "                \"--hparams=%s\"\n",
+        "                % json.dumps(\n",
+        "                    {\n",
+        "                        \"learning_rate\": learning_rate,\n",
+        "                        \"batch_size\": batch_size,\n",
+        "                        \"epochs\": epochs,\n",
+        "                        \"do_fine_tuning\": do_fine_tuning,\n",
+        "                        \"l1_regularizer\": l1_regularizer,\n",
+        "                        \"l2_regularizer\": l2_regularizer,\n",
+        "                        \"do_data_augmentation\": do_data_augmentation,\n",
+        "                        \"decay_samples\": decay_samples,\n",
+        "                        \"warmup_epochs\": warmup_epochs,\n",
+        "                        \"cosine_decay_epochs\": cosine_decay_epochs,\n",
+        "                        \"cosine_decay_alpha\": cosine_decay_alpha,\n",
+        "                    }\n",
+        "                ),\n",
+        "            ],\n",
+        "        },\n",
+        "    }\n",
+        "]\n",
+        "\n",
+        "training_job = aiplatform.CustomJob(\n",
+        "    display_name=TRAINING_JOB_DISPLAY_NAME,\n",
+        "    project=PROJECT_ID,\n",
+        "    worker_pool_specs=worker_pool_specs,\n",
+        "    staging_bucket=STAGING_BUCKET,\n",
+        ")\n",
+        "\n",
+        "training_job.run()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mV-Djz-frBni"
+      },
+      "source": [
+        "### Evaluate performance\n",
+        "\n",
+        "If you have specified test data, you can evaluate it on the test dataset and print the loss and coco metrics. The most important metric for evaluating the model performance is typically the \"AP\" coco metric for Average Precision.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "09Rz1AYspK19"
+      },
+      "outputs": [],
+      "source": [
+        "def get_evaluation_result(evaluation_result_path):\n",
+        "    try:\n",
+        "        with tensorflow.io.gfile.GFile(evaluation_result_path, \"r\") as input_file:\n",
+        "            evalutation_result = json.loads(input_file.read())\n",
+        "        return evalutation_result[\"loss\"], evalutation_result[\"coco_metrics\"]\n",
+        "    except:\n",
+        "        print(\"Evaluation result not found. Did you provide a test dataset?\")\n",
+        "        return None\n",
+        "\n",
+        "\n",
+        "evaluation_result = get_evaluation_result(EVALUATION_RESULT_OUTPUT_FILE)\n",
+        "\n",
+        "if evaluation_result is not None:\n",
+        "    print(f\"Validation loss: {evaluation_result[0]}\")\n",
+        "    print(f\"Validation coco metrics: {evaluation_result[1]}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g0BGaofgsMsy"
+      },
+      "source": [
+        "## Export model\n",
+        "After retraining and evaluating the model, you can save it as Tensorflow Lite model, try it out in the [Object Detector](https://mediapipe-studio.webapps.google.com/demo/object_detector) demo in MediaPipe Studio or integrate it with your application by following the [Object detection task guide](https://developers.google.com/mediapipe/solutions/vision/object_detector). The exported model also includes metadata and the label map."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NYuQowyZEtxK"
+      },
+      "outputs": [],
+      "source": [
+        "def copy_model(model_source, model_dest):\n",
+        "    ! gsutil cp {model_source} {model_dest}\n",
+        "\n",
+        "copy_model(EXPORTED_MODEL_OUTPUT_FILE, \"object_detection_model.tflite\")\n",
+        "\n",
+        "if \"google.colab\" in str(get_ipython()):\n",
+        "    from google.colab import files\n",
+        "\n",
+        "    files.download(\"object_detection_model.tflite\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kkH2nrpdp4sp"
+      },
+      "source": [
+        "## Clean up"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Ax6vQVZhp9pR"
+      },
+      "outputs": [],
+      "source": [
+        "# Delete training data and jobs.\n",
+        "if training_job.list(filter=f'display_name=\"{TRAINING_JOB_DISPLAY_NAME}\"'):\n",
+        "    training_job.delete()\n",
+        "\n",
+        "!gsutil rm -r {STAGING_BUCKET}"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "model_garden_mediapipe_object_detection.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
This adds a new community notebook to train MediaPipe models via Model Maker on Vertex AI

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [ x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
