### PR TITLE
Add missing 'import os' for notebooks in Colab

### DIFF
--- a/notebooks/official/explainable_ai/sdk_automl_tabular_binary_classification_batch_explain.ipynb
+++ b/notebooks/official/explainable_ai/sdk_automl_tabular_binary_classification_batch_explain.ipynb
@@ -149,8 +149,6 @@
       },
       "outputs": [],
       "source": [
-        "import os\n",
-        "\n",
         "! pip3 install --upgrade --quiet google-cloud-aiplatform\n",
         "! pip3 install --upgrade --quiet google-cloud-storage\n",
         "! pip3 install --upgrade --quiet tensorflow"

--- a/notebooks/official/explainable_ai/sdk_automl_tabular_binary_classification_batch_explain.ipynb
+++ b/notebooks/official/explainable_ai/sdk_automl_tabular_binary_classification_batch_explain.ipynb
@@ -784,6 +784,8 @@
       },
       "outputs": [],
       "source": [
+        "import os\n",
+        "\n",
         "# Set this to true only if you'd like to delete your bucket\n",
         "delete_bucket = False\n",
         "\n",

--- a/notebooks/official/explainable_ai/sdk_custom_image_classification_online_explain.ipynb
+++ b/notebooks/official/explainable_ai/sdk_custom_image_classification_online_explain.ipynb
@@ -356,6 +356,8 @@
       },
       "outputs": [],
       "source": [
+        "import os\n",
+        "\n",
         "import google.cloud.aiplatform as aip"
       ]
     },

--- a/notebooks/official/explainable_ai/sdk_custom_tabular_regression_online_explain_get_metadata.ipynb
+++ b/notebooks/official/explainable_ai/sdk_custom_tabular_regression_online_explain_get_metadata.ipynb
@@ -409,6 +409,8 @@
       },
       "outputs": [],
       "source": [
+        "import os\n",
+        "\n",
         "if os.getenv(\"IS_TESTING_TRAIN_GPU\"):\n",
         "    TRAIN_GPU, TRAIN_NGPU = (\n",
         "        aip.gapic.AcceleratorType.NVIDIA_TESLA_K80,\n",


### PR DESCRIPTION
The module is imported previously, but the Colab instructions restart the kernel losing the import.

Make sure `os` is imported on use.


It's my first PR! 🎉  … I am not sure how to submit the Contributor License Agreement but I believe mine is id 106950177079614963579.