### PR TITLE
[Vertex AI SDK] Add custom serializer args for bigframes tensorflow

### DIFF
--- a/notebooks/official/vertex_ai_sdk/remote_training_bigframes_tensorflow.ipynb
+++ b/notebooks/official/vertex_ai_sdk/remote_training_bigframes_tensorflow.ipynb
@@ -456,8 +456,7 @@
         "    \"virginica\": 1,\n",
         "    \"setosa\": 2,\n",
         "}\n",
-        "df[\"target\"] = df[\"species\"].map(species_categories)\n",
-        "df = df.drop(columns=[\"species\"])\n",
+        "df[\"species\"] = df[\"species\"].map(species_categories)\n",
         "\n",
         "train, test = bf_train_test_split(df, test_size=0.2)"
       ]
@@ -501,6 +500,12 @@
         "model.fit.vertex.remote_config.machine_type = \"n1-highmem-4\"\n",
         "model.fit.vertex.remote_config.accelerator_type = \"NVIDIA_TESLA_K80\"\n",
         "model.fit.vertex.remote_config.accelerator_count = 4\n",
+        "\n",
+        "# (Optional) Set batch_size, target_col\n",
+        "model.fit.vertex.remote_config.serializer_args[train] = {\n",
+        "    \"batch_size\": 32,\n",
+        "    \"target_col\": \"species\",\n",
+        "}\n",
         "\n",
         "# Train model on Vertex\n",
         "model.fit(train, epochs=10)"
@@ -557,7 +562,7 @@
       "source": [
         "# User must convert bigframes to pandas dataframe for local evaluation\n",
         "feature_columns = [\"sepal_length\", \"sepal_width\", \"petal_length\", \"petal_width\"]\n",
-        "label_columns = [\"target\"]\n",
+        "label_columns = [\"species\"]\n",
         "\n",
         "train_X_np = train[feature_columns].to_pandas().values.astype(float)\n",
         "train_y_np = train[label_columns].to_pandas().values.astype(float)\n",

--- a/notebooks/official/vertex_ai_sdk/remote_training_bigframes_tensorflow.ipynb
+++ b/notebooks/official/vertex_ai_sdk/remote_training_bigframes_tensorflow.ipynb
@@ -536,6 +536,12 @@
         "# Disable GPU for remote prediction\n",
         "model.predict.vertex.remote_config.enable_cuda = False\n",
         "\n",
+        "# (Optional) Set batch_size, target_col\n",
+        "model.predict.vertex.remote_config.serializer_args[train] = {\n",
+        "    \"batch_size\": 32,\n",
+        "    \"target_col\": \"species\",\n",
+        "}\n",
+        "\n",
         "predictions = model.predict(train)\n",
         "\n",
         "print(f\"Remote predictions: {predictions}\")"


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Add custom serializer args (`batch_size` and `target_col`) for bigframes tensorflow
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [ ] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [ ] Follow the style and grammar rules outlined in the above notebook template.
- [ ] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.
