### PR TITLE
Update timm notebook to use vertex-ai docker link.

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_timm.ipynb
@@ -54,7 +54,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "76BCoQcm2AMJ"
@@ -125,7 +124,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ad1f36f4b5c3"
@@ -233,7 +231,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "14a500024b7b"
@@ -245,7 +242,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "54859170c1ad"
@@ -272,7 +268,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "17e6d8a0dac3"
@@ -294,7 +289,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "0f2ce8fa5439"
@@ -328,7 +322,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "8a6e2ea460ad"
@@ -352,7 +345,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "691139fc5789"
@@ -380,7 +372,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "a8740b668da6"
@@ -405,7 +396,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "4120d1585355"
@@ -429,7 +419,9 @@
       "outputs": [],
       "source": [
         "# The prebuilt training docker uri.\n",
-        "TRAIN_DOCKER_URI = \"us-docker.pkg.dev/vertex-ai-restricted/vertex-vision-model-garden-dockers/pytorch-timm-train\"\n",
+        "TRAIN_DOCKER_URI = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-timm-train\"\n",
+        ")\n",
         "\n",
         "# The path to data directory on Cloud Storage without gs:// prefix.\n",
         "# In the form of: <bucket-name>/path-to-data\n",


### PR DESCRIPTION
Update existing timm notebook to use vertex-ai docker link.

<br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
