### PR TITLE
Add vLLM support to open-llama and llama2 notebooks

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
@@ -66,6 +66,7 @@
         "\n",
         "- Deploy prebuilt LLaMA2 models\n",
         "- Finetune and deploy LLaMA2 models with PEFT\n",
+        "- Deploy LLaMA2 with [vLLM](https://github.com/vllm-project/vllm) to improve serving throughput\n",
         "\n",
         "### Costs\n",
         "\n",
@@ -231,8 +232,15 @@
       "outputs": [],
       "source": [
         "# The pre-built training and serving docker images.\n",
-        "TRAIN_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-peft-train\"\n",
-        "PREDICTION_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-peft-serve\""
+        "TRAIN_DOCKER_URI = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-peft-train\"\n",
+        ")\n",
+        "PREDICTION_DOCKER_URI = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-peft-serve\"\n",
+        ")\n",
+        "VLLM_DOCKER_URI = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-vllm-serve\"\n",
+        ")"
       ]
     },
     {
@@ -293,6 +301,47 @@
         "        serving_container_health_route=\"/ping\",\n",
         "        serving_container_environment_variables=serving_env,\n",
         "    )\n",
+        "    model.deploy(\n",
+        "        endpoint=endpoint,\n",
+        "        machine_type=machine_type,\n",
+        "        accelerator_type=accelerator_type,\n",
+        "        accelerator_count=accelerator_count,\n",
+        "        deploy_request_timeout=1800,\n",
+        "        service_account=service_account,\n",
+        "    )\n",
+        "    return model, endpoint\n",
+        "\n",
+        "\n",
+        "def deploy_model_vllm(\n",
+        "    model_name,\n",
+        "    model_id,\n",
+        "    service_account,\n",
+        "    machine_type=\"n1-standard-8\",\n",
+        "    accelerator_type=\"NVIDIA_TESLA_V100\",\n",
+        "    accelerator_count=1,\n",
+        "):\n",
+        "    \"\"\"Deploys trained models with vLLM into Vertex AI.\"\"\"\n",
+        "    endpoint = aiplatform.Endpoint.create(display_name=f\"{model_name}-endpoint\")\n",
+        "\n",
+        "    vllm_args = [\n",
+        "        \"--host=0.0.0.0\",\n",
+        "        \"--port=7080\",\n",
+        "        f\"--model={model_id}\",\n",
+        "        f\"--tensor-parallel-size={accelerator_count}\",\n",
+        "        \"--swap-space=16\",\n",
+        "        \"--gpu-memory-utilization=0.95\",\n",
+        "        \"--disable-log-stats\",\n",
+        "    ]\n",
+        "    model = aiplatform.Model.upload(\n",
+        "        display_name=model_name,\n",
+        "        serving_container_image_uri=VLLM_DOCKER_URI,\n",
+        "        serving_container_command=[\"python\", \"-m\", \"vllm.entrypoints.api_server\"],\n",
+        "        serving_container_args=vllm_args,\n",
+        "        serving_container_ports=[7080],\n",
+        "        serving_container_predict_route=\"/generate\",\n",
+        "        serving_container_health_route=\"/ping\",\n",
+        "    )\n",
+        "\n",
         "    model.deploy(\n",
         "        endpoint=endpoint,\n",
         "        machine_type=machine_type,\n",
@@ -513,6 +562,80 @@
         "\n",
         "    # Show the results.\n",
         "    show_text_moderation(generated_text, response)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8neJc8CnDDpu"
+      },
+      "source": [
+        "## Deploy Prebuilt LLaMA2 with vLLM\n",
+        "\n",
+        "This section deploys prebuilt OpenLLaMA models with [vLLM](https://github.com/vllm-project/vllm) on the Endpoint. The model deployment step will take ~15 minutes to complete.\n",
+        "\n",
+        "vLLM is an highly optimized LLM serving framework which can increase serving throughput a lot. The higher QPS you have, the more benefits you get using vLLM."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "70e1e5bec8fa"
+      },
+      "outputs": [],
+      "source": [
+        "# Sets V100 to deploy LLaMA2 7B.\n",
+        "machine_type = \"n1-standard-8\"\n",
+        "accelerator_type = \"NVIDIA_TESLA_V100\"\n",
+        "accelerator_count = 1\n",
+        "\n",
+        "# Sets A100 (40G) to deploy LLaMA2 13B.\n",
+        "# machine_type = \"a2-highgpu-1g\"\n",
+        "# accelerator_type = \"NVIDIA_TESLA_A100\"\n",
+        "# accelerator_count = 1\n",
+        "\n",
+        "# Sets 4 A100 (40G) to deploy LLaMA2 70B models.\n",
+        "# machine_type = \"a2-highgpu-4g\"\n",
+        "# accelerator_type = \"NVIDIA_TESLA_A100\"\n",
+        "# accelerator_count = 4\n",
+        "\n",
+        "model_with_peft, endpoint_with_peft = deploy_model_vllm(\n",
+        "    model_name=get_job_name_with_datetime(prefix=\"llama2-serve-vllm\"),\n",
+        "    model_id=base_model_id,\n",
+        "    service_account=SERVICE_ACCOUNT,\n",
+        "    machine_type=machine_type,\n",
+        "    accelerator_type=accelerator_type,\n",
+        "    accelerator_count=accelerator_count,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sGKIjgmDFRW2"
+      },
+      "source": [
+        "NOTE: The prebuilt model weights will be downloaded on the fly from the orginal location after the deployment succeeds. Thus additional 5 minutes of waiting time is needed **after** the above model deployment step succeeds and before you run the next step below. Otherwise you might see a `ServiceUnavailable: 503 502:Bad Gateway` error when you send requests to the endpoint.\n",
+        "\n",
+        "Once deployment succeeds, you can send requests to the endpoint with text prompts."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1ed0642571c6"
+      },
+      "outputs": [],
+      "source": [
+        "instance = {\n",
+        "    \"prompt\": \"Hi, Google.\"\n",
+        "    \"n\": 1,\n",
+        "    \"max_tokens\": 32,\n",
+        "}\n",
+        "response = endpoint_without_peft.predict(instances=[instance])\n",
+        "print(response.predictions[0])"
       ]
     },
     {

--- a/notebooks/community/model_garden/model_garden_pytorch_openllama_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_openllama_peft.ipynb
@@ -67,6 +67,7 @@
         "- Run local inference with prebuilt OpenLLaMA\n",
         "- Deploy prebuilt OpenLLaMA\n",
         "- Finetune and deploy OpenLLaMA with PEFT, supporting\n",
+        "- Deploy OpenLLaMA with [vLLM](https://github.com/vllm-project/vllm) to improve serving throughput\n",
         "\n",
         "| Models | LoRA |\n",
         "| :- | :- |\n",
@@ -236,7 +237,10 @@
       "source": [
         "# The pre-built training and serving docker images.\n",
         "TRAIN_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/pytorch-peft-train\"\n",
-        "PREDICTION_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/pytorch-peft-serve\""
+        "PREDICTION_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/pytorch-peft-serve\"\n",
+        "VLLM_DOCKER_URI = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-vllm-serve\"\n",
+        ")"
       ]
     },
     {
@@ -299,6 +303,47 @@
         "        machine_type=machine_type,\n",
         "        accelerator_type=accelerator_type,\n",
         "        accelerator_count=1,\n",
+        "        deploy_request_timeout=1800,\n",
+        "        service_account=service_account,\n",
+        "    )\n",
+        "    return model, endpoint\n",
+        "\n",
+        "\n",
+        "def deploy_model_vllm(\n",
+        "    model_name,\n",
+        "    model_id,\n",
+        "    service_account,\n",
+        "    machine_type=\"n1-standard-8\",\n",
+        "    accelerator_type=\"NVIDIA_TESLA_V100\",\n",
+        "    accelerator_count=1,\n",
+        "):\n",
+        "    \"\"\"Deploys trained models with vLLM into Vertex AI.\"\"\"\n",
+        "    endpoint = aiplatform.Endpoint.create(display_name=f\"{model_name}-endpoint\")\n",
+        "\n",
+        "    vllm_args = [\n",
+        "        \"--host=0.0.0.0\",\n",
+        "        \"--port=7080\",\n",
+        "        f\"--model={model_id}\",\n",
+        "        f\"--tensor-parallel-size={accelerator_count}\",\n",
+        "        \"--swap-space=16\",\n",
+        "        \"--gpu-memory-utilization=0.95\",\n",
+        "        \"--disable-log-stats\",\n",
+        "    ]\n",
+        "    model = aiplatform.Model.upload(\n",
+        "        display_name=model_name,\n",
+        "        serving_container_image_uri=VLLM_DOCKER_URI,\n",
+        "        serving_container_command=[\"python\", \"-m\", \"vllm.entrypoints.api_server\"],\n",
+        "        serving_container_args=vllm_args,\n",
+        "        serving_container_ports=[7080],\n",
+        "        serving_container_predict_route=\"/generate\",\n",
+        "        serving_container_health_route=\"/ping\",\n",
+        "    )\n",
+        "\n",
+        "    model.deploy(\n",
+        "        endpoint=endpoint,\n",
+        "        machine_type=machine_type,\n",
+        "        accelerator_type=accelerator_type,\n",
+        "        accelerator_count=accelerator_count,\n",
         "        deploy_request_timeout=1800,\n",
         "        service_account=service_account,\n",
         "    )\n",
@@ -434,6 +479,65 @@
         "\n",
         "for prediction in response.predictions[0]:\n",
         "    print(prediction[\"generated_text\"])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8neJc8CnDDpu"
+      },
+      "source": [
+        "## Deploy Prebuilt OpenLLaMA with vLLM\n",
+        "\n",
+        "This section deploys prebuilt OpenLLaMA models with [vLLM](https://github.com/vllm-project/vllm) on the Endpoint. The model deployment step will take ~15 minutes to complete.\n",
+        "\n",
+        "vLLM is an highly optimized LLM serving framework which can increase serving throughput a lot. The higher QPS you have, the more benefits you get using vLLM."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6686c0605008"
+      },
+      "outputs": [],
+      "source": [
+        "model_with_peft, endpoint_with_peft = deploy_model_vllm(\n",
+        "    model_name=get_job_name_with_datetime(prefix=\"openllama-serve-vllm\"),\n",
+        "    model_id=\"openlm-research/open_llama_13b\",\n",
+        "    service_account=SERVICE_ACCOUNT,\n",
+        "    machine_type=\"n1-highmem-8\",\n",
+        "    accelerator_type=\"NVIDIA_TESLA_V100\",\n",
+        "    accelerator_count=2,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sGKIjgmDFRW2"
+      },
+      "source": [
+        "NOTE: The prebuilt model weights will be downloaded on the fly from the orginal location after the deployment succeeds. Thus additional 5 minutes of waiting time is needed **after** the above model deployment step succeeds and before you run the next step below. Otherwise you might see a `ServiceUnavailable: 503 502:Bad Gateway` error when you send requests to the endpoint.\n",
+        "\n",
+        "Once deployment succeeds, you can send requests to the endpoint with text prompts."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "a345dbcdf0d3"
+      },
+      "outputs": [],
+      "source": [
+        "instance = {\n",
+        "    \"prompt\": \"Hi, Google.\"\n",
+        "    \"n\": 1,\n",
+        "    \"max_tokens\": 32,\n",
+        "}\n",
+        "response = endpoint_without_peft.predict(instances=[instance])\n",
+        "print(response.predictions[0])"
       ]
     },
     {


### PR DESCRIPTION
**REQUIRED:** Add vLLM support to open-llama and llama2 notebooks

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [y ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [y ] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
