### PR TITLE
Update model_garden_pytorch_stable_diffusion_2_1.ipynb

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_stable_diffusion_2_1.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_stable_diffusion_2_1.ipynb
@@ -394,7 +394,7 @@
         "\n",
         "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
         "model_id = \"stabilityai/stable-diffusion-2-1\"\n",
-        "pipe = StableDiffusionPipeline.from_pretrained(model_id, torch_dtype=torch.float16)\n",
+        "pipe = StableDiffusionPipeline.from_pretrained(model_id)\n",
         "pipe.scheduler = DPMSolverMultistepScheduler.from_config(pipe.scheduler.config)\n",
         "pipe = pipe.to(device)\n",
         "pipe.enable_attention_slicing()\n",


### PR DESCRIPTION
Deleted `torch_dtype=torch.float16` on line 397

**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
--- YOUR PR SUMMARY GOES HERE ---

The notebook `notebooks/community/model_garden/model_garden_pytorch_stable_diffusion_2_1.ipynb` didn't work if the setting is default with the error on Colab Enterprise. 

I removed `torch_dtype=torch.float16`.

```
RuntimeError: "LayerNormKernelImpl" not implemented for 'Half' 
```
<br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team. @bingatgoogle
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

closes #2447 
