### PR TITLE
fix: increase the wait time for the service to start

### DIFF
--- a/notebooks/official/feature_store/online_feature_serving_and_vector_retrieval_bigquery_data_with_feature_store.ipynb
+++ b/notebooks/official/feature_store/online_feature_serving_and_vector_retrieval_bigquery_data_with_feature_store.ipynb
@@ -925,7 +925,7 @@
         "        status = \"Succeed\" if feature_view_sync.final_status.code == 0 else \"Failed\"\n",
         "        print(f\"Sync {status} for {feature_view_sync.name}.\")\n",
         "        # wait a little more for the job to properly shutdown\n",
-        "        time.sleep(30)\n",
+        "        time.sleep(120)\n",
         "        break\n",
         "    else:\n",
         "        print(\"Sync ongoing, waiting for 30 seconds.\")\n",


### PR DESCRIPTION
Increase the wait time for the service to start.

Error in a regression:https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/212286a8-5011-40ea-8ba5-ac51b21e4e7a?project=python-docs-samples-tests&e=13802955&mods=-ai_platform_fake_service