### PR TITLE
Fix vllm deploy in open-llama and llama2 notebooks

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
@@ -581,7 +581,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "70e1e5bec8fa"
+        "id": "03d504bcd60b"
       },
       "outputs": [],
       "source": [
@@ -600,7 +600,7 @@
         "# accelerator_type = \"NVIDIA_TESLA_A100\"\n",
         "# accelerator_count = 4\n",
         "\n",
-        "model_with_peft, endpoint_with_peft = deploy_model_vllm(\n",
+        "model_without_peft_vllm, endpoint_without_peft_vllm = deploy_model_vllm(\n",
         "    model_name=get_job_name_with_datetime(prefix=\"llama2-serve-vllm\"),\n",
         "    model_id=base_model_id,\n",
         "    service_account=SERVICE_ACCOUNT,\n",
@@ -625,7 +625,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "1ed0642571c6"
+        "id": "3f5a1e1de60d"
       },
       "outputs": [],
       "source": [
@@ -634,7 +634,7 @@
         "    \"n\": 1,\n",
         "    \"max_tokens\": 32,\n",
         "}\n",
-        "response = endpoint_without_peft.predict(instances=[instance])\n",
+        "response = endpoint_without_peft_vllm.predict(instances=[instance])\n",
         "print(response.predictions[0])"
       ]
     },
@@ -878,10 +878,12 @@
         "# Undeploy model and delete endpoint.\n",
         "endpoint_without_peft.delete(force=True)\n",
         "endpoint_with_peft.delete(force=True)\n",
+        "endpoint_without_peft_vllm.delete(force=True)\n",
         "\n",
         "# Delete models.\n",
         "model_without_peft.delete()\n",
         "model_with_peft.delete()\n",
+        "model_without_peft_vllm.delete()\n",
         "\n",
         "# Delete Cloud Storage objects that were created\n",
         "delete_bucket = False\n",

--- a/notebooks/community/model_garden/model_garden_pytorch_openllama_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_openllama_peft.ipynb
@@ -498,11 +498,11 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "6686c0605008"
+        "id": "ee610586eddb"
       },
       "outputs": [],
       "source": [
-        "model_with_peft, endpoint_with_peft = deploy_model_vllm(\n",
+        "model_without_peft_vllm, endpoint_without_peft_vllm = deploy_model_vllm(\n",
         "    model_name=get_job_name_with_datetime(prefix=\"openllama-serve-vllm\"),\n",
         "    model_id=\"openlm-research/open_llama_13b\",\n",
         "    service_account=SERVICE_ACCOUNT,\n",
@@ -527,7 +527,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "a345dbcdf0d3"
+        "id": "63bb8fb78d0b"
       },
       "outputs": [],
       "source": [
@@ -536,7 +536,7 @@
         "    \"n\": 1,\n",
         "    \"max_tokens\": 32,\n",
         "}\n",
-        "response = endpoint_without_peft.predict(instances=[instance])\n",
+        "response = endpoint_without_peft_vllm.predict(instances=[instance])\n",
         "print(response.predictions[0])"
       ]
     },
@@ -735,10 +735,12 @@
         "# Undeploy model and delete endpoint.\n",
         "endpoint_without_peft.delete(force=True)\n",
         "endpoint_with_peft.delete(force=True)\n",
+        "endpoint_without_peft_vllm.delete(force=True)\n",
         "\n",
         "# Delete models.\n",
         "model_without_peft.delete()\n",
-        "model_with_peft.delete()"
+        "model_with_peft.delete()\n",
+        "model_without_peft_vllm.delete()"
       ]
     }
   ],


### PR DESCRIPTION
**REQUIRED:** Fix vllm deploy in open-llama and llama2 notebooks

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [ y] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ y] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).