### PR TITLE
fix: Update RLHF large_model_reference to match text.

### DIFF
--- a/notebooks/official/generative_ai/rlhf_tune_llm.ipynb
+++ b/notebooks/official/generative_ai/rlhf_tune_llm.ipynb
@@ -632,7 +632,7 @@
         "        \"preference_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/summarize_from_feedback_tfds/comparisons/train/*.jsonl\",\n",
         "        \"prompt_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/reddit_tfds/train/*.jsonl\",\n",
         "        \"eval_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/reddit_tfds/val/*.jsonl\",\n",
-        "        \"large_model_reference\": \"t5-xl\",  # See table 1 for values\n",
+        "        \"large_model_reference\": \"text-bison@001\",  # See table 1 for values\n",
         "        \"model_display_name\": \"my_rlhf_tutorial_model\",  # Optional. If omitted, a default model_display_name will be created.\n",
         "        \"reward_model_train_steps\": 100,  # Please remember to read \"A Note on choosing train_steps\" section.\n",
         "        \"reinforcement_learning_train_steps\": 100,  # Please remember to read \"A Note on choosing train_steps\" section.\n",


### PR DESCRIPTION
The RLHF tuning notebook states we'll show the user how to tune a bison model, but the large model reference was `t5-xl`. These changes align the `large_model_reference` used in the code example to that of the text.