### PR TITLE
Remove tensorboard billing alert from get_started_with_vertex_experim…

### DIFF
--- a/notebooks/official/experiments/get_started_with_vertex_experiments_autologging.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments_autologging.ipynb
@@ -119,7 +119,6 @@
         "This tutorial uses billable components of Google Cloud:\n",
         "\n",
         "* Vertex AI Experiments\n",
-        "* Vertex AI Tensorboard\n",
         "* Cloud Storage\n",
         "\n",
         "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing),\n",
@@ -855,15 +854,6 @@
         "Because some model types like TensorFlow result in autologging time series metrics, you need to create a TensorBoard instance.\n",
         "\n",
         "To create a TensorBoard instance, you can use `vertex_ai.Tensorboard.create()`.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mRoiPPk1XCWi"
-      },
-      "source": [
-        "<div class=\"alert alert-danger\">Notice that if you did not activate yet, Vertex AI TensorBoard charges a monthly fee of $300 per unique active user. Learn more about [TensorBoard overview](https://cloud.google.com/vertex-ai/docs/experiments/tensorboard-overview). </div>\n"
       ]
     },
     {


### PR DESCRIPTION
…ents_autologging.ipynb

<br>
With the updated tensorboard billing model users are no longer charged a subscription fee. We should remove the reference to this so users are not unnecessarily deterred. 
<br><br><br>