### PR TITLE
Update #ModelGarden TFVision notebooks model export docker URI.

### DIFF
--- a/notebooks/community/model_garden/model_garden_tfvision_image_classification.ipynb
+++ b/notebooks/community/model_garden/model_garden_tfvision_image_classification.ipynb
@@ -259,7 +259,7 @@
         "\n",
         "# Export constants.\n",
         "EXPORT_JOB_PREFIX = \"export\"\n",
-        "EXPORT_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/tfvision-serving\"\n",
+        "EXPORT_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/tfvision-model-export\"\n",
         "EXPORT_MACHINE_TYPE = \"n1-highmem-8\"\n",
         "\n",
         "# Prediction constants.\n",

--- a/notebooks/community/model_garden/model_garden_tfvision_image_object_detection.ipynb
+++ b/notebooks/community/model_garden/model_garden_tfvision_image_object_detection.ipynb
@@ -265,7 +265,7 @@
         "\n",
         "# Export constants.\n",
         "EXPORT_JOB_PREFIX = \"export\"\n",
-        "EXPORT_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/tfvision-serving\"\n",
+        "EXPORT_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/tfvision-model-export\"\n",
         "EXPORT_MACHINE_TYPE = \"n1-highmem-8\"\n",
         "\n",
         "# Prediction constants.\n",

--- a/notebooks/community/model_garden/model_garden_tfvision_image_segmentation.ipynb
+++ b/notebooks/community/model_garden/model_garden_tfvision_image_segmentation.ipynb
@@ -246,7 +246,7 @@
         "\n",
         "# Export constants.\n",
         "EXPORT_JOB_PREFIX = \"export\"\n",
-        "EXPORT_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/tfvision-serving\"\n",
+        "EXPORT_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/tfvision-model-export\"\n",
         "EXPORT_MACHINE_TYPE = \"n1-highmem-8\"\n",
         "\n",
         "# Prediction constants.\n",


### PR DESCRIPTION
Previously, the model export docker was named `tfvision-serving` which is confusing, since it's not supposed to be used as a serving docker in Vertex online prediction. `tfvision-model-export` is more appropriate. We have verified that the new docker URI is live in the production environment and is safe to switch.

**REQUIRED:** Fill out the below checklists or remove if irrelevant
<br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

<br>

