### PR TITLE
fix: update notebook template comment

### DIFF
--- a/notebooks/notebook_template.ipynb
+++ b/notebooks/notebook_template.ipynb
@@ -182,7 +182,7 @@
       },
       "outputs": [],
       "source": [
-        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+        "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
         "# import IPython\n",
         "\n",
         "# app = IPython.Application.instance()\n",


### PR DESCRIPTION
Add extra # character. This enables users to uncomment the whole cell, versus picking just the right lines to uncomment.