### PR TITLE
increase max_num_batched_tokens for vllm and remove streaming

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_codellama.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_codellama.ipynb
@@ -314,7 +314,8 @@
         "        f\"--model={model_id}\",\n",
         "        f\"--tensor-parallel-size={accelerator_count}\",\n",
         "        f\"--swap-space={swap_space}\",\n",
-        "        \"--gpu-memory-utilization=0.95\",\n",
+        "        \"--gpu-memory-utilization=0.9\",\n",
+        "        \"--max_num_batched_tokens=4096\",\n",
         "        f\"--dtype={precision}\",\n",
         "        \"--disable-log-stats\",\n",
         "    ]\n",
@@ -691,59 +692,6 @@
         "]\n",
         "response = endpoint_vllm.predict(instances=instances)\n",
         "print(response.predictions[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "a327e35bcaf2"
-      },
-      "source": [
-        "Additionaly, you can send requests to the endpoint and get streaming response from it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "82a38f8815ef"
-      },
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "\n",
-        "import requests\n",
-        "\n",
-        "\n",
-        "def get_streaming_response(response: requests.Response):\n",
-        "    for chunk in response.iter_lines(\n",
-        "        chunk_size=8192, decode_unicode=False, delimiter=b\"\\0\"\n",
-        "    ):\n",
-        "        if chunk:\n",
-        "            data = json.loads(chunk.decode(\"utf-8\"))\n",
-        "            yield data\n",
-        "\n",
-        "\n",
-        "instance = {\n",
-        "    \"prompt\": \"import argparse\",\n",
-        "    \"n\": 1,\n",
-        "    \"max_tokens\": 200,\n",
-        "    \"temperature\": 1.0,\n",
-        "    \"top_p\": 1.0,\n",
-        "    \"top_k\": 10,\n",
-        "}\n",
-        "response = endpoint_vllm.raw_predict(\n",
-        "    body=json.dumps({\"instances\": [instance]}),\n",
-        "    headers={\"Content-Type\": \"application/json\"},\n",
-        ")\n",
-        "\n",
-        "text_len = 0\n",
-        "print(\"Streaming:\")\n",
-        "for output in get_streaming_response(response):\n",
-        "    text = output[\"predictions\"][0]\n",
-        "    print(text[text_len:])\n",
-        "    text_len = len(text)\n",
-        "print(\"Output:\\n\", text)"
       ]
     },
     {

--- a/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama2_peft.ipynb
@@ -358,7 +358,8 @@
         "        f\"--model={model_id}\",\n",
         "        f\"--tensor-parallel-size={accelerator_count}\",\n",
         "        \"--swap-space=16\",\n",
-        "        \"--gpu-memory-utilization=0.95\",\n",
+        "        \"--gpu-memory-utilization=0.9\",\n",
+        "        \"--max_num_batched_tokens=4096\",\n",
         "        \"--disable-log-stats\",\n",
         "    ]\n",
         "    model = aiplatform.Model.upload(\n",
@@ -832,57 +833,6 @@
         "}\n",
         "response = endpoint_without_peft_vllm.predict(instances=[instance])\n",
         "print(response.predictions[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4c1a59efe76b"
-      },
-      "source": [
-        "Additionaly, you can send requests to the endpoint and get streaming response from it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "72a02bc98640"
-      },
-      "outputs": [],
-      "source": [
-        "import requests\n",
-        "\n",
-        "\n",
-        "def get_streaming_response(response: requests.Response):\n",
-        "    for chunk in response.iter_lines(\n",
-        "        chunk_size=8192, decode_unicode=False, delimiter=b\"\\0\"\n",
-        "    ):\n",
-        "        if chunk:\n",
-        "            data = json.loads(chunk.decode(\"utf-8\"))\n",
-        "            yield data\n",
-        "\n",
-        "\n",
-        "instance = {\n",
-        "    \"prompt\": \"Hi, Google.\",\n",
-        "    \"n\": 1,\n",
-        "    \"max_tokens\": 32,\n",
-        "    \"temperature\": 1.0,\n",
-        "    \"top_p\": 1.0,\n",
-        "    \"top_k\": 10,\n",
-        "}\n",
-        "response = endpoint_without_peft_vllm.raw_predict(\n",
-        "    body=json.dumps({\"instances\": [instance]}),\n",
-        "    headers={\"Content-Type\": \"application/json\"},\n",
-        ")\n",
-        "\n",
-        "text_len = 0\n",
-        "print(\"Streaming:\")\n",
-        "for output in get_streaming_response(response):\n",
-        "    text = output[\"predictions\"][0]\n",
-        "    print(text[text_len:])\n",
-        "    text_len = len(text)\n",
-        "print(\"Output:\\n\", text)"
       ]
     },
     {

--- a/notebooks/community/model_garden/model_garden_pytorch_mistral.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_mistral.ipynb
@@ -305,6 +305,7 @@
         "        \"--swap-space=16\",\n",
         "        f\"--dtype={dtype}\",\n",
         "        \"--gpu-memory-utilization=0.9\",\n",
+        "        \"--max_num_batched_tokens=4096\",\n",
         "        \"--disable-log-stats\",\n",
         "    ]\n",
         "    model = aiplatform.Model.upload(\n",
@@ -486,53 +487,6 @@
         "}\n",
         "response = endpoint.predict(instances=[instance])\n",
         "print(response.predictions[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2c454f993e13"
-      },
-      "source": [
-        "Additionaly, you can send requests to the endpoint and get streaming response from it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "43f0f4511728"
-      },
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "\n",
-        "import requests\n",
-        "\n",
-        "\n",
-        "def get_streaming_response(response: requests.Response):\n",
-        "    for chunk in response.iter_lines(\n",
-        "        chunk_size=8192, decode_unicode=False, delimiter=b\"\\0\"\n",
-        "    ):\n",
-        "        if chunk:\n",
-        "            data = json.loads(chunk.decode(\"utf-8\"))\n",
-        "            yield data\n",
-        "\n",
-        "\n",
-        "instance = {\"prompt\": \"How are you doing?\", \"n\": 1, \"max_tokens\": 32, \"stream\": True}\n",
-        "response = endpoint.raw_predict(\n",
-        "    body=json.dumps({\"instances\": [instance]}),\n",
-        "    headers={\"Content-Type\": \"application/json\"},\n",
-        ")\n",
-        "\n",
-        "print(\"Prompt:\\n\", prompt)\n",
-        "text_len = 0\n",
-        "print(\"Streaming:\")\n",
-        "for output in get_streaming_response(response):\n",
-        "    text = output[\"predictions\"][0]\n",
-        "    print(text[text_len:])\n",
-        "    text_len = len(text)\n",
-        "print(\"Output:\\n\", text)"
       ]
     },
     {

--- a/notebooks/community/model_garden/model_garden_pytorch_openllama_peft.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_openllama_peft.ipynb
@@ -332,7 +332,8 @@
         "        f\"--model={model_id}\",\n",
         "        f\"--tensor-parallel-size={accelerator_count}\",\n",
         "        \"--swap-space=4\",\n",
-        "        \"--gpu-memory-utilization=0.95\",\n",
+        "        \"--gpu-memory-utilization=0.9\",\n",
+        "        \"--max_num_batched_tokens=4096\",\n",
         "        \"--disable-log-stats\",\n",
         "    ]\n",
         "    model = aiplatform.Model.upload(\n",
@@ -515,59 +516,6 @@
         "}\n",
         "response = endpoint_without_peft.predict(instances=[instance])\n",
         "print(response.predictions[0])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "99b8e659d577"
-      },
-      "source": [
-        "Additionaly, you can send requests to the endpoint and get streaming response from it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "531481ed399d"
-      },
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "\n",
-        "import requests\n",
-        "\n",
-        "\n",
-        "def get_streaming_response(response: requests.Response):\n",
-        "    for chunk in response.iter_lines(\n",
-        "        chunk_size=8192, decode_unicode=False, delimiter=b\"\\0\"\n",
-        "    ):\n",
-        "        if chunk:\n",
-        "            data = json.loads(chunk.decode(\"utf-8\"))\n",
-        "            yield data\n",
-        "\n",
-        "\n",
-        "instance = {\n",
-        "    \"prompt\": \"Hi, Google. How are you doing?\",\n",
-        "    \"n\": 1,\n",
-        "    \"max_tokens\": 32,\n",
-        "    \"temperature\": 1.0,\n",
-        "    \"top_p\": 1.0,\n",
-        "    \"top_k\": 10,\n",
-        "}\n",
-        "response = endpoint_without_peft.raw_predict(\n",
-        "    body=json.dumps({\"instances\": [instance]}),\n",
-        "    headers={\"Content-Type\": \"application/json\"},\n",
-        ")\n",
-        "\n",
-        "text_len = 0\n",
-        "print(\"Streaming:\")\n",
-        "for output in get_streaming_response(response):\n",
-        "    text = output[\"predictions\"][0]\n",
-        "    print(text[text_len:])\n",
-        "    text_len = len(text)\n",
-        "print(\"Output:\\n\", text)"
       ]
     },
     {


### PR DESCRIPTION
**REQUIRED:** increase max_num_batched_tokens for vllm and remove streaming

1. Increase `--max_num_batched_tokens` to 4096 for longer sequence.
2. Remove streaming mode, it's not supported by Vertex SDK endpoint APIs yet.

**REQUIRED:** Fill out the below checklists or remove if irrelevant

3. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [ y] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ y] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

