### PR TITLE
Update for GA relase, use v1 sdk, and remove known issues

### DIFF
--- a/notebooks/official/feature_store/online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb
+++ b/notebooks/official/feature_store/online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb
@@ -347,12 +347,11 @@
       "outputs": [],
       "source": [
         "from google.cloud import aiplatform, bigquery\n",
-        "from google.cloud.aiplatform_v1 import (\n",
-        "    FeatureOnlineStoreAdminServiceClient, FeatureOnlineStoreServiceClient,\n",
-        "    FeatureRegistryServiceClient)\n",
+        "from google.cloud.aiplatform_v1 import (FeatureOnlineStoreAdminServiceClient,\n",
+        "                                        FeatureOnlineStoreServiceClient,\n",
+        "                                        FeatureRegistryServiceClient)\n",
         "from google.cloud.aiplatform_v1.types import feature as feature_pb2\n",
-        "from google.cloud.aiplatform_v1.types import \\\n",
-        "    feature_group as feature_group_pb2\n",
+        "from google.cloud.aiplatform_v1.types import feature_group as feature_group_pb2\n",
         "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_online_store as feature_online_store_pb2\n",
         "from google.cloud.aiplatform_v1.types import \\\n",
@@ -362,8 +361,7 @@
         "    feature_online_store_service as feature_online_store_service_pb2\n",
         "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_registry_service as feature_registry_service_pb2\n",
-        "from google.cloud.aiplatform_v1.types import \\\n",
-        "    feature_view as feature_view_pb2\n",
+        "from google.cloud.aiplatform_v1.types import feature_view as feature_view_pb2\n",
         "from google.cloud.aiplatform_v1.types import \\\n",
         "    featurestore_service as featurestore_service_pb2\n",
         "from google.cloud.aiplatform_v1.types import io as io_pb2"
@@ -957,7 +955,7 @@
         ")"
       ]
     },
-     {
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "H1t0xA5XB_3n"

--- a/notebooks/official/feature_store/online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb
+++ b/notebooks/official/feature_store/online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb
@@ -161,9 +161,14 @@
       "outputs": [],
       "source": [
         "# Install the packages\n",
-        "! pip3 install --upgrade --quiet google-cloud-aiplatform\\\n",
-        "                                 google-cloud-bigquery\\\n",
-        "                                 db-dtypes"
+        "! pip3 install --upgrade --quiet google-cloud-bigquery\\\n",
+        "                                 db-dtypes\n",
+        "\n",
+        "# Uninstall previous version of google-cloud-aiplatform SDK\n",
+        "!pip3 uninstall google-cloud-aiplatform -y\n",
+        "\n",
+        "# Install the SDK from github\n",
+        "!pip3 install --upgrade git+https://github.com/googleapis/python-aiplatform.git"
       ]
     },
     {
@@ -356,26 +361,26 @@
       "outputs": [],
       "source": [
         "from google.cloud import aiplatform, bigquery\n",
-        "from google.cloud.aiplatform_v1beta1 import (\n",
+        "from google.cloud.aiplatform_v1 import (\n",
         "    FeatureOnlineStoreAdminServiceClient, FeatureOnlineStoreServiceClient,\n",
         "    FeatureRegistryServiceClient)\n",
-        "from google.cloud.aiplatform_v1beta1.types import feature as feature_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import feature as feature_pb2\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_group as feature_group_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_online_store as feature_online_store_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_online_store_admin_service as \\\n",
         "    feature_online_store_admin_service_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_online_store_service as feature_online_store_service_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_registry_service as feature_registry_service_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    feature_view as feature_view_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import \\\n",
+        "from google.cloud.aiplatform_v1.types import \\\n",
         "    featurestore_service as featurestore_service_pb2\n",
-        "from google.cloud.aiplatform_v1beta1.types import io as io_pb2"
+        "from google.cloud.aiplatform_v1.types import io as io_pb2"
       ]
     },
     {
@@ -966,6 +971,16 @@
         ")"
       ]
     },
+     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H1t0xA5XB_3n"
+      },
+      "source": [
+        "###Note\n",
+        "Syncing data into FeatureOnlineStores is a public Preview release. By using the feature, you acknowledge that you're aware of the open issues and that this preview is provided “as is” under the pre-GA terms of service.\n"
+      ]
+    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -1092,7 +1107,7 @@
         "data_client.fetch_feature_values(\n",
         "    request=feature_online_store_service_pb2.FetchFeatureValuesRequest(\n",
         "        feature_view=f\"projects/{PROJECT_ID}/locations/{REGION}/featureOnlineStores/{FEATURE_ONLINE_STORE_ID}/featureViews/{FEATURE_VIEW_ID}\",\n",
-        "        id=\"28098\",\n",
+        "        data_key=feature_online_store_service_pb2.FeatureViewDataKey(key=\"28098\"),\n",
         "    )\n",
         ")"
       ]
@@ -1117,8 +1132,8 @@
         "data_client.fetch_feature_values(\n",
         "    request=feature_online_store_service_pb2.FetchFeatureValuesRequest(\n",
         "        feature_view=f\"projects/{PROJECT_ID}/locations/{REGION}/featureOnlineStores/{FEATURE_ONLINE_STORE_ID}/featureViews/{FEATURE_VIEW_ID}\",\n",
-        "        id=\"28098\",\n",
-        "        format=feature_online_store_service_pb2.FetchFeatureValuesRequest.Format.PROTO_STRUCT,\n",
+        "        data_key=feature_online_store_service_pb2.FeatureViewDataKey(key=\"28098\"),\n",
+        "        data_format=feature_online_store_service_pb2.FeatureViewDataFormat.PROTO_STRUCT,\n",
         "    )\n",
         ")"
       ]
@@ -1175,7 +1190,7 @@
   ],
   "metadata": {
     "colab": {
-      "name": "online_feature_serving_and_fetching_bigquery_data_with_feature_store.ipynb",
+      "name": "online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb",
       "toc_visible": true
     },
     "kernelspec": {

--- a/notebooks/official/feature_store/online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb
+++ b/notebooks/official/feature_store/online_feature_serving_and_fetching_bigquery_data_with_feature_store_bigtable.ipynb
@@ -91,20 +91,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XIMD3zCgDGop"
-      },
-      "source": [
-        "### Known Issues\n",
-        "This public Preview release has the following known issues:\n",
-        "\n",
-        "- While running, the data sync pipeline creates temporary tables and datasets in your Google Cloud project. These tables and datasets can be viewed by all users who have `bigquery.tables.getData` permission for the project.\n",
-        "\n",
-        "The development team is actively working on resolutions for these issues. By using the feature, you acknowledge that you're aware of the open issues and that this preview is provided “as is” under the pre-GA terms of service."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "SbCa7Pcpqgaz"
       },
       "source": [


### PR DESCRIPTION
<br>
 - Uses new v1 SDK for Bigtable serving notebook example.
 -  Updates all FS 2 notebooks to use new `data_key` and `data_format` fields.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.