### PR TITLE
Fix: lowercase custom training

### DIFF
--- a/notebooks/official/tensorboard/tensorboard_custom_training_with_custom_container.ipynb
+++ b/notebooks/official/tensorboard/tensorboard_custom_training_with_custom_container.ipynb
@@ -29,7 +29,7 @@
         "id": "ed2pOXQMb8fY"
       },
       "source": [
-        "# Vertex AI TensorBoard Custom Training with custom container\n",
+        "# Vertex AI TensorBoard custom training with custom container\n",
         "\n",
         "<table align=\"left\">\n",
         "  <td>\n",


### PR DESCRIPTION
Lowercase "custom training" in workbook title