### PR TITLE
feat: make max number of parallel notebooks an cmdarg

### DIFF
--- a/.cloud-build/execute_changed_notebooks_cli.py
+++ b/.cloud-build/execute_changed_notebooks_cli.py
@@ -176,5 +176,5 @@ else:
         variable_service_account=args.variable_service_account,
         variable_vpc_network=args.variable_vpc_network,
         private_pool_id=args.private_pool_id,
-        rate_limit=args.rate_limit
+        rate_limit_count=args.rate_limit
 )

--- a/.cloud-build/execute_changed_notebooks_cli.py
+++ b/.cloud-build/execute_changed_notebooks_cli.py
@@ -122,6 +122,13 @@ parser.add_argument(
     help="Should run notebooks in parallel.",
 )
 parser.add_argument(
+    "--rate_limit",
+    type=int,
+    help="Number of parallel notebook executions per minute",
+    default=10,
+    required=False,
+)
+parser.add_argument(
     "--dry_run",
     type=str2bool,
     default=False,
@@ -168,5 +175,6 @@ else:
         variable_region=args.variable_region,
         variable_service_account=args.variable_service_account,
         variable_vpc_network=args.variable_vpc_network,
-        private_pool_id=args.private_pool_id
+        private_pool_id=args.private_pool_id,
+        rate_limit=args.rate_limit
 )

--- a/.cloud-build/execute_changed_notebooks_helper.py
+++ b/.cloud-build/execute_changed_notebooks_helper.py
@@ -528,7 +528,7 @@ def process_and_execute_notebooks(
                             variable_vpc_network,
                             private_pool_id,
                             deadline,
-                            rate_limit,
+                            rate_limit_count,
                         ),
                         notebooks,
                     )
@@ -546,7 +546,7 @@ def process_and_execute_notebooks(
                     private_pool_id=private_pool_id,
                     deadline=deadline,
                     notebook=notebook,
-                    rate_limit=rate_limit,
+                    rate_limit=rate_limit_count,
                 )
                 for notebook in notebooks
             ]

--- a/.cloud-build/execute_changed_notebooks_helper.py
+++ b/.cloud-build/execute_changed_notebooks_helper.py
@@ -505,12 +505,12 @@ def process_and_execute_notebooks(
 
         print(f"Found {len(notebooks)} modified notebooks: {notebooks}")
 
+        rate_limit = RateLimit(max_count=rate_limit_count, per=60, greedy=False)
         if should_parallelize and len(notebooks) > 1:
             print(
                 "Running notebooks in parallel, so no logs will be displayed. Please wait..."
             )
 
-            rate_limit = RateLimit(max_count=rate_limit_count, per=60, greedy=False)
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
                 print(f"Max workers: {executor._max_workers}")
@@ -528,7 +528,7 @@ def process_and_execute_notebooks(
                             variable_vpc_network,
                             private_pool_id,
                             deadline,
-                            rate_limit_count,
+                            rate_limit,
                         ),
                         notebooks,
                     )
@@ -546,7 +546,7 @@ def process_and_execute_notebooks(
                     private_pool_id=private_pool_id,
                     deadline=deadline,
                     notebook=notebook,
-                    rate_limit=rate_limit_count,
+                    rate_limit=rate_limit,
                 )
                 for notebook in notebooks
             ]


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Add flexibility to weekly regression testing, where the max number of parallel notebooks per minute is now a command line arg.

Testing: Did a --dry_run with pseudo values for arguments. No syntax errors, initial path works,
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [ ] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [ ] Follow the style and grammar rules outlined in the above notebook template.
- [ ] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ ] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

<br>

3. If you are opening a PR for `Community Content` under the [community-content](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/community-content) folder:
- [ ] Make sure your main `Content Directory Name` is descriptive, informative, and includes some of the key products and attributes of your content, so that it is differentiable from other content
- [ ] The main content directory has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/community-content/CODEOWNERS) file under the `Community Content` section, pointing to the author or the author's team.
- [ ] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
