### PR TITLE
Fix: update video in workbook title

### DIFF
--- a/notebooks/official/model_evaluation/automl_video_classification_model_evaluation.ipynb
+++ b/notebooks/official/model_evaluation/automl_video_classification_model_evaluation.ipynb
@@ -29,7 +29,7 @@
         "id": "title"
       },
       "source": [
-        "# Vertex AI Pipelines: Evaluating batch prediction results from AutoML Video classification model\n",
+        "# Vertex AI Pipelines: Evaluating batch prediction results from AutoML video classification model\n",
         "\n",
         "<table align=\"left\">\n",
         "\n",
@@ -654,7 +654,6 @@
         "models = aiplatform.Model.list(filter=\"display_name=hmdb\")\n",
         "\n",
         "if len(models) != 0:\n",
-        "\n",
         "    # Get the model object\n",
         "    MODEL_RSC_NAME = models[0].resource_name\n",
         "    print(\"Vertex AI Model resource name:\", MODEL_RSC_NAME)\n",


### PR DESCRIPTION
Lowercase "video" in the notebook title, plus a small formatting change.