### PR TITLE
Fix: lowercase maintenance

### DIFF
--- a/notebooks/official/workbench/predictive_maintainance/predictive_maintenance_usecase.ipynb
+++ b/notebooks/official/workbench/predictive_maintainance/predictive_maintenance_usecase.ipynb
@@ -29,7 +29,7 @@
         "id": "aef73cfa8725"
       },
       "source": [
-        "# Predictive Maintenance using Vertex AI\n",
+        "# Predictive maintenance using Vertex AI\n",
         "\n",
         "<table align=\"left\">\n",
         "  <td>\n",


### PR DESCRIPTION
Lowercase "maintenance" in workbook title