### PR TITLE
Remove eval_dataset from RLHF tuning parameters.

### DIFF
--- a/notebooks/official/generative_ai/rlhf_tune_llm.ipynb
+++ b/notebooks/official/generative_ai/rlhf_tune_llm.ipynb
@@ -631,7 +631,6 @@
         "    parameter_values={\n",
         "        \"preference_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/summarize_from_feedback_tfds/comparisons/train/*.jsonl\",\n",
         "        \"prompt_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/reddit_tfds/train/*.jsonl\",\n",
-        "        \"eval_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/reddit_tfds/val/*.jsonl\",\n",
         "        \"large_model_reference\": \"text-bison@001\",  # See table 1 for values\n",
         "        \"model_display_name\": \"my_rlhf_tutorial_model\",  # Optional. If omitted, a default model_display_name will be created.\n",
         "        \"reward_model_train_steps\": 100,  # Please remember to read \"A Note on choosing train_steps\" section.\n",


### PR DESCRIPTION
We temporarily disabled this parameter for first-party models, so this will avoid validation errors when running the RLHF tuning notebook in the meantime.