### PR TITLE
Add Vertex Online Prediction to #ModelGarden #MediaPipe image generation notebook

### DIFF
--- a/notebooks/community/model_garden/model_garden_mediapipe_image_generation.ipynb
+++ b/notebooks/community/model_garden/model_garden_mediapipe_image_generation.ipynb
@@ -299,7 +299,7 @@
         "id": "n6IFz75WGCam"
       },
       "source": [
-        "### Define training machine specs"
+        "### Define training and serving constants"
       ]
     },
     {
@@ -314,7 +314,13 @@
         "TRAINING_CONTAINER = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/mediapipe-stable-diffusion-train\"\n",
         "TRAINING_MACHINE_TYPE = \"a2-highgpu-1g\"\n",
         "TRAINING_ACCELERATOR_TYPE = \"NVIDIA_TESLA_A100\"\n",
-        "TRAINING_ACCELERATOR_COUNT = 1"
+        "TRAINING_ACCELERATOR_COUNT = 1\n",
+        "\n",
+        "PREDICTION_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-peft-serve\"\n",
+        "PREDICTION_PORT = 7080\n",
+        "PREDICTION_ACCELERATOR_TYPE = \"NVIDIA_TESLA_V100\"\n",
+        "PREDICTION_MACHINE_TYPE = \"n1-standard-8\"\n",
+        "UPLOAD_MODEL_NAME = \"mediapipe_stable_diffusion_model_%s\" % now"
       ]
     },
     {
@@ -359,6 +365,31 @@
       "source": [
         "### Set training options\n",
         "\n",
+        "The Image Generator comes with a set of pre-defined HParams settings that work best for specific situations. You should select a template that best matches your use case.\n",
+        "\n",
+        "If applicable, you can also use one of our pre-trained models for these templates. These can be used directly and without training:\n",
+        "* [Object - Berry Bowl](https://storage.googleapis.com/mediapipe-tasks/image_generator/object/pytorch_lora_weights.bin)\n",
+        "* [Face](https://storage.googleapis.com/mediapipe-tasks/image_generator/face/pytorch_lora_weights.bin)\n",
+        "* [Style](https://storage.googleapis.com/mediapipe-tasks/image_generator/style/pytorch_lora_weights.bin)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "bj31hD4W02Ui"
+      },
+      "outputs": [],
+      "source": [
+        "template = \"\"  # @param [\"\", \"Face\", \"Object\", \"Style\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lYF-4ydq0k0u"
+      },
+      "source": [
         "To set custom training parameters, adjust the following values:"
       ]
     },
@@ -373,8 +404,8 @@
         "# Parameters about training configuration\n",
         "# The learning rate to use for gradient descent training.\n",
         "learning_rate: float = 0.00001  # @param {type:\"number\"}\n",
-        "#  Number of training steps.\n",
-        "num_train_steps: int = 1000  # @param {type:\"integer\"}\n",
+        "# Number of training steps. If set to 0, uses the default value.\n",
+        "num_train_steps: int = 0  # @param {type:\"integer\"}\n",
         "# Save the checkpoint in every n steps.\n",
         "save_checkpoints_every_n: int = 100  # @param {type:\"integer\"}\n",
         "# Batch size for training.\n",
@@ -383,9 +414,14 @@
         "# Dataset-related parameters\n",
         "# Whether to use random horizontal flip on data.\n",
         "random_flip: bool = False  # @param {type:\"boolean\"}\n",
+        "# Whether to use random largest square crop.\n",
+        "random_crop: bool = False  # @param {type:\"boolean\"}\n",
+        "# Whether to distort the color of the image (jittering order is random).\n",
+        "random_color_jitter: bool = False  # @param {type:\"boolean\"}\n",
         "\n",
         "# Hyperparameters for LoRA tuning\n",
-        "lora_rank: int = 4  # @param {type:\"integer\"}"
+        "# The rank in the low-rank matrices. If set to 0, uses the default value.\n",
+        "lora_rank: int = 0  # @param {type:\"integer\"}"
       ]
     },
     {
@@ -425,7 +461,7 @@
         "id": "nvhSeCt1GbUy"
       },
       "source": [
-        "## Customize image generation\n",
+        "### Customize image generation\n",
         "\n",
         "You may customize the image generation."
       ]
@@ -493,6 +529,8 @@
         "                        \"save_checkpoints_every_n\": save_checkpoints_every_n,\n",
         "                        \"batch_size\": batch_size,\n",
         "                        \"random_flip\": random_flip,\n",
+        "                        \"random_crop\": random_crop,\n",
+        "                        \"random_color_jitter\": random_color_jitter,\n",
         "                        \"lora_rank\": lora_rank,\n",
         "                    }\n",
         "                ),\n",
@@ -525,7 +563,7 @@
         "id": "Jdm1dOgsMH9O"
       },
       "source": [
-        "# Download generated images\n",
+        "## Download generated images\n",
         "\n",
         "You can download and preview the generated images."
       ]
@@ -545,9 +583,10 @@
         "\n",
         "def copy_image(images_source, images_dest):\n",
         "    os.makedirs(images_dest, exist_ok=True)\n",
-        "    ! gsutil cp -r {images_source} {images_dest}\n",
+        "    ! gsutil cp -r {images_source}/* {images_dest}\n",
         "\n",
-        "local_image_path = \"/images\"\n",
+        "\n",
+        "local_image_path = \"./images/\"\n",
         "copy_image(IMAGE_EXPORT_PATH, local_image_path)\n",
         "\n",
         "for filename in os.listdir(local_image_path):\n",
@@ -581,17 +620,144 @@
         "\n",
         "def copy_model(model_source, model_dest):\n",
         "    os.makedirs(model_dest, exist_ok=True)\n",
-        "    ! gsutil cp -r {model_source} {model_dest}\n",
+        "    ! gsutil -m cp -r {model_source}/* {model_dest}\n",
+        "\n",
         "\n",
         "local_model_path = \"/models\"\n",
         "copy_model(MODEL_EXPORT_PATH, local_model_path)\n",
         "\n",
-        "! tar czf models.tar.gz {local_model_path}\n",
+        "! tar czf models.tar.gz {local_model_path}/*\n",
         "\n",
         "if \"google.colab\" in sys.modules:\n",
         "    from google.colab import files\n",
         "\n",
         "    files.download(\"models.tar.gz\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-gqs4Kc4u6U3"
+      },
+      "source": [
+        "## Use trained models on Vertex AI\n",
+        "\n",
+        "This section shows the way to test with trained models.\n",
+        "1. Upload and deploy models to the [Vertex AI Model Registry](https://cloud.google.com/vertex-ai/docs/model-registry/introduction)\n",
+        "2. Get [online predictions](https://cloud.google.com/vertex-ai/docs/predictions/get-online-predictions) from the deployed model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Y_HV9vMbvF_6"
+      },
+      "source": [
+        "### Upload model to Vertex AI Model Registry"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "OL6wdXf-1rta"
+      },
+      "outputs": [],
+      "source": [
+        "serving_env = {\n",
+        "    \"TASK\": \"text-to-image-lora\",\n",
+        "    \"BASE_MODEL_ID\": \"runwayml/stable-diffusion-v1-5\",\n",
+        "    \"FINETUNED_LORA_MODEL_PATH\": MODEL_EXPORT_PATH,\n",
+        "}\n",
+        "\n",
+        "model = aiplatform.Model.upload(\n",
+        "    display_name=UPLOAD_MODEL_NAME,\n",
+        "    serving_container_image_uri=PREDICTION_CONTAINER_URI,\n",
+        "    serving_container_ports=[PREDICTION_PORT],\n",
+        "    serving_container_predict_route=\"/predictions/peft_serving\",\n",
+        "    serving_container_health_route=\"/ping\",\n",
+        "    serving_container_environment_variables=serving_env,\n",
+        ")\n",
+        "\n",
+        "model.wait()\n",
+        "\n",
+        "print(\"The uploaded model name is: \", UPLOAD_MODEL_NAME)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NjXg3QHw2GCT"
+      },
+      "source": [
+        "### Deploy the uploaded model\n",
+        "\n",
+        "You will deploy models in Google Cloud Vertex AI. The default setting will use 1 V100 GPU for deployment.\n",
+        "\n",
+        "Please create a Service Account for serving with dockers if you do not have one yet.\n",
+        "\n",
+        "The model deployment will take around 1 minute to finish."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "BLTA7nRcw57D"
+      },
+      "outputs": [],
+      "source": [
+        "# Please go to https://cloud.google.com/iam/docs/service-accounts-create#iam-service-accounts-create-console\n",
+        "# and create service account with `Vertex AI User` and `Storage Object Admin` roles.\n",
+        "service_account = \"\"  # @param {type:\"string\"}\n",
+        "\n",
+        "endpoint = aiplatform.Endpoint.create(display_name=f\"{UPLOAD_MODEL_NAME}-endpoint\")\n",
+        "model.deploy(\n",
+        "    endpoint=endpoint,\n",
+        "    machine_type=PREDICTION_MACHINE_TYPE,\n",
+        "    accelerator_type=PREDICTION_ACCELERATOR_TYPE,\n",
+        "    accelerator_count=1,\n",
+        "    deploy_request_timeout=1800,\n",
+        "    service_account=service_account,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tMfwrH32_uIM"
+      },
+      "source": [
+        "The docker container still needs to download and load the model after the endpoint is created. Therefore, we recommend waiting for 3 extra minutes before proceeding to the next cell.\n",
+        "\n",
+        "Once deployed, you can send a batch of text prompts to the endpoint to generate images."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wr7wg9JQ_tjM"
+      },
+      "outputs": [],
+      "source": [
+        "import base64\n",
+        "from io import BytesIO\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "from PIL import Image\n",
+        "\n",
+        "instances = [\n",
+        "    {\"prompt\": \"Two monadikos teapots on a table\"},\n",
+        "    {\"prompt\": \"Two monadikos teapots on the floor\"},\n",
+        "]\n",
+        "response = endpoint.predict(instances=instances)\n",
+        "\n",
+        "plt.figure()\n",
+        "_, grid = plt.subplots(1, len(instances))\n",
+        "for cell, prediction in zip(grid, response.predictions):\n",
+        "    image = Image.open(BytesIO(base64.b64decode(prediction)))\n",
+        "    cell.imshow(image)"
       ]
     },
     {
@@ -613,7 +779,10 @@
       "outputs": [],
       "source": [
         "if training_job.list(filter=f'display_name=\"{TRAINING_JOB_DISPLAY_NAME}\"'):\n",
-        "    training_job.delete()"
+        "    training_job.delete()\n",
+        "# Undeploys models and deletes endpoints.\n",
+        "endpoint.delete(force=True)\n",
+        "model.delete()"
       ]
     },
     {


### PR DESCRIPTION
Add Vertex Online Prediction to #ModelGarden #MediaPipe image generation notebook.

Also fixed some issues in the notebook.

**REQUIRED:** Fill out the below checklists or remove if irrelevant

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

<br>