### PR TITLE
Fix errors in get_started_with_vertex_experiments.ipynb 

### DIFF
--- a/notebooks/official/CODEOWNERS
+++ b/notebooks/official/CODEOWNERS
@@ -16,6 +16,7 @@
 /model_monitoring @andrewferlitsch
 /tensorboard @zbl94
 /vertex_ai_sdk @jaycee-li
+/experiments @lakeyk
 
 /bigquery_ml/bqml-online-prediction.ipynb @polong-lin
 /model_monitoring/model_monitoring.ipynb @andrewferlitsch

--- a/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
@@ -388,7 +388,7 @@
       },
       "outputs": [],
       "source": [
-        "IS_COLAB=False",
+        "IS_COLAB=False\n",
         "if (\n",
         "    SERVICE_ACCOUNT == \"\"\n",
         "    or SERVICE_ACCOUNT is None\n",

--- a/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
@@ -388,6 +388,7 @@
       },
       "outputs": [],
       "source": [
+        "IS_COLAB=False",
         "if (\n",
         "    SERVICE_ACCOUNT == \"\"\n",
         "    or SERVICE_ACCOUNT is None\n",

--- a/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
@@ -389,6 +389,7 @@
       "outputs": [],
       "source": [
         "IS_COLAB=False\n",
+        "\n",
         "if (\n",
         "    SERVICE_ACCOUNT == \"\"\n",
         "    or SERVICE_ACCOUNT is None\n",

--- a/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
@@ -1338,7 +1338,7 @@
       "outputs": [],
       "source": [
         "EXPERIMENT_NAME = f\"example-{uuid.uuid1()}\"\n",
-        "aiplatform.init(experiment=EXPERIMENT_NAME)"
+        "aiplatform.init(experiment=EXPERIMENT_NAME)",
         "\n",
         "CMDARGS = [\n",
         "    \"--model-dir=\" + BUCKET_URI,\n",

--- a/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
@@ -179,8 +179,7 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install --upgrade --quiet google-cloud-aiplatform==1.34.0 \\\n",
-        "                                 pandas"
+        "! pip3 install --upgrade --quiet google-cloud-aiplatform\n"
       ]
     },
     {
@@ -518,18 +517,12 @@
         "if os.getenv(\"IS_TESTING_TF\"):\n",
         "    TF = os.getenv(\"IS_TESTING_TF\")\n",
         "else:\n",
-        "    TF = \"2.5\".replace(\".\", \"-\")\n",
+        "    TF = \"2.12\".replace(\".\", \"-\")\n",
         "\n",
-        "if TF[0] == \"2\":\n",
-        "    if TRAIN_GPU:\n",
-        "        TRAIN_VERSION = \"tf-gpu.{}\".format(TF)\n",
-        "    else:\n",
-        "        TRAIN_VERSION = \"tf-cpu.{}\".format(TF)\n",
+        "if TRAIN_GPU:\n",
+        "    TRAIN_VERSION = \"tf-gpu.{}.py310\".format(TF)\n",
         "else:\n",
-        "    if TRAIN_GPU:\n",
-        "        TRAIN_VERSION = \"tf-gpu.{}\".format(TF)\n",
-        "    else:\n",
-        "        TRAIN_VERSION = \"tf-cpu.{}\".format(TF)\n",
+        "    TRAIN_VERSION = \"tf-cpu.{}.py310\".format(TF)\n",
         "\n",
         "\n",
         "TRAIN_IMAGE = \"{}-docker.pkg.dev/vertex-ai/training/{}:latest\".format(\n",
@@ -767,7 +760,7 @@
         "\n",
         "experiment_df = aiplatform.get_experiment_df()\n",
         "experiment_df = experiment_df[experiment_df.experiment_name == EXPERIMENT_NAME]\n",
-        "experiment_df.T"
+        "print(experiment_df.T)"
       ]
     },
     {
@@ -830,7 +823,7 @@
         "\n",
         "experiment_df = aiplatform.get_experiment_df()\n",
         "experiment_df = experiment_df[experiment_df.experiment_name == EXPERIMENT_NAME]\n",
-        "experiment_df.T"
+        "print(experiment_df.T)"
       ]
     },
     {
@@ -979,7 +972,7 @@
         "\n",
         "experiment_df = aiplatform.get_experiment_df()\n",
         "experiment_df = experiment_df[experiment_df.experiment_name == EXPERIMENT_NAME]\n",
-        "experiment_df.T"
+        "print(experiment_df.T)"
       ]
     },
     {
@@ -1345,6 +1338,7 @@
       "outputs": [],
       "source": [
         "EXPERIMENT_NAME = f\"example-{uuid.uuid1()}\"\n",
+        "aiplatform.init(experiment=EXPERIMENT_NAME)"
         "\n",
         "CMDARGS = [\n",
         "    \"--model-dir=\" + BUCKET_URI,\n",
@@ -1386,7 +1380,7 @@
       "source": [
         "experiment_df = aiplatform.get_experiment_df()\n",
         "experiment_df = experiment_df[experiment_df.experiment_name == EXPERIMENT_NAME]\n",
-        "experiment_df.T"
+        "print(experiment_df.T)"
       ]
     },
     {

--- a/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
+++ b/notebooks/official/experiments/get_started_with_vertex_experiments.ipynb
@@ -388,7 +388,7 @@
       },
       "outputs": [],
       "source": [
-        "IS_COLAB=False\n",
+        "IS_COLAB = False\n",
         "\n",
         "if (\n",
         "    SERVICE_ACCOUNT == \"\"\n",


### PR DESCRIPTION
<br>
Fix several errors preventing notebook from being run out of the box, namely the custom job container image.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [x] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.
