### PR TITLE
Remove extra print statement in LLaMA 2 notebook.

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
@@ -719,7 +719,6 @@
         "    headers={\"Content-Type\": \"application/json\"},\n",
         ")\n",
         "\n",
-        "print(\"Prompt:\\n\", prompt)\n",
         "text_len = 0\n",
         "print(\"Streaming:\")\n",
         "for output in get_streaming_response(response):\n",


### PR DESCRIPTION
Remove extra print statement in LLaMA 2 notebook.

<br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
<br>
2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
