### PR TITLE
Fix typo in LLaMA 2 instructions.

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
@@ -717,7 +717,7 @@
         "]\n",
         "response = endpoint_without_peft.predict(instances=instances)\n",
         "\n",
-        "endpoint_output = response.predictions[0]:\n",
+        "endpoint_output = response.predictions[0]\n",
         "print(f\"[Endpoint output]\\n{endpoint_output}\\n\")\n",
         "\n",
         "model_output_start_index = endpoint_output.find(\"\\nOutput:\\n\") + len(\"\\nOutput:\\n\")\n",


### PR DESCRIPTION
This is a minor update to an existing notebook: Fix typo in LLaMA 2 instructions.

<br>


**REQUIRED:** Fill out the below checklists or remove if irrelevant

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
