### PR TITLE
feat: adding Vertex AI Deployer notebook

### DIFF
--- a/notebooks/community/CODEOWNERS
+++ b/notebooks/community/CODEOWNERS
@@ -109,3 +109,4 @@
 /notebooks/community/model_garden/model_garden_pytorch_llama2_evaluation.ipynb @kathyyu-google
 /notebooks/community/model_garden/model_garden_pytorch_llama2_rlhf_tuning.ipynb @genquan9
 /notebooks/community/model_garden/model_garden_pytorch_wizard_coder.ipynb @KCFindstr
+/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb angelmontero@ @inardini

--- a/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
+++ b/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
@@ -1,981 +1,1000 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ur8xi4C7S06n"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2023 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JAPoU8Sm5E6e"
-      },
-      "source": [
-        "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "24743cf4a1e1"
-      },
-      "source": [
-        "**_NOTE_**: This notebook has been tested in the following environment:\n",
-        "\n",
-        "* Python version = 3.9"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tvgnzT1CKxrO"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "After a model is trained, validated and added to model registry, it is ready for deployment. Before to deploy the model, you may need to go through continuous deployment process to test and validate the model.\n",
-        "\n",
-        "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
-        "\n",
-        "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "d975e698c9a4"
-      },
-      "source": [
-        "### Objective\n",
-        "\n",
-        "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
-        "\n",
-        "This tutorial uses the following Google Cloud ML services and resources:\n",
-        "\n",
-        "- Vertex AI Model Registry\n",
-        "- Vertex AI Endpoint\n",
-        "- Cloud Deploy\n",
-        "\n",
-        "The steps performed include:\n",
-        "\n",
-        "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
-        "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
-        "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "08d289fa873f"
-      },
-      "source": [
-        "### Dataset\n",
-        "\n",
-        "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aed92deeb4a0"
-      },
-      "source": [
-        "### Costs\n",
-        "\n",
-        "This tutorial uses billable components of Google Cloud:\n",
-        "\n",
-        "* Vertex AI\n",
-        "* Cloud Storage\n",
-        "* Cloud Deploy\n",
-        "\n",
-        "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
-        "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
-        "to generate a cost estimate based on your projected usage."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hiz2inv3pywJ"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
-        "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "i7EUnXsZhAGF"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "Install the following packages required to execute this notebook.\n",
-        "\n",
-        "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2b4ef9b72d43"
-      },
-      "outputs": [],
-      "source": [
-        "# Install the packages\n",
-        "import os\n",
-        "\n",
-        "if not os.getenv(\"IS_TESTING\"):\n",
-        "    USER = \"--user\"\n",
-        "else:\n",
-        "    USER = \"\"\n",
-        "! pip3 install {USER} --upgrade google-cloud-aiplatform"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "58707a750154"
-      },
-      "source": [
-        "### Colab only: Uncomment the following cell to restart the kernel."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f200f10a1da3"
-      },
-      "outputs": [],
-      "source": [
-        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-        "# import IPython\n",
-        "\n",
-        "# app = IPython.Application.instance()\n",
-        "# app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BF1j6f9HApxa"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
-        "\n",
-        "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
-        "\n",
-        "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WReHDGG5g0XY"
-      },
-      "source": [
-        "#### Set your project ID\n",
-        "\n",
-        "**If you don't know your project ID**, try the following:\n",
-        "* Run `gcloud config list`.\n",
-        "* Run `gcloud projects list`.\n",
-        "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "oM1iC_MfAts1"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-        "\n",
-        "# Set the project id\n",
-        "! gcloud config set project {PROJECT_ID}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QAup21nz6LHk"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sBCra4QMA2wR"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "74ccc9e52986"
-      },
-      "source": [
-        "**1. Vertex AI Workbench**\n",
-        "* Do nothing as you are already authenticated."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "de775a3773ba"
-      },
-      "source": [
-        "**2. Local JupyterLab instance, uncomment and run:**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "254614fa0c46"
-      },
-      "outputs": [],
-      "source": [
-        "# ! gcloud auth login"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ef21552ccea8"
-      },
-      "source": [
-        "**3. Colab, uncomment and run:**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "603adbbf0532"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import auth\n",
-        "# auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "f6b2ccc891ed"
-      },
-      "source": [
-        "**4. Service account or other**\n",
-        "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zgPO1eR3CYjk"
-      },
-      "source": [
-        "### Create a Cloud Storage bucket\n",
-        "\n",
-        "Create a storage bucket to store intermediate artifacts such as datasets."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "MzGDU7TWdts_"
-      },
-      "outputs": [],
-      "source": [
-        "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-EcIXiGsCePi"
-      },
-      "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NIq7R4HZCfIc"
-      },
-      "outputs": [],
-      "source": [
-        "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "set_service_account"
-      },
-      "source": [
-        "### Service Account\n",
-        "\n",
-        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "CRriz5kNGEv7"
-      },
-      "outputs": [],
-      "source": [
-        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "autoset_service_account"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "IS_COLAB = \"google.colab\" in sys.modules\n",
-        "\n",
-        "if (\n",
-        "    SERVICE_ACCOUNT == \"\"\n",
-        "    or SERVICE_ACCOUNT is None\n",
-        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-        "):\n",
-        "    # Get your service account from gcloud\n",
-        "    if not IS_COLAB:\n",
-        "        shell_output = !gcloud auth list 2>/dev/null\n",
-        "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
-        "\n",
-        "    if IS_COLAB:\n",
-        "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
-        "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
-        "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
-        "\n",
-        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_LhX1D3Z12Ce"
-      },
-      "source": [
-        "### Set permissions for the service account\n",
-        "\n",
-        "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
-        "\n",
-        "To use Cloud Deploy, you need to set the following roles on your service account:\n",
-        "\n",
-        "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
-        "\n",
-        "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
-        "\n",
-        "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
-        "\n",
-        "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
-        "\n",
-        "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
-        "\n",
-        "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "u9e6Q-9Ke9nW"
-      },
-      "outputs": [],
-      "source": [
-        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-        "    --role=\"roles/clouddeploy.jobRunner\"\n",
-        "\n",
-        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-        "    --role=\"roles/clouddeploy.developer\"\n",
-        "\n",
-        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-        "    --role=\"roles/clouddeploy.operator\"\n",
-        "\n",
-        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-        "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
-        "\n",
-        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-        "    --role=\"roles/containeranalysis.notes.editor\"\n",
-        "\n",
-        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-        "    --role=\"roles/aiplatform.user\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "960505627ddf"
-      },
-      "source": [
-        "### Import libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PyQmSRbKA8r-"
-      },
-      "outputs": [],
-      "source": [
-        "from google.cloud import aiplatform as vertex_ai"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8e20nW5yH-s5"
-      },
-      "source": [
-        "### Set variables\n",
-        "\n",
-        "Below you set the model and the serving image you use in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "M6iyDeMrIAVl"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL_URI = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model\"\n",
-        "DEPLOY_IMAGE = (\n",
-        "    \"us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk,all"
-      },
-      "source": [
-        "### Initialize Vertex AI SDK for Python\n",
-        "\n",
-        "Initialize the Vertex AI SDK for Python for your project."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xfFTb9Tu6LHm"
-      },
-      "outputs": [],
-      "source": [
-        "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vdQmak-2Gk7L"
-      },
-      "source": [
-        "## Introduction to Cloud Deploy Vertex AI Deployer\n",
-        "\n",
-        "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
-        "\n",
-        "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
-        "\n",
-        "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qnrHVkk4G0MB"
-      },
-      "source": [
-        "### Register a model into Vertex AI Model Registry\n",
-        "\n",
-        "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
-        "\n",
-        "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-uc1K6GRHwGO"
-      },
-      "outputs": [],
-      "source": [
-        "registered_model = vertex_ai.Model.upload(\n",
-        "    display_name=\"model_to_deploy\",\n",
-        "    artifact_uri=MODEL_URI,\n",
-        "    serving_container_image_uri=DEPLOY_IMAGE,\n",
-        ")\n",
-        "\n",
-        "print(registered_model)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EJebO0xRKZwO"
-      },
-      "source": [
-        "### Create a Vertex AI Endpoint\n",
-        "\n",
-        "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "JgSJ2TrbLB4-"
-      },
-      "outputs": [],
-      "source": [
-        "endpoint = vertex_ai.Endpoint.create(\n",
-        "    display_name=\"target_endpoint\",\n",
-        "    project=PROJECT_ID,\n",
-        "    location=REGION,\n",
-        ")\n",
-        "\n",
-        "print(endpoint)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2QYcYzLo5cbY"
-      },
-      "source": [
-        "### Create delivery pipeline, target, and custom target type\n",
-        "\n",
-        "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
-        "\n",
-        "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
-        "\n",
-        "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
-        "\n",
-        "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
-        "\n",
-        "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
-        "\n",
-        "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
-        "\n",
-        "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "h20VT-mAQZg4"
-      },
-      "outputs": [],
-      "source": [
-        "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
-        "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YlJC-lPVRJ0H"
-      },
-      "source": [
-        "Run the script that builds the image and registers the custom target type."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "HUYVCRSaj6qV"
-      },
-      "outputs": [],
-      "source": [
-        "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BoaLsEOq5iEW"
-      },
-      "source": [
-        "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qNLigFcXkcsa"
-      },
-      "outputs": [],
-      "source": [
-        "endpoint_id = endpoint.name\n",
-        "\n",
-        "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9ejsEd8s556r"
-      },
-      "source": [
-        "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rUJ3Kxr_6pbw"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sL4LBtjp5HgL"
-      },
-      "source": [
-        "### Create a release and rollout\n",
-        "\n",
-        "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoind.\n",
-        "\n",
-        "To create a Cloud Deploy release, you have to specify\n",
-        "\n",
-        "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
-        "\n",
-        "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
-        "\n",
-        "Here, you provide the custom deployer with two parameters:\n",
-        "\n",
-        "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
-        "\n",
-        "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
-        "is specified by `--project` and `--region` respectively."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0vzd0UBl4HHB"
-      },
-      "outputs": [],
-      "source": [
-        "model_id = registered_model.name\n",
-        "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
-        "\n",
-        "! gcloud deploy releases create release-0001 \\\n",
-        "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
-        "    --project=$PROJECT_ID \\\n",
-        "    --region=$REGION \\\n",
-        "    --source=configuration \\\n",
-        "    --deploy-parameters=$deploy_params"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AjtDtH7d7uSQ"
-      },
-      "source": [
-        "### Monitor the release's progress\n",
-        "\n",
-        "To check release details, run the command below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qnGUFIFP729K"
-      },
-      "outputs": [],
-      "source": [
-        "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "riBnpRaB76jP"
-      },
-      "source": [
-        "Run this command to filter only the render status of the release.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "nNZVgIc07-EK"
-      },
-      "outputs": [],
-      "source": [
-        "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5QNy6BErIBBU"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>\n",
-        "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
-        "</b>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mk7IFJ4Z8Bn5"
-      },
-      "source": [
-        "### Monitor rollout status"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "s0uHB9TC8F7G"
-      },
-      "source": [
-        "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
-        "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
-        "\n",
-        "You can also describe the rollout created using the following command."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3Q0eur7x8Iei"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "g4TYF0Jd8LML"
-      },
-      "source": [
-        "### Inspect Endpoint of the deployed model\n",
-        "\n",
-        "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3vr2mSBl8RLs"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "g1SsVCBYsG1c"
-      },
-      "source": [
-        "### Inspect aliases in the deployed model\n",
-        "\n",
-        "Monitor the post-deploy operation by querying the rollout.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6jm1hKEqsPh1"
-      },
-      "outputs": [],
-      "source": [
-        "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yI7Sv4lUsW55"
-      },
-      "source": [
-        "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "RE1jmGb4sWmW"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TpV-iwP9qw9c"
-      },
-      "source": [
-        "## Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "h4Kdd7P4Wdyt"
-      },
-      "outputs": [],
-      "source": [
-        "delete_endpoint = True\n",
-        "delete_model = True\n",
-        "delete_cloud_deploy = True\n",
-        "\n",
-        "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
-        "    endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
-        "    for endpoint in endpoint_list:\n",
-        "        endpoint.delete(force=True)\n",
-        "\n",
-        "if delete_model or os.getenv(\"IS_TESTING\"):\n",
-        "    model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
-        "    for model in model_list:\n",
-        "        model.delete()\n",
-        "\n",
-        "if delete_model or os.getenv(\"IS_TESTING\"):\n",
-        "    ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "get_started_with_vertex_ai_deployer.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ur8xi4C7S06n"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2023 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JAPoU8Sm5E6e"
+   },
+   "source": [
+    "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "24743cf4a1e1"
+   },
+   "source": [
+    "**_NOTE_**: This notebook has been tested in the following environment:\n",
+    "\n",
+    "* Python version = 3.9"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tvgnzT1CKxrO"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "After a model is trained, validated and added to model registry, it is ready for deployment. Before deploying the model, you may need to  go through a continuous deployment process deployment process to test and validate the model.\n",
+    "\n",
+    "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
+    "\n",
+    "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "d975e698c9a4"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
+    "\n",
+    "This tutorial uses the following Google Cloud ML services and resources:\n",
+    "\n",
+    "- Vertex AI Model Registry\n",
+    "- Vertex AI Endpoint\n",
+    "- Cloud Deploy\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
+    "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
+    "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "08d289fa873f"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aed92deeb4a0"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "* Cloud Deploy\n",
+    "\n",
+    "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
+    "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hiz2inv3pywJ"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
+    "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "i7EUnXsZhAGF"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the following packages required to execute this notebook.\n",
+    "\n",
+    "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2b4ef9b72d43"
+   },
+   "outputs": [],
+   "source": [
+    "# Install the packages\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    USER = \"--user\"\n",
+    "else:\n",
+    "    USER = \"\"\n",
+    "! pip3 install {USER} --upgrade google-cloud-aiplatform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "58707a750154"
+   },
+   "source": [
+    "### Colab only: Uncomment the following cell to restart the kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f200f10a1da3"
+   },
+   "outputs": [],
+   "source": [
+    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "# import IPython\n",
+    "\n",
+    "# app = IPython.Application.instance()\n",
+    "# app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BF1j6f9HApxa"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
+    "\n",
+    "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
+    "\n",
+    "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WReHDGG5g0XY"
+   },
+   "source": [
+    "#### Set your project ID\n",
+    "\n",
+    "**If you don't know your project ID**, try the following:\n",
+    "* Run `gcloud config list`.\n",
+    "* Run `gcloud projects list`.\n",
+    "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oM1iC_MfAts1"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Set the project id\n",
+    "! gcloud config set project {PROJECT_ID}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QAup21nz6LHk"
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sBCra4QMA2wR"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "74ccc9e52986"
+   },
+   "source": [
+    "**1. Vertex AI Workbench**\n",
+    "* Do nothing as you are already authenticated."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "de775a3773ba"
+   },
+   "source": [
+    "**2. Local JupyterLab instance, uncomment and run:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "254614fa0c46"
+   },
+   "outputs": [],
+   "source": [
+    "# ! gcloud auth login"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ef21552ccea8"
+   },
+   "source": [
+    "**3. Colab, uncomment and run:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "603adbbf0532"
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import auth\n",
+    "# auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "f6b2ccc891ed"
+   },
+   "source": [
+    "**4. Service account or other**\n",
+    "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zgPO1eR3CYjk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "Create a storage bucket to store intermediate artifacts such as datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MzGDU7TWdts_"
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-EcIXiGsCePi"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NIq7R4HZCfIc"
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CRriz5kNGEv7"
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "IS_COLAB = \"google.colab\" in sys.modules\n",
+    "\n",
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your service account from gcloud\n",
+    "    if not IS_COLAB:\n",
+    "        shell_output = !gcloud auth list 2>/dev/null\n",
+    "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
+    "\n",
+    "    if IS_COLAB:\n",
+    "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
+    "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
+    "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
+    "\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_LhX1D3Z12Ce"
+   },
+   "source": [
+    "### Set permissions for the service account\n",
+    "\n",
+    "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
+    "\n",
+    "To use Cloud Deploy, you need to set the following roles on your service account:\n",
+    "\n",
+    "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
+    "\n",
+    "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
+    "\n",
+    "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
+    "\n",
+    "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
+    "\n",
+    "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
+    "\n",
+    "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u9e6Q-9Ke9nW"
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.jobRunner\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.developer\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.operator\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/containeranalysis.notes.editor\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/aiplatform.user\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "960505627ddf"
+   },
+   "source": [
+    "### Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PyQmSRbKA8r-"
+   },
+   "outputs": [],
+   "source": [
+    "from google.cloud import aiplatform as vertex_ai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8e20nW5yH-s5"
+   },
+   "source": [
+    "### Set variables\n",
+    "\n",
+    "Below you set the model and the serving image you use in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "M6iyDeMrIAVl"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_URI = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model\"\n",
+    "DEPLOY_IMAGE = (\n",
+    "    \"us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk,all"
+   },
+   "source": [
+    "### Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xfFTb9Tu6LHm"
+   },
+   "outputs": [],
+   "source": [
+    "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vdQmak-2Gk7L"
+   },
+   "source": [
+    "## Introduction to Cloud Deploy Vertex AI Deployer\n",
+    "\n",
+    "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
+    "\n",
+    "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
+    "\n",
+    "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qnrHVkk4G0MB"
+   },
+   "source": [
+    "### Register a model into Vertex AI Model Registry\n",
+    "\n",
+    "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
+    "\n",
+    "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-uc1K6GRHwGO"
+   },
+   "outputs": [],
+   "source": [
+    "registered_model = vertex_ai.Model.upload(\n",
+    "    display_name=\"model_to_deploy\",\n",
+    "    artifact_uri=MODEL_URI,\n",
+    "    serving_container_image_uri=DEPLOY_IMAGE,\n",
+    ")\n",
+    "\n",
+    "print(registered_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EJebO0xRKZwO"
+   },
+   "source": [
+    "### Create a Vertex AI Endpoint\n",
+    "\n",
+    "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JgSJ2TrbLB4-"
+   },
+   "outputs": [],
+   "source": [
+    "endpoint = vertex_ai.Endpoint.create(\n",
+    "    display_name=\"target_endpoint\",\n",
+    "    project=PROJECT_ID,\n",
+    "    location=REGION,\n",
+    ")\n",
+    "\n",
+    "print(endpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2QYcYzLo5cbY"
+   },
+   "source": [
+    "### Create delivery pipeline, target, and custom target type\n",
+    "\n",
+    "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
+    "\n",
+    "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
+    "\n",
+    "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
+    "\n",
+    "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
+    "\n",
+    "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
+    "\n",
+    "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
+    "\n",
+    "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h20VT-mAQZg4"
+   },
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
+    "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YlJC-lPVRJ0H"
+   },
+   "source": [
+    "Run the script that builds the image and registers the custom target type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "HUYVCRSaj6qV"
+   },
+   "outputs": [],
+   "source": [
+    "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BoaLsEOq5iEW"
+   },
+   "source": [
+    "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qNLigFcXkcsa"
+   },
+   "outputs": [],
+   "source": [
+    "endpoint_id = endpoint.name\n",
+    "\n",
+    "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9ejsEd8s556r"
+   },
+   "source": [
+    "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rUJ3Kxr_6pbw"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sL4LBtjp5HgL"
+   },
+   "source": [
+    "### Create a release and rollout\n",
+    "\n",
+    "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoint.\n",
+    "\n",
+    "To create a Cloud Deploy release, you have to specify\n",
+    "\n",
+    "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
+    "\n",
+    "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
+    "\n",
+    "Here, you provide the custom deployer with two parameters:\n",
+    "\n",
+    "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
+    "\n",
+    "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
+    "is specified by `--project` and `--region` respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0vzd0UBl4HHB"
+   },
+   "outputs": [],
+   "source": [
+    "model_id = registered_model.name\n",
+    "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
+    "\n",
+    "! gcloud deploy releases create release-0001 \\\n",
+    "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
+    "    --project=$PROJECT_ID \\\n",
+    "    --region=$REGION \\\n",
+    "    --source=configuration \\\n",
+    "    --deploy-parameters=$deploy_params"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AjtDtH7d7uSQ"
+   },
+   "source": [
+    "### Monitor the release's progress\n",
+    "\n",
+    "To check release details, run the command below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qnGUFIFP729K"
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "riBnpRaB76jP"
+   },
+   "source": [
+    "Run this command to filter only the render status of the release.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nNZVgIc07-EK"
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5QNy6BErIBBU"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>\n",
+    "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
+    "</b>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mk7IFJ4Z8Bn5"
+   },
+   "source": [
+    "### Monitor rollout status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "s0uHB9TC8F7G"
+   },
+   "source": [
+    "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
+    "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
+    "\n",
+    "You can also describe the rollout created using the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3Q0eur7x8Iei"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g4TYF0Jd8LML"
+   },
+   "source": [
+    "### Inspect Endpoint of the deployed model\n",
+    "\n",
+    "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3vr2mSBl8RLs"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g1SsVCBYsG1c"
+   },
+   "source": [
+    "### Inspect aliases in the deployed model\n",
+    "\n",
+    "Monitor the post-deploy operation by querying the rollout.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6jm1hKEqsPh1"
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yI7Sv4lUsW55"
+   },
+   "source": [
+    "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "RE1jmGb4sWmW"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TpV-iwP9qw9c"
+   },
+   "source": [
+    "## Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h4Kdd7P4Wdyt"
+   },
+   "outputs": [],
+   "source": [
+    "delete_endpoint = True\n",
+    "delete_model = True\n",
+    "delete_cloud_deploy = True\n",
+    "\n",
+    "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
+    "    endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
+    "    for endpoint in endpoint_list:\n",
+    "        endpoint.delete(force=True)\n",
+    "\n",
+    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+    "    model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
+    "    for model in model_list:\n",
+    "        model.delete()\n",
+    "\n",
+    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+    "    ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "get_started_with_vertex_ai_deployer.ipynb",
+   "toc_visible": true
+  },
+  "environment": {
+   "kernel": "python3",
+   "name": "tf2-cpu.2-11.m114",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/tf2-cpu.2-11:m114"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (Local)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
+++ b/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
@@ -1,1027 +1,981 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ur8xi4C7S06n"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2023 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "JAPoU8Sm5E6e"
-   },
-   "source": [
-    "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "24743cf4a1e1"
-   },
-   "source": [
-    "**_NOTE_**: This notebook has been tested in the following environment:\n",
-    "\n",
-    "* Python version = 3.9"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "tvgnzT1CKxrO"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "After a model is trained, validated and added to model registry, it is ready for deployment. Before to deploy the model, you may need to go through continuous deployment process to test and validate the model.\n",
-    "\n",
-    "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
-    "\n",
-    "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "d975e698c9a4"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
-    "\n",
-    "This tutorial uses the following Google Cloud ML services and resources:\n",
-    "\n",
-    "- Vertex AI Model Registry\n",
-    "- Vertex AI Endpoint\n",
-    "- Cloud Deploy\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
-    "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
-    "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "08d289fa873f"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aed92deeb4a0"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "* Cloud Deploy\n",
-    "\n",
-    "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
-    "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "hiz2inv3pywJ"
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
-    "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "i7EUnXsZhAGF"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the following packages required to execute this notebook.\n",
-    "\n",
-    "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "2b4ef9b72d43",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Install the packages\n",
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    USER = \"--user\"\n",
-    "else:\n",
-    "    USER = \"\"\n",
-    "! pip3 install {USER} --upgrade google-cloud-aiplatform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "58707a750154"
-   },
-   "source": [
-    "### Colab only: Uncomment the following cell to restart the kernel."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "f200f10a1da3"
-   },
-   "outputs": [],
-   "source": [
-    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-    "# import IPython\n",
-    "\n",
-    "# app = IPython.Application.instance()\n",
-    "# app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BF1j6f9HApxa"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
-    "\n",
-    "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
-    "\n",
-    "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "WReHDGG5g0XY"
-   },
-   "source": [
-    "#### Set your project ID\n",
-    "\n",
-    "**If you don't know your project ID**, try the following:\n",
-    "* Run `gcloud config list`.\n",
-    "* Run `gcloud projects list`.\n",
-    "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "oM1iC_MfAts1",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-    "\n",
-    "# Set the project id\n",
-    "! gcloud config set project {PROJECT_ID}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "QAup21nz6LHk",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "sBCra4QMA2wR"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "74ccc9e52986"
-   },
-   "source": [
-    "**1. Vertex AI Workbench**\n",
-    "* Do nothing as you are already authenticated."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "de775a3773ba"
-   },
-   "source": [
-    "**2. Local JupyterLab instance, uncomment and run:**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "254614fa0c46",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# ! gcloud auth login"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ef21552ccea8"
-   },
-   "source": [
-    "**3. Colab, uncomment and run:**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "603adbbf0532",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# from google.colab import auth\n",
-    "# auth.authenticate_user()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "f6b2ccc891ed"
-   },
-   "source": [
-    "**4. Service account or other**\n",
-    "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "zgPO1eR3CYjk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "Create a storage bucket to store intermediate artifacts such as datasets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "MzGDU7TWdts_",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-EcIXiGsCePi"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "NIq7R4HZCfIc",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "CRriz5kNGEv7",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "IS_COLAB = \"google.colab\" in sys.modules\n",
-    "\n",
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your service account from gcloud\n",
-    "    if not IS_COLAB:\n",
-    "        shell_output = !gcloud auth list 2>/dev/null\n",
-    "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
-    "\n",
-    "    if IS_COLAB:\n",
-    "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
-    "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
-    "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
-    "\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "_LhX1D3Z12Ce"
-   },
-   "source": [
-    "### Set permissions for the service account\n",
-    "\n",
-    "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
-    "\n",
-    "To use Cloud Deploy, you need to set the following roles on your service account:\n",
-    "\n",
-    "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
-    "\n",
-    "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
-    "\n",
-    "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
-    "\n",
-    "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
-    "\n",
-    "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
-    "\n",
-    "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "u9e6Q-9Ke9nW",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.jobRunner\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.developer\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.operator\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/containeranalysis.notes.editor\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/aiplatform.user\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "960505627ddf"
-   },
-   "source": [
-    "### Import libraries"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "PyQmSRbKA8r-",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from google.cloud import aiplatform as vertex_ai"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "8e20nW5yH-s5"
-   },
-   "source": [
-    "### Set variables\n",
-    "\n",
-    "Below you set the model and the serving image you use in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "M6iyDeMrIAVl",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_URI = 'gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model'\n",
-    "DEPLOY_IMAGE = 'us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk,all"
-   },
-   "source": [
-    "### Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "xfFTb9Tu6LHm",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "vdQmak-2Gk7L"
-   },
-   "source": [
-    "## Introduction to Cloud Deploy Vertex AI Deployer\n",
-    "\n",
-    "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
-    "\n",
-    "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
-    "\n",
-    "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qnrHVkk4G0MB"
-   },
-   "source": [
-    "### Register a model into Vertex AI Model Registry\n",
-    "\n",
-    "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
-    "\n",
-    "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "-uc1K6GRHwGO",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "registered_model = vertex_ai.Model.upload(\n",
-    "    display_name='model_to_deploy',\n",
-    "    artifact_uri=MODEL_URI,\n",
-    "    serving_container_image_uri=DEPLOY_IMAGE\n",
-    ")\n",
-    "\n",
-    "print(registered_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "EJebO0xRKZwO"
-   },
-   "source": [
-    "### Create a Vertex AI Endpoint\n",
-    "\n",
-    "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "JgSJ2TrbLB4-",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "endpoint = vertex_ai.Endpoint.create(\n",
-    "    display_name=\"target_endpoint\",\n",
-    "    project=PROJECT_ID,\n",
-    "    location=REGION,\n",
-    ")\n",
-    "\n",
-    "print(endpoint)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "2QYcYzLo5cbY"
-   },
-   "source": [
-    "### Create delivery pipeline, target, and custom target type\n",
-    "\n",
-    "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
-    "\n",
-    "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
-    "\n",
-    "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
-    "\n",
-    "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
-    "\n",
-    "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
-    "\n",
-    "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
-    "\n",
-    "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "h20VT-mAQZg4",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
-    "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "YlJC-lPVRJ0H"
-   },
-   "source": [
-    "Run the script that builds the image and registers the custom target type."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "HUYVCRSaj6qV",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BoaLsEOq5iEW"
-   },
-   "source": [
-    "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qNLigFcXkcsa",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "endpoint_id = endpoint.name\n",
-    "\n",
-    "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9ejsEd8s556r"
-   },
-   "source": [
-    "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "rUJ3Kxr_6pbw",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "sL4LBtjp5HgL"
-   },
-   "source": [
-    "### Create a release and rollout\n",
-    "\n",
-    "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoind.\n",
-    "\n",
-    "To create a Cloud Deploy release, you have to specify\n",
-    "\n",
-    "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
-    "\n",
-    "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
-    "\n",
-    "Here, you provide the custom deployer with two parameters:\n",
-    "\n",
-    "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
-    "\n",
-    "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
-    "is specified by `--project` and `--region` respectively."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "0vzd0UBl4HHB",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "model_id = registered_model.name\n",
-    "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
-    "\n",
-    "! gcloud deploy releases create release-0001 \\\n",
-    "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
-    "    --project=$PROJECT_ID \\\n",
-    "    --region=$REGION \\\n",
-    "    --source=configuration \\\n",
-    "    --deploy-parameters=$deploy_params"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "AjtDtH7d7uSQ"
-   },
-   "source": [
-    "### Monitor the release's progress\n",
-    "\n",
-    "To check release details, run the command below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qnGUFIFP729K",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "riBnpRaB76jP"
-   },
-   "source": [
-    "Run this command to filter only the render status of the release.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "nNZVgIc07-EK",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "5QNy6BErIBBU"
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<b>\n",
-    "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
-    "</b>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mk7IFJ4Z8Bn5"
-   },
-   "source": [
-    "### Monitor rollout status"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "s0uHB9TC8F7G"
-   },
-   "source": [
-    "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
-    "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
-    "\n",
-    "You can also describe the rollout created using the following command."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "3Q0eur7x8Iei",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "g4TYF0Jd8LML"
-   },
-   "source": [
-    "### Inspect Endpoint of the deployed model\n",
-    "\n",
-    "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "3vr2mSBl8RLs",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "g1SsVCBYsG1c"
-   },
-   "source": [
-    "### Inspect aliases in the deployed model\n",
-    "\n",
-    "Monitor the post-deploy operation by querying the rollout.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "6jm1hKEqsPh1",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "yI7Sv4lUsW55"
-   },
-   "source": [
-    "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "RE1jmGb4sWmW",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "TpV-iwP9qw9c"
-   },
-   "source": [
-    "## Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "h4Kdd7P4Wdyt"
-   },
-   "outputs": [],
-   "source": [
-    "delete_endpoint = True\n",
-    "delete_model = True\n",
-    "delete_cloud_deploy = True\n",
-    "\n",
-    "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
-    "  endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
-    "  for endpoint in endpoint_list:\n",
-    "    endpoint.delete(force=True)\n",
-    "\n",
-    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
-    "  model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
-    "  for model in model_list:\n",
-    "    model.delete()\n",
-    "\n",
-    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
-    "  ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "provenance": [],
-   "toc_visible": true
-  },
-  "environment": {
-   "kernel": "python3",
-   "name": "tf2-cpu.2-11.m114",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-cpu.2-11:m114"
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (Local)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.13"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ur8xi4C7S06n"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2023 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JAPoU8Sm5E6e"
+      },
+      "source": [
+        "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "24743cf4a1e1"
+      },
+      "source": [
+        "**_NOTE_**: This notebook has been tested in the following environment:\n",
+        "\n",
+        "* Python version = 3.9"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tvgnzT1CKxrO"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "After a model is trained, validated and added to model registry, it is ready for deployment. Before to deploy the model, you may need to go through continuous deployment process to test and validate the model.\n",
+        "\n",
+        "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
+        "\n",
+        "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d975e698c9a4"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
+        "\n",
+        "This tutorial uses the following Google Cloud ML services and resources:\n",
+        "\n",
+        "- Vertex AI Model Registry\n",
+        "- Vertex AI Endpoint\n",
+        "- Cloud Deploy\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
+        "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
+        "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "08d289fa873f"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aed92deeb4a0"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "* Cloud Deploy\n",
+        "\n",
+        "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
+        "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hiz2inv3pywJ"
+      },
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
+        "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "i7EUnXsZhAGF"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the following packages required to execute this notebook.\n",
+        "\n",
+        "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2b4ef9b72d43"
+      },
+      "outputs": [],
+      "source": [
+        "# Install the packages\n",
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    USER = \"--user\"\n",
+        "else:\n",
+        "    USER = \"\"\n",
+        "! pip3 install {USER} --upgrade google-cloud-aiplatform"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "58707a750154"
+      },
+      "source": [
+        "### Colab only: Uncomment the following cell to restart the kernel."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f200f10a1da3"
+      },
+      "outputs": [],
+      "source": [
+        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+        "# import IPython\n",
+        "\n",
+        "# app = IPython.Application.instance()\n",
+        "# app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BF1j6f9HApxa"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
+        "\n",
+        "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
+        "\n",
+        "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WReHDGG5g0XY"
+      },
+      "source": [
+        "#### Set your project ID\n",
+        "\n",
+        "**If you don't know your project ID**, try the following:\n",
+        "* Run `gcloud config list`.\n",
+        "* Run `gcloud projects list`.\n",
+        "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "oM1iC_MfAts1"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+        "\n",
+        "# Set the project id\n",
+        "! gcloud config set project {PROJECT_ID}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QAup21nz6LHk"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sBCra4QMA2wR"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "74ccc9e52986"
+      },
+      "source": [
+        "**1. Vertex AI Workbench**\n",
+        "* Do nothing as you are already authenticated."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "de775a3773ba"
+      },
+      "source": [
+        "**2. Local JupyterLab instance, uncomment and run:**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "254614fa0c46"
+      },
+      "outputs": [],
+      "source": [
+        "# ! gcloud auth login"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ef21552ccea8"
+      },
+      "source": [
+        "**3. Colab, uncomment and run:**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "603adbbf0532"
+      },
+      "outputs": [],
+      "source": [
+        "# from google.colab import auth\n",
+        "# auth.authenticate_user()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f6b2ccc891ed"
+      },
+      "source": [
+        "**4. Service account or other**\n",
+        "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zgPO1eR3CYjk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "Create a storage bucket to store intermediate artifacts such as datasets."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MzGDU7TWdts_"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-EcIXiGsCePi"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NIq7R4HZCfIc"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CRriz5kNGEv7"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "\n",
+        "IS_COLAB = \"google.colab\" in sys.modules\n",
+        "\n",
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your service account from gcloud\n",
+        "    if not IS_COLAB:\n",
+        "        shell_output = !gcloud auth list 2>/dev/null\n",
+        "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
+        "\n",
+        "    if IS_COLAB:\n",
+        "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
+        "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
+        "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
+        "\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_LhX1D3Z12Ce"
+      },
+      "source": [
+        "### Set permissions for the service account\n",
+        "\n",
+        "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
+        "\n",
+        "To use Cloud Deploy, you need to set the following roles on your service account:\n",
+        "\n",
+        "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
+        "\n",
+        "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
+        "\n",
+        "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
+        "\n",
+        "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
+        "\n",
+        "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
+        "\n",
+        "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "u9e6Q-9Ke9nW"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.jobRunner\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.developer\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.operator\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/containeranalysis.notes.editor\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/aiplatform.user\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "960505627ddf"
+      },
+      "source": [
+        "### Import libraries"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PyQmSRbKA8r-"
+      },
+      "outputs": [],
+      "source": [
+        "from google.cloud import aiplatform as vertex_ai"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8e20nW5yH-s5"
+      },
+      "source": [
+        "### Set variables\n",
+        "\n",
+        "Below you set the model and the serving image you use in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "M6iyDeMrIAVl"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_URI = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model\"\n",
+        "DEPLOY_IMAGE = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk,all"
+      },
+      "source": [
+        "### Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xfFTb9Tu6LHm"
+      },
+      "outputs": [],
+      "source": [
+        "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vdQmak-2Gk7L"
+      },
+      "source": [
+        "## Introduction to Cloud Deploy Vertex AI Deployer\n",
+        "\n",
+        "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
+        "\n",
+        "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
+        "\n",
+        "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qnrHVkk4G0MB"
+      },
+      "source": [
+        "### Register a model into Vertex AI Model Registry\n",
+        "\n",
+        "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
+        "\n",
+        "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-uc1K6GRHwGO"
+      },
+      "outputs": [],
+      "source": [
+        "registered_model = vertex_ai.Model.upload(\n",
+        "    display_name=\"model_to_deploy\",\n",
+        "    artifact_uri=MODEL_URI,\n",
+        "    serving_container_image_uri=DEPLOY_IMAGE,\n",
+        ")\n",
+        "\n",
+        "print(registered_model)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EJebO0xRKZwO"
+      },
+      "source": [
+        "### Create a Vertex AI Endpoint\n",
+        "\n",
+        "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JgSJ2TrbLB4-"
+      },
+      "outputs": [],
+      "source": [
+        "endpoint = vertex_ai.Endpoint.create(\n",
+        "    display_name=\"target_endpoint\",\n",
+        "    project=PROJECT_ID,\n",
+        "    location=REGION,\n",
+        ")\n",
+        "\n",
+        "print(endpoint)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2QYcYzLo5cbY"
+      },
+      "source": [
+        "### Create delivery pipeline, target, and custom target type\n",
+        "\n",
+        "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
+        "\n",
+        "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
+        "\n",
+        "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
+        "\n",
+        "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
+        "\n",
+        "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
+        "\n",
+        "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
+        "\n",
+        "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "h20VT-mAQZg4"
+      },
+      "outputs": [],
+      "source": [
+        "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
+        "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YlJC-lPVRJ0H"
+      },
+      "source": [
+        "Run the script that builds the image and registers the custom target type."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HUYVCRSaj6qV"
+      },
+      "outputs": [],
+      "source": [
+        "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BoaLsEOq5iEW"
+      },
+      "source": [
+        "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qNLigFcXkcsa"
+      },
+      "outputs": [],
+      "source": [
+        "endpoint_id = endpoint.name\n",
+        "\n",
+        "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9ejsEd8s556r"
+      },
+      "source": [
+        "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rUJ3Kxr_6pbw"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sL4LBtjp5HgL"
+      },
+      "source": [
+        "### Create a release and rollout\n",
+        "\n",
+        "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoind.\n",
+        "\n",
+        "To create a Cloud Deploy release, you have to specify\n",
+        "\n",
+        "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
+        "\n",
+        "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
+        "\n",
+        "Here, you provide the custom deployer with two parameters:\n",
+        "\n",
+        "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
+        "\n",
+        "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
+        "is specified by `--project` and `--region` respectively."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0vzd0UBl4HHB"
+      },
+      "outputs": [],
+      "source": [
+        "model_id = registered_model.name\n",
+        "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
+        "\n",
+        "! gcloud deploy releases create release-0001 \\\n",
+        "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
+        "    --project=$PROJECT_ID \\\n",
+        "    --region=$REGION \\\n",
+        "    --source=configuration \\\n",
+        "    --deploy-parameters=$deploy_params"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AjtDtH7d7uSQ"
+      },
+      "source": [
+        "### Monitor the release's progress\n",
+        "\n",
+        "To check release details, run the command below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qnGUFIFP729K"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "riBnpRaB76jP"
+      },
+      "source": [
+        "Run this command to filter only the render status of the release.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nNZVgIc07-EK"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5QNy6BErIBBU"
+      },
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>\n",
+        "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
+        "</b>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mk7IFJ4Z8Bn5"
+      },
+      "source": [
+        "### Monitor rollout status"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "s0uHB9TC8F7G"
+      },
+      "source": [
+        "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
+        "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
+        "\n",
+        "You can also describe the rollout created using the following command."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3Q0eur7x8Iei"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g4TYF0Jd8LML"
+      },
+      "source": [
+        "### Inspect Endpoint of the deployed model\n",
+        "\n",
+        "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3vr2mSBl8RLs"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g1SsVCBYsG1c"
+      },
+      "source": [
+        "### Inspect aliases in the deployed model\n",
+        "\n",
+        "Monitor the post-deploy operation by querying the rollout.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6jm1hKEqsPh1"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yI7Sv4lUsW55"
+      },
+      "source": [
+        "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "RE1jmGb4sWmW"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TpV-iwP9qw9c"
+      },
+      "source": [
+        "## Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "h4Kdd7P4Wdyt"
+      },
+      "outputs": [],
+      "source": [
+        "delete_endpoint = True\n",
+        "delete_model = True\n",
+        "delete_cloud_deploy = True\n",
+        "\n",
+        "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
+        "    endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
+        "    for endpoint in endpoint_list:\n",
+        "        endpoint.delete(force=True)\n",
+        "\n",
+        "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+        "    model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
+        "    for model in model_list:\n",
+        "        model.delete()\n",
+        "\n",
+        "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+        "    ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "get_started_with_vertex_ai_deployer.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
+++ b/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
@@ -1,1000 +1,981 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ur8xi4C7S06n"
-   },
-   "outputs": [],
-   "source": [
-    "# Copyright 2023 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "JAPoU8Sm5E6e"
-   },
-   "source": [
-    "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
-    "\n",
-    "<table align=\"left\">\n",
-    "\n",
-    "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-    "      View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
-    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-    "      Open in Vertex AI Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "24743cf4a1e1"
-   },
-   "source": [
-    "**_NOTE_**: This notebook has been tested in the following environment:\n",
-    "\n",
-    "* Python version = 3.9"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "tvgnzT1CKxrO"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "After a model is trained, validated and added to model registry, it is ready for deployment. Before deploying the model, you may need to  go through a continuous deployment process deployment process to test and validate the model.\n",
-    "\n",
-    "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
-    "\n",
-    "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "d975e698c9a4"
-   },
-   "source": [
-    "### Objective\n",
-    "\n",
-    "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
-    "\n",
-    "This tutorial uses the following Google Cloud ML services and resources:\n",
-    "\n",
-    "- Vertex AI Model Registry\n",
-    "- Vertex AI Endpoint\n",
-    "- Cloud Deploy\n",
-    "\n",
-    "The steps performed include:\n",
-    "\n",
-    "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
-    "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
-    "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "08d289fa873f"
-   },
-   "source": [
-    "### Dataset\n",
-    "\n",
-    "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aed92deeb4a0"
-   },
-   "source": [
-    "### Costs\n",
-    "\n",
-    "This tutorial uses billable components of Google Cloud:\n",
-    "\n",
-    "* Vertex AI\n",
-    "* Cloud Storage\n",
-    "* Cloud Deploy\n",
-    "\n",
-    "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
-    "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
-    "to generate a cost estimate based on your projected usage."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "hiz2inv3pywJ"
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
-    "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "i7EUnXsZhAGF"
-   },
-   "source": [
-    "## Installation\n",
-    "\n",
-    "Install the following packages required to execute this notebook.\n",
-    "\n",
-    "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "2b4ef9b72d43"
-   },
-   "outputs": [],
-   "source": [
-    "# Install the packages\n",
-    "import os\n",
-    "\n",
-    "if not os.getenv(\"IS_TESTING\"):\n",
-    "    USER = \"--user\"\n",
-    "else:\n",
-    "    USER = \"\"\n",
-    "! pip3 install {USER} --upgrade google-cloud-aiplatform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "58707a750154"
-   },
-   "source": [
-    "### Colab only: Uncomment the following cell to restart the kernel."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "f200f10a1da3"
-   },
-   "outputs": [],
-   "source": [
-    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-    "# import IPython\n",
-    "\n",
-    "# app = IPython.Application.instance()\n",
-    "# app.kernel.do_shutdown(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BF1j6f9HApxa"
-   },
-   "source": [
-    "## Before you begin\n",
-    "\n",
-    "### Set up your Google Cloud project\n",
-    "\n",
-    "**The following steps are required, regardless of your notebook environment.**\n",
-    "\n",
-    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-    "\n",
-    "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
-    "\n",
-    "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
-    "\n",
-    "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "WReHDGG5g0XY"
-   },
-   "source": [
-    "#### Set your project ID\n",
-    "\n",
-    "**If you don't know your project ID**, try the following:\n",
-    "* Run `gcloud config list`.\n",
-    "* Run `gcloud projects list`.\n",
-    "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "oM1iC_MfAts1"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-    "\n",
-    "# Set the project id\n",
-    "! gcloud config set project {PROJECT_ID}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "region"
-   },
-   "source": [
-    "#### Region\n",
-    "\n",
-    "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "QAup21nz6LHk"
-   },
-   "outputs": [],
-   "source": [
-    "REGION = \"us-central1\"  # @param {type: \"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "sBCra4QMA2wR"
-   },
-   "source": [
-    "### Authenticate your Google Cloud account\n",
-    "\n",
-    "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "74ccc9e52986"
-   },
-   "source": [
-    "**1. Vertex AI Workbench**\n",
-    "* Do nothing as you are already authenticated."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "de775a3773ba"
-   },
-   "source": [
-    "**2. Local JupyterLab instance, uncomment and run:**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "254614fa0c46"
-   },
-   "outputs": [],
-   "source": [
-    "# ! gcloud auth login"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ef21552ccea8"
-   },
-   "source": [
-    "**3. Colab, uncomment and run:**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "603adbbf0532"
-   },
-   "outputs": [],
-   "source": [
-    "# from google.colab import auth\n",
-    "# auth.authenticate_user()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "f6b2ccc891ed"
-   },
-   "source": [
-    "**4. Service account or other**\n",
-    "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "zgPO1eR3CYjk"
-   },
-   "source": [
-    "### Create a Cloud Storage bucket\n",
-    "\n",
-    "Create a storage bucket to store intermediate artifacts such as datasets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "MzGDU7TWdts_"
-   },
-   "outputs": [],
-   "source": [
-    "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-EcIXiGsCePi"
-   },
-   "source": [
-    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "NIq7R4HZCfIc"
-   },
-   "outputs": [],
-   "source": [
-    "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "set_service_account"
-   },
-   "source": [
-    "### Service Account\n",
-    "\n",
-    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "CRriz5kNGEv7"
-   },
-   "outputs": [],
-   "source": [
-    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "autoset_service_account"
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "\n",
-    "IS_COLAB = \"google.colab\" in sys.modules\n",
-    "\n",
-    "if (\n",
-    "    SERVICE_ACCOUNT == \"\"\n",
-    "    or SERVICE_ACCOUNT is None\n",
-    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
-    "):\n",
-    "    # Get your service account from gcloud\n",
-    "    if not IS_COLAB:\n",
-    "        shell_output = !gcloud auth list 2>/dev/null\n",
-    "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
-    "\n",
-    "    if IS_COLAB:\n",
-    "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
-    "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
-    "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
-    "\n",
-    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "_LhX1D3Z12Ce"
-   },
-   "source": [
-    "### Set permissions for the service account\n",
-    "\n",
-    "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
-    "\n",
-    "To use Cloud Deploy, you need to set the following roles on your service account:\n",
-    "\n",
-    "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
-    "\n",
-    "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
-    "\n",
-    "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
-    "\n",
-    "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
-    "\n",
-    "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
-    "\n",
-    "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "u9e6Q-9Ke9nW"
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.jobRunner\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.developer\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.operator\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/containeranalysis.notes.editor\"\n",
-    "\n",
-    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
-    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
-    "    --role=\"roles/aiplatform.user\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "960505627ddf"
-   },
-   "source": [
-    "### Import libraries"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "PyQmSRbKA8r-"
-   },
-   "outputs": [],
-   "source": [
-    "from google.cloud import aiplatform as vertex_ai"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "8e20nW5yH-s5"
-   },
-   "source": [
-    "### Set variables\n",
-    "\n",
-    "Below you set the model and the serving image you use in this tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "M6iyDeMrIAVl"
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_URI = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model\"\n",
-    "DEPLOY_IMAGE = (\n",
-    "    \"us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "init_aip:mbsdk,all"
-   },
-   "source": [
-    "### Initialize Vertex AI SDK for Python\n",
-    "\n",
-    "Initialize the Vertex AI SDK for Python for your project."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "xfFTb9Tu6LHm"
-   },
-   "outputs": [],
-   "source": [
-    "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "vdQmak-2Gk7L"
-   },
-   "source": [
-    "## Introduction to Cloud Deploy Vertex AI Deployer\n",
-    "\n",
-    "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
-    "\n",
-    "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
-    "\n",
-    "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qnrHVkk4G0MB"
-   },
-   "source": [
-    "### Register a model into Vertex AI Model Registry\n",
-    "\n",
-    "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
-    "\n",
-    "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "-uc1K6GRHwGO"
-   },
-   "outputs": [],
-   "source": [
-    "registered_model = vertex_ai.Model.upload(\n",
-    "    display_name=\"model_to_deploy\",\n",
-    "    artifact_uri=MODEL_URI,\n",
-    "    serving_container_image_uri=DEPLOY_IMAGE,\n",
-    ")\n",
-    "\n",
-    "print(registered_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "EJebO0xRKZwO"
-   },
-   "source": [
-    "### Create a Vertex AI Endpoint\n",
-    "\n",
-    "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "JgSJ2TrbLB4-"
-   },
-   "outputs": [],
-   "source": [
-    "endpoint = vertex_ai.Endpoint.create(\n",
-    "    display_name=\"target_endpoint\",\n",
-    "    project=PROJECT_ID,\n",
-    "    location=REGION,\n",
-    ")\n",
-    "\n",
-    "print(endpoint)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "2QYcYzLo5cbY"
-   },
-   "source": [
-    "### Create delivery pipeline, target, and custom target type\n",
-    "\n",
-    "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
-    "\n",
-    "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
-    "\n",
-    "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
-    "\n",
-    "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
-    "\n",
-    "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
-    "\n",
-    "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
-    "\n",
-    "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "h20VT-mAQZg4"
-   },
-   "outputs": [],
-   "source": [
-    "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
-    "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "YlJC-lPVRJ0H"
-   },
-   "source": [
-    "Run the script that builds the image and registers the custom target type."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "HUYVCRSaj6qV"
-   },
-   "outputs": [],
-   "source": [
-    "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BoaLsEOq5iEW"
-   },
-   "source": [
-    "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qNLigFcXkcsa"
-   },
-   "outputs": [],
-   "source": [
-    "endpoint_id = endpoint.name\n",
-    "\n",
-    "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9ejsEd8s556r"
-   },
-   "source": [
-    "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "rUJ3Kxr_6pbw"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "sL4LBtjp5HgL"
-   },
-   "source": [
-    "### Create a release and rollout\n",
-    "\n",
-    "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoint.\n",
-    "\n",
-    "To create a Cloud Deploy release, you have to specify\n",
-    "\n",
-    "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
-    "\n",
-    "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
-    "\n",
-    "Here, you provide the custom deployer with two parameters:\n",
-    "\n",
-    "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
-    "\n",
-    "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
-    "is specified by `--project` and `--region` respectively."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "0vzd0UBl4HHB"
-   },
-   "outputs": [],
-   "source": [
-    "model_id = registered_model.name\n",
-    "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
-    "\n",
-    "! gcloud deploy releases create release-0001 \\\n",
-    "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
-    "    --project=$PROJECT_ID \\\n",
-    "    --region=$REGION \\\n",
-    "    --source=configuration \\\n",
-    "    --deploy-parameters=$deploy_params"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "AjtDtH7d7uSQ"
-   },
-   "source": [
-    "### Monitor the release's progress\n",
-    "\n",
-    "To check release details, run the command below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qnGUFIFP729K"
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "riBnpRaB76jP"
-   },
-   "source": [
-    "Run this command to filter only the render status of the release.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "nNZVgIc07-EK"
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "5QNy6BErIBBU"
-   },
-   "source": [
-    "<div class=\"alert alert-block alert-warning\">\n",
-    "<b>\n",
-    "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
-    "</b>\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mk7IFJ4Z8Bn5"
-   },
-   "source": [
-    "### Monitor rollout status"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "s0uHB9TC8F7G"
-   },
-   "source": [
-    "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
-    "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
-    "\n",
-    "You can also describe the rollout created using the following command."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "3Q0eur7x8Iei"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "g4TYF0Jd8LML"
-   },
-   "source": [
-    "### Inspect Endpoint of the deployed model\n",
-    "\n",
-    "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "3vr2mSBl8RLs"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "g1SsVCBYsG1c"
-   },
-   "source": [
-    "### Inspect aliases in the deployed model\n",
-    "\n",
-    "Monitor the post-deploy operation by querying the rollout.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "6jm1hKEqsPh1"
-   },
-   "outputs": [],
-   "source": [
-    "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "yI7Sv4lUsW55"
-   },
-   "source": [
-    "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "RE1jmGb4sWmW"
-   },
-   "outputs": [],
-   "source": [
-    "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "TpV-iwP9qw9c"
-   },
-   "source": [
-    "## Cleaning up\n",
-    "\n",
-    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-    "\n",
-    "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "h4Kdd7P4Wdyt"
-   },
-   "outputs": [],
-   "source": [
-    "delete_endpoint = True\n",
-    "delete_model = True\n",
-    "delete_cloud_deploy = True\n",
-    "\n",
-    "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
-    "    endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
-    "    for endpoint in endpoint_list:\n",
-    "        endpoint.delete(force=True)\n",
-    "\n",
-    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
-    "    model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
-    "    for model in model_list:\n",
-    "        model.delete()\n",
-    "\n",
-    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
-    "    ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "get_started_with_vertex_ai_deployer.ipynb",
-   "toc_visible": true
-  },
-  "environment": {
-   "kernel": "python3",
-   "name": "tf2-cpu.2-11.m114",
-   "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-cpu.2-11:m114"
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (Local)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.13"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ur8xi4C7S06n"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2023 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JAPoU8Sm5E6e"
+      },
+      "source": [
+        "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "\n",
+        "  <td>\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+        "      View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+        "      Open in Vertex AI Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "24743cf4a1e1"
+      },
+      "source": [
+        "**_NOTE_**: This notebook has been tested in the following environment:\n",
+        "\n",
+        "* Python version = 3.9"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tvgnzT1CKxrO"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "After a model is trained, validated and added to model registry, it is ready for deployment. Before deploying the model, you may need to  go through a continuous deployment process deployment process to test and validate the model.\n",
+        "\n",
+        "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
+        "\n",
+        "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d975e698c9a4"
+      },
+      "source": [
+        "### Objective\n",
+        "\n",
+        "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
+        "\n",
+        "This tutorial uses the following Google Cloud ML services and resources:\n",
+        "\n",
+        "- Vertex AI Model Registry\n",
+        "- Vertex AI Endpoint\n",
+        "- Cloud Deploy\n",
+        "\n",
+        "The steps performed include:\n",
+        "\n",
+        "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
+        "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
+        "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "08d289fa873f"
+      },
+      "source": [
+        "### Dataset\n",
+        "\n",
+        "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aed92deeb4a0"
+      },
+      "source": [
+        "### Costs\n",
+        "\n",
+        "This tutorial uses billable components of Google Cloud:\n",
+        "\n",
+        "* Vertex AI\n",
+        "* Cloud Storage\n",
+        "* Cloud Deploy\n",
+        "\n",
+        "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
+        "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
+        "to generate a cost estimate based on your projected usage."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hiz2inv3pywJ"
+      },
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
+        "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "i7EUnXsZhAGF"
+      },
+      "source": [
+        "## Installation\n",
+        "\n",
+        "Install the following packages required to execute this notebook.\n",
+        "\n",
+        "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2b4ef9b72d43"
+      },
+      "outputs": [],
+      "source": [
+        "# Install the packages\n",
+        "import os\n",
+        "\n",
+        "if not os.getenv(\"IS_TESTING\"):\n",
+        "    USER = \"--user\"\n",
+        "else:\n",
+        "    USER = \"\"\n",
+        "! pip3 install {USER} --upgrade google-cloud-aiplatform"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "58707a750154"
+      },
+      "source": [
+        "### Colab only: Uncomment the following cell to restart the kernel."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "f200f10a1da3"
+      },
+      "outputs": [],
+      "source": [
+        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+        "# import IPython\n",
+        "\n",
+        "# app = IPython.Application.instance()\n",
+        "# app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BF1j6f9HApxa"
+      },
+      "source": [
+        "## Before you begin\n",
+        "\n",
+        "### Set up your Google Cloud project\n",
+        "\n",
+        "**The following steps are required, regardless of your notebook environment.**\n",
+        "\n",
+        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+        "\n",
+        "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
+        "\n",
+        "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
+        "\n",
+        "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WReHDGG5g0XY"
+      },
+      "source": [
+        "#### Set your project ID\n",
+        "\n",
+        "**If you don't know your project ID**, try the following:\n",
+        "* Run `gcloud config list`.\n",
+        "* Run `gcloud projects list`.\n",
+        "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "oM1iC_MfAts1"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+        "\n",
+        "# Set the project id\n",
+        "! gcloud config set project {PROJECT_ID}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "region"
+      },
+      "source": [
+        "#### Region\n",
+        "\n",
+        "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QAup21nz6LHk"
+      },
+      "outputs": [],
+      "source": [
+        "REGION = \"us-central1\"  # @param {type: \"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sBCra4QMA2wR"
+      },
+      "source": [
+        "### Authenticate your Google Cloud account\n",
+        "\n",
+        "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "74ccc9e52986"
+      },
+      "source": [
+        "**1. Vertex AI Workbench**\n",
+        "* Do nothing as you are already authenticated."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "de775a3773ba"
+      },
+      "source": [
+        "**2. Local JupyterLab instance, uncomment and run:**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "254614fa0c46"
+      },
+      "outputs": [],
+      "source": [
+        "# ! gcloud auth login"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ef21552ccea8"
+      },
+      "source": [
+        "**3. Colab, uncomment and run:**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "603adbbf0532"
+      },
+      "outputs": [],
+      "source": [
+        "# from google.colab import auth\n",
+        "# auth.authenticate_user()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f6b2ccc891ed"
+      },
+      "source": [
+        "**4. Service account or other**\n",
+        "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zgPO1eR3CYjk"
+      },
+      "source": [
+        "### Create a Cloud Storage bucket\n",
+        "\n",
+        "Create a storage bucket to store intermediate artifacts such as datasets."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MzGDU7TWdts_"
+      },
+      "outputs": [],
+      "source": [
+        "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-EcIXiGsCePi"
+      },
+      "source": [
+        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NIq7R4HZCfIc"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "set_service_account"
+      },
+      "source": [
+        "### Service Account\n",
+        "\n",
+        "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CRriz5kNGEv7"
+      },
+      "outputs": [],
+      "source": [
+        "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "autoset_service_account"
+      },
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "\n",
+        "IS_COLAB = \"google.colab\" in sys.modules\n",
+        "\n",
+        "if (\n",
+        "    SERVICE_ACCOUNT == \"\"\n",
+        "    or SERVICE_ACCOUNT is None\n",
+        "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+        "):\n",
+        "    # Get your service account from gcloud\n",
+        "    if not IS_COLAB:\n",
+        "        shell_output = !gcloud auth list 2>/dev/null\n",
+        "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
+        "\n",
+        "    if IS_COLAB:\n",
+        "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
+        "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
+        "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
+        "\n",
+        "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_LhX1D3Z12Ce"
+      },
+      "source": [
+        "### Set permissions for the service account\n",
+        "\n",
+        "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
+        "\n",
+        "To use Cloud Deploy, you need to set the following roles on your service account:\n",
+        "\n",
+        "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
+        "\n",
+        "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
+        "\n",
+        "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
+        "\n",
+        "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
+        "\n",
+        "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
+        "\n",
+        "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "u9e6Q-9Ke9nW"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.jobRunner\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.developer\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.operator\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/containeranalysis.notes.editor\"\n",
+        "\n",
+        "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+        "    --role=\"roles/aiplatform.user\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "960505627ddf"
+      },
+      "source": [
+        "### Import libraries"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PyQmSRbKA8r-"
+      },
+      "outputs": [],
+      "source": [
+        "from google.cloud import aiplatform as vertex_ai"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8e20nW5yH-s5"
+      },
+      "source": [
+        "### Set variables\n",
+        "\n",
+        "Below you set the model and the serving image you use in this tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "M6iyDeMrIAVl"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_URI = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model\"\n",
+        "DEPLOY_IMAGE = (\n",
+        "    \"us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "init_aip:mbsdk,all"
+      },
+      "source": [
+        "### Initialize Vertex AI SDK for Python\n",
+        "\n",
+        "Initialize the Vertex AI SDK for Python for your project."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xfFTb9Tu6LHm"
+      },
+      "outputs": [],
+      "source": [
+        "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vdQmak-2Gk7L"
+      },
+      "source": [
+        "## Introduction to Cloud Deploy Vertex AI Deployer\n",
+        "\n",
+        "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
+        "\n",
+        "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
+        "\n",
+        "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qnrHVkk4G0MB"
+      },
+      "source": [
+        "### Register a model into Vertex AI Model Registry\n",
+        "\n",
+        "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
+        "\n",
+        "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-uc1K6GRHwGO"
+      },
+      "outputs": [],
+      "source": [
+        "registered_model = vertex_ai.Model.upload(\n",
+        "    display_name=\"model_to_deploy\",\n",
+        "    artifact_uri=MODEL_URI,\n",
+        "    serving_container_image_uri=DEPLOY_IMAGE,\n",
+        ")\n",
+        "\n",
+        "print(registered_model)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EJebO0xRKZwO"
+      },
+      "source": [
+        "### Create a Vertex AI Endpoint\n",
+        "\n",
+        "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JgSJ2TrbLB4-"
+      },
+      "outputs": [],
+      "source": [
+        "endpoint = vertex_ai.Endpoint.create(\n",
+        "    display_name=\"target_endpoint\",\n",
+        "    project=PROJECT_ID,\n",
+        "    location=REGION,\n",
+        ")\n",
+        "\n",
+        "print(endpoint)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2QYcYzLo5cbY"
+      },
+      "source": [
+        "### Create delivery pipeline, target, and custom target type\n",
+        "\n",
+        "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
+        "\n",
+        "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
+        "\n",
+        "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
+        "\n",
+        "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
+        "\n",
+        "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
+        "\n",
+        "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
+        "\n",
+        "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "h20VT-mAQZg4"
+      },
+      "outputs": [],
+      "source": [
+        "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
+        "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YlJC-lPVRJ0H"
+      },
+      "source": [
+        "Run the script that builds the image and registers the custom target type."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HUYVCRSaj6qV"
+      },
+      "outputs": [],
+      "source": [
+        "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BoaLsEOq5iEW"
+      },
+      "source": [
+        "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qNLigFcXkcsa"
+      },
+      "outputs": [],
+      "source": [
+        "endpoint_id = endpoint.name\n",
+        "\n",
+        "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9ejsEd8s556r"
+      },
+      "source": [
+        "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rUJ3Kxr_6pbw"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sL4LBtjp5HgL"
+      },
+      "source": [
+        "### Create a release and rollout\n",
+        "\n",
+        "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoint.\n",
+        "\n",
+        "To create a Cloud Deploy release, you have to specify\n",
+        "\n",
+        "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
+        "\n",
+        "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
+        "\n",
+        "Here, you provide the custom deployer with two parameters:\n",
+        "\n",
+        "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
+        "\n",
+        "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
+        "is specified by `--project` and `--region` respectively."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0vzd0UBl4HHB"
+      },
+      "outputs": [],
+      "source": [
+        "model_id = registered_model.name\n",
+        "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
+        "\n",
+        "! gcloud deploy releases create release-0001 \\\n",
+        "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
+        "    --project=$PROJECT_ID \\\n",
+        "    --region=$REGION \\\n",
+        "    --source=configuration \\\n",
+        "    --deploy-parameters=$deploy_params"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AjtDtH7d7uSQ"
+      },
+      "source": [
+        "### Monitor the release's progress\n",
+        "\n",
+        "To check release details, run the command below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qnGUFIFP729K"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "riBnpRaB76jP"
+      },
+      "source": [
+        "Run this command to filter only the render status of the release.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nNZVgIc07-EK"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5QNy6BErIBBU"
+      },
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>\n",
+        "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
+        "</b>\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mk7IFJ4Z8Bn5"
+      },
+      "source": [
+        "### Monitor rollout status"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "s0uHB9TC8F7G"
+      },
+      "source": [
+        "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
+        "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
+        "\n",
+        "You can also describe the rollout created using the following command."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3Q0eur7x8Iei"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g4TYF0Jd8LML"
+      },
+      "source": [
+        "### Inspect Endpoint of the deployed model\n",
+        "\n",
+        "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3vr2mSBl8RLs"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g1SsVCBYsG1c"
+      },
+      "source": [
+        "### Inspect aliases in the deployed model\n",
+        "\n",
+        "Monitor the post-deploy operation by querying the rollout.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6jm1hKEqsPh1"
+      },
+      "outputs": [],
+      "source": [
+        "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yI7Sv4lUsW55"
+      },
+      "source": [
+        "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "RE1jmGb4sWmW"
+      },
+      "outputs": [],
+      "source": [
+        "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TpV-iwP9qw9c"
+      },
+      "source": [
+        "## Cleaning up\n",
+        "\n",
+        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+        "\n",
+        "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "h4Kdd7P4Wdyt"
+      },
+      "outputs": [],
+      "source": [
+        "delete_endpoint = True\n",
+        "delete_model = True\n",
+        "delete_cloud_deploy = True\n",
+        "\n",
+        "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
+        "    endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
+        "    for endpoint in endpoint_list:\n",
+        "        endpoint.delete(force=True)\n",
+        "\n",
+        "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+        "    model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
+        "    for model in model_list:\n",
+        "        model.delete()\n",
+        "\n",
+        "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+        "    ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "get_started_with_vertex_ai_deployer.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
+++ b/notebooks/community/model_registry/get_started_with_vertex_ai_deployer.ipynb
@@ -1,0 +1,1027 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ur8xi4C7S06n"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2023 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JAPoU8Sm5E6e"
+   },
+   "source": [
+    "# Get started with Cloud Deploy Vertex AI Model Deployer\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/model_registry/get_started_with_vertex_ai_deployer.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "24743cf4a1e1"
+   },
+   "source": [
+    "**_NOTE_**: This notebook has been tested in the following environment:\n",
+    "\n",
+    "* Python version = 3.9"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tvgnzT1CKxrO"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "After a model is trained, validated and added to model registry, it is ready for deployment. Before to deploy the model, you may need to go through continuous deployment process to test and validate the model.\n",
+    "\n",
+    "This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.\n",
+    "\n",
+    "Learn more about [Cloud Deploy](https://cloud.google.com/deploy) and [Vertex AI](https://cloud.google.com/vertex-ai)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "d975e698c9a4"
+   },
+   "source": [
+    "### Objective\n",
+    "\n",
+    "In this tutorial, you learn how to deploy a Vertex AI Model to an endpoint usign a Cloud Deploy custom target:\n",
+    "\n",
+    "This tutorial uses the following Google Cloud ML services and resources:\n",
+    "\n",
+    "- Vertex AI Model Registry\n",
+    "- Vertex AI Endpoint\n",
+    "- Cloud Deploy\n",
+    "\n",
+    "The steps performed include:\n",
+    "\n",
+    "- Import a Vertex AI model into model registry and create an endpoint where the model will be deployed.\n",
+    "- Define a Cloud Deploy delivery pipeline, custom target type for Vertex AI, and one target.\n",
+    "- Create a Cloud Deploy release and rollout to deploy a Vertex AI model to the target."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "08d289fa873f"
+   },
+   "source": [
+    "### Dataset\n",
+    "\n",
+    "The dataset used for the pre-trained model is the Boston Housing dataset contains information collected by the U.S Census Service concerning housing in the area of Boston Mass."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aed92deeb4a0"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* Vertex AI\n",
+    "* Cloud Storage\n",
+    "* Cloud Deploy\n",
+    "\n",
+    "Learn about [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing), [Cloud Storage pricing](https://cloud.google.com/storage/pricing), and [Cloud Deploy pricing](https://cloud.google.com/cloud-deploy/pricing)\n",
+    "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hiz2inv3pywJ"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>⚠️ This is not an officially supported Google product, and it is not covered by a Google Cloud support contract.\n",
+    "To report bugs or request features in a Google Cloud product, please contact Google Cloud support⚠️</b>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "i7EUnXsZhAGF"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the following packages required to execute this notebook.\n",
+    "\n",
+    "{TODO: Suggest using the latest major GA version of each package; i.e., --upgrade}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2b4ef9b72d43",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Install the packages\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"IS_TESTING\"):\n",
+    "    USER = \"--user\"\n",
+    "else:\n",
+    "    USER = \"\"\n",
+    "! pip3 install {USER} --upgrade google-cloud-aiplatform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "58707a750154"
+   },
+   "source": [
+    "### Colab only: Uncomment the following cell to restart the kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f200f10a1da3"
+   },
+   "outputs": [],
+   "source": [
+    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "# import IPython\n",
+    "\n",
+    "# app = IPython.Application.instance()\n",
+    "# app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BF1j6f9HApxa"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "### Set up your Google Cloud project\n",
+    "\n",
+    "**The following steps are required, regardless of your notebook environment.**\n",
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
+    "\n",
+    "3. [Enable APIs](https://console.cloud.google.com/flows/enableapi?apiid=clouddeploy.googleapis.com,containeranalysis.googleapis.com,compute.googleapis.com,aiplatform.googleapis.com).\n",
+    "\n",
+    "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WReHDGG5g0XY"
+   },
+   "source": [
+    "#### Set your project ID\n",
+    "\n",
+    "**If you don't know your project ID**, try the following:\n",
+    "* Run `gcloud config list`.\n",
+    "* Run `gcloud projects list`.\n",
+    "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oM1iC_MfAts1",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Set the project id\n",
+    "! gcloud config set project {PROJECT_ID}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "region"
+   },
+   "source": [
+    "#### Region\n",
+    "\n",
+    "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QAup21nz6LHk",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "REGION = \"us-central1\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sBCra4QMA2wR"
+   },
+   "source": [
+    "### Authenticate your Google Cloud account\n",
+    "\n",
+    "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "74ccc9e52986"
+   },
+   "source": [
+    "**1. Vertex AI Workbench**\n",
+    "* Do nothing as you are already authenticated."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "de775a3773ba"
+   },
+   "source": [
+    "**2. Local JupyterLab instance, uncomment and run:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "254614fa0c46",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# ! gcloud auth login"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ef21552ccea8"
+   },
+   "source": [
+    "**3. Colab, uncomment and run:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "603adbbf0532",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import auth\n",
+    "# auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "f6b2ccc891ed"
+   },
+   "source": [
+    "**4. Service account or other**\n",
+    "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zgPO1eR3CYjk"
+   },
+   "source": [
+    "### Create a Cloud Storage bucket\n",
+    "\n",
+    "Create a storage bucket to store intermediate artifacts such as datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MzGDU7TWdts_",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_URI = \"gs://your-bucket-name-unique\"  # @param {type:\"string\"}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-EcIXiGsCePi"
+   },
+   "source": [
+    "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NIq7R4HZCfIc",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "set_service_account"
+   },
+   "source": [
+    "### Service Account\n",
+    "\n",
+    "**If you don't know your service account**, try to get your service account using `gcloud` command by executing the second cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CRriz5kNGEv7",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = \"[your-service-account]\"  # @param {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "autoset_service_account",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "IS_COLAB = \"google.colab\" in sys.modules\n",
+    "\n",
+    "if (\n",
+    "    SERVICE_ACCOUNT == \"\"\n",
+    "    or SERVICE_ACCOUNT is None\n",
+    "    or SERVICE_ACCOUNT == \"[your-service-account]\"\n",
+    "):\n",
+    "    # Get your service account from gcloud\n",
+    "    if not IS_COLAB:\n",
+    "        shell_output = !gcloud auth list 2>/dev/null\n",
+    "        SERVICE_ACCOUNT = shell_output[2].replace(\"*\", \"\").strip()\n",
+    "\n",
+    "    if IS_COLAB:\n",
+    "        shell_output = ! gcloud projects describe  $PROJECT_ID\n",
+    "        project_number = shell_output[-1].split(\":\")[1].strip().replace(\"'\", \"\")\n",
+    "        SERVICE_ACCOUNT = f\"{project_number}-compute@developer.gserviceaccount.com\"\n",
+    "\n",
+    "    print(\"Service Account:\", SERVICE_ACCOUNT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_LhX1D3Z12Ce"
+   },
+   "source": [
+    "### Set permissions for the service account\n",
+    "\n",
+    "**Important**: Before to run the following cell, if you are authenticated with the service account, check that it has the required permissions. See the `Before to begin` section [here](https://cloud.google.com/iam/docs/manage-access-service-accounts#before_you_begin) for more details.\n",
+    "\n",
+    "To use Cloud Deploy, you need to set the following roles on your service account:\n",
+    "\n",
+    "* `roles/clouddeploy.jobRunner` this is required to create cloud deploy resources, and to create releases and deployments against a pipeline.\n",
+    "\n",
+    "* `roles/clouddeploy.developer` required to access cloud deploy resources.\n",
+    "\n",
+    "*  `roles/clouddeploy.operator` required to manage Cloud Deploy pipelines, target resources, releases, rollouts, and job runs.\n",
+    "\n",
+    "*  `roles/clouddeploy.customTargetTypeAdmin` required to have full control of Cloud Deploy custom target types.\n",
+    "\n",
+    "* `roles/containeranalysis.notes.editor` required for the custom image to run Artifact Analysis along the release process\n",
+    "\n",
+    "* `roles/aiplatform.user` required for the custom image to create and import models and to access model information, and to make model deployments.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u9e6Q-9Ke9nW",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.jobRunner\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.developer\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.operator\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/clouddeploy.customTargetTypeAdmin\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/containeranalysis.notes.editor\"\n",
+    "\n",
+    "!gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+    "    --member=serviceAccount:{SERVICE_ACCOUNT} \\\n",
+    "    --role=\"roles/aiplatform.user\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "960505627ddf"
+   },
+   "source": [
+    "### Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PyQmSRbKA8r-",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from google.cloud import aiplatform as vertex_ai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8e20nW5yH-s5"
+   },
+   "source": [
+    "### Set variables\n",
+    "\n",
+    "Below you set the model and the serving image you use in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "M6iyDeMrIAVl",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_URI = 'gs://cloud-samples-data/vertex-ai/model-deployment/models/boston/model'\n",
+    "DEPLOY_IMAGE = 'us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-cpu.nightly:latest'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk,all"
+   },
+   "source": [
+    "### Initialize Vertex AI SDK for Python\n",
+    "\n",
+    "Initialize the Vertex AI SDK for Python for your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xfFTb9Tu6LHm",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "vertex_ai.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vdQmak-2Gk7L"
+   },
+   "source": [
+    "## Introduction to Cloud Deploy Vertex AI Deployer\n",
+    "\n",
+    "Cloud Deploy Vertex AI Deployer is a custom target for Cloud Deploy.\n",
+    "\n",
+    "Cloud Deploy is a managed continuous delivery service. Users can use Cloud Deploy to define a delivery pipeline and configure an ordered sequence of targets. With custom targets, users can deploy to other systems besides the supported runtimes including Vertex AI endpoints.\n",
+    "\n",
+    "With Vertex AI, once the Vertex AI target endpoint is defined, users can create a release, which is associated with a specific version of the model. Then they can create a rollout, which is a deployment of that a model release to a specific target endpoint in the pipeline sequence. And finally, users can promote this release to the next target in the sequence.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qnrHVkk4G0MB"
+   },
+   "source": [
+    "### Register a model into Vertex AI Model Registry\n",
+    "\n",
+    "You upload your model as a version of the `Model` resource in the `Model Registry`. At minimum, you specify the display name, the Cloud Bucket location of the model and the Prediction Image you want to use.\n",
+    "\n",
+    "For this tutorial, you use a pre-trained model from Vertex AI's cloud samples bucket. For the docker image, you use a Cloud AI optimized version of tensorflow: [tf_opt](https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-uc1K6GRHwGO",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "registered_model = vertex_ai.Model.upload(\n",
+    "    display_name='model_to_deploy',\n",
+    "    artifact_uri=MODEL_URI,\n",
+    "    serving_container_image_uri=DEPLOY_IMAGE\n",
+    ")\n",
+    "\n",
+    "print(registered_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EJebO0xRKZwO"
+   },
+   "source": [
+    "### Create a Vertex AI Endpoint\n",
+    "\n",
+    "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JgSJ2TrbLB4-",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "endpoint = vertex_ai.Endpoint.create(\n",
+    "    display_name=\"target_endpoint\",\n",
+    "    project=PROJECT_ID,\n",
+    "    location=REGION,\n",
+    ")\n",
+    "\n",
+    "print(endpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2QYcYzLo5cbY"
+   },
+   "source": [
+    "### Create delivery pipeline, target, and custom target type\n",
+    "\n",
+    "When you use Vertex AI Deployer to deploy a registered model, you cover the following steps:\n",
+    "\n",
+    "- You define a custom action which is similar to deploy hooks and is defined in the skaffold.yaml file.\n",
+    "\n",
+    "- You define a custom target type which is a Cloud Deploy resource identifying the custom action used by targets of this type. In your case, a Vertex AI Endpoint.\n",
+    "\n",
+    "- You set a target definition for a custom target is the same as for any target type, except that it includes some properties.\n",
+    "\n",
+    "Once you have all the necessary components, you setup a Cloud Deploy delivery pipeline that references the configured target. And you can fully utilize Cloud Deploy features like promotion, approvals, and rollbacks by referencing the target to deploy you model. If you want to know more about custom targets and how custom targets work in Cloud Deploy, check out the [official documentation](https://cloud.google.com/deploy/docs/custom-targets).\n",
+    "\n",
+    "To cover all these steps, you can use the `build_and_register.sh` script in the [vertex-ai](https://github.com/GoogleCloudPlatform/cloud-deploy-samples/tree/main/custom-targets/vertex-ai) directory. The script can be used to build the Vertex AI model deployer image and register a Cloud Deploy custom target type that references the image.\n",
+    "\n",
+    "Below, you clone the Cloud Deploy samples repository and set the current directory to the vertex AI sample quickstart folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h20VT-mAQZg4",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/googlecloudplatform/cloud-deploy-samples.git\n",
+    "%cd cloud-deploy-samples/custom-targets/vertex-ai/quickstart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YlJC-lPVRJ0H"
+   },
+   "source": [
+    "Run the script that builds the image and registers the custom target type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "HUYVCRSaj6qV",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!../build_and_register.sh -p $PROJECT_ID -r $REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BoaLsEOq5iEW"
+   },
+   "source": [
+    "Run the following command to fill in the placeholders in the Cloud Deploy and Skaffold configuration values with the actual images.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qNLigFcXkcsa",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "endpoint_id = endpoint.name\n",
+    "\n",
+    "!./replace_variables.sh -p $PROJECT_ID -r $REGION -e $endpoint_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9ejsEd8s556r"
+   },
+   "source": [
+    "Finally, apply the Cloud Deploy configuration defined in `clouddeploy.yaml`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rUJ3Kxr_6pbw",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud deploy apply --file=clouddeploy.yaml --project=$PROJECT_ID --region=$REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sL4LBtjp5HgL"
+   },
+   "source": [
+    "### Create a release and rollout\n",
+    "\n",
+    "Create a Cloud Deploy release for the `configuration` defined in the configuration directory. Notice that the configuration file contains deployment settings including machine type, number of replicas and more which are associated with your endpoint. This automatically creates a rollout that deploys the first model version to the target endpoind.\n",
+    "\n",
+    "To create a Cloud Deploy release, you have to specify\n",
+    "\n",
+    "* The `--source` command line flag which instructs gcloud where to look for the configuration files relative to the working directory where the command is run.\n",
+    "\n",
+    "* The `--deploy-parameters` flag which is used to provide the custom deployer with additional parameters needed to perform the deployment.\n",
+    "\n",
+    "Here, you provide the custom deployer with two parameters:\n",
+    "\n",
+    "* `customTarget/vertexAIModel` which indicates the full resource name of the model to deploy\n",
+    "\n",
+    "* `--delivery-pipeline` which is the name of the delivery pipeline where the release will be created, and the project and region of the pipeline\n",
+    "is specified by `--project` and `--region` respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0vzd0UBl4HHB",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_id = registered_model.name\n",
+    "deploy_params = f'customTarget/vertexAIModel=projects/{PROJECT_ID}/locations/{REGION}/models/{model_id}'\n",
+    "\n",
+    "! gcloud deploy releases create release-0001 \\\n",
+    "    --delivery-pipeline=vertex-ai-cloud-deploy-pipeline \\\n",
+    "    --project=$PROJECT_ID \\\n",
+    "    --region=$REGION \\\n",
+    "    --source=configuration \\\n",
+    "    --deploy-parameters=$deploy_params"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AjtDtH7d7uSQ"
+   },
+   "source": [
+    "### Monitor the release's progress\n",
+    "\n",
+    "To check release details, run the command below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qnGUFIFP729K",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "riBnpRaB76jP"
+   },
+   "source": [
+    "Run this command to filter only the render status of the release.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nNZVgIc07-EK",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud deploy releases describe release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(renderState)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5QNy6BErIBBU"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>\n",
+    "⚠️ It will take up to 15 minutes for the model to fully deploy. ⚠️\n",
+    "</b>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mk7IFJ4Z8Bn5"
+   },
+   "source": [
+    "### Monitor rollout status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "s0uHB9TC8F7G"
+   },
+   "source": [
+    "In the [Cloud Deploy UI](https://cloud.google.com/deploy) for your project click on the\n",
+    "`vertex-ai-cloud-deploy-pipeline` delivery pipeline. Here you can see the release created and the rollout to the dev target for the release.\n",
+    "\n",
+    "You can also describe the rollout created using the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3Q0eur7x8Iei",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g4TYF0Jd8LML"
+   },
+   "source": [
+    "### Inspect Endpoint of the deployed model\n",
+    "\n",
+    "After the rollout completes, you can inspect the deployed models and traffic splits of the endpoint with `gcloud`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3vr2mSBl8RLs",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud ai endpoints describe $endpoint_id --region $REGION --project $PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g1SsVCBYsG1c"
+   },
+   "source": [
+    "### Inspect aliases in the deployed model\n",
+    "\n",
+    "Monitor the post-deploy operation by querying the rollout.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6jm1hKEqsPh1",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!gcloud deploy rollouts describe release-0001-to-prod-endpoint-0001 --release=release-0001 --delivery-pipeline=vertex-ai-cloud-deploy-pipeline --project=$PROJECT_ID --region=$REGION --format \"(phases[0].deploymentJobs.postdeployJob)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yI7Sv4lUsW55"
+   },
+   "source": [
+    "After the post-deploy job has succeeded, you can then inspect the deployed model and view its currently assigned aliases. `prod` and `champion` should be assigned. Those aliases would help you to manage the delivery process of your model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "RE1jmGb4sWmW",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud ai models describe $model_id --region $REGION --project $PROJECT_ID --format \"(versionAliases)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TpV-iwP9qw9c"
+   },
+   "source": [
+    "## Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "Otherwise, you can delete the individual resources you created in this tutorial as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h4Kdd7P4Wdyt"
+   },
+   "outputs": [],
+   "source": [
+    "delete_endpoint = True\n",
+    "delete_model = True\n",
+    "delete_cloud_deploy = True\n",
+    "\n",
+    "if delete_endpoint or os.getenv(\"IS_TESTING\"):\n",
+    "  endpoint_list = vertex_ai.Endpoint.list(filter='display_name=\"target_endpoint\"')\n",
+    "  for endpoint in endpoint_list:\n",
+    "    endpoint.delete(force=True)\n",
+    "\n",
+    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+    "  model_list = vertex_ai.Model.list(filter='display_name=\"model_to_deploy\"')\n",
+    "  for model in model_list:\n",
+    "    model.delete()\n",
+    "\n",
+    "if delete_model or os.getenv(\"IS_TESTING\"):\n",
+    "  ! gcloud deploy delete --file=clouddeploy.yaml --force --project=$PROJECT_ID --region=$REGION"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "environment": {
+   "kernel": "python3",
+   "name": "tf2-cpu.2-11.m114",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/tf2-cpu.2-11:m114"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (Local)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
<br>
This tutorial demonstrates how to deploy a Vertex AI model to an endpoint using a Cloud Deploy custom target, which allows you to specify a Vertex AI Endpoint as runtime environment into which to deploy your model.
<br>
<br><br>

If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
