### PR TITLE
fix: properly handle python versions

### DIFF
--- a/.cloud-build/execute_changed_notebooks_helper.py
+++ b/.cloud-build/execute_changed_notebooks_helper.py
@@ -238,7 +238,7 @@ def _get_notebook_python_version(notebook_path: str) -> str:
 
             # Look for the python version specification pattern
             re_match = re.search(
-                "python version = (\d\.\d)", markdown, flags=re.IGNORECASE
+                "python version = (\d+\.\d+)", markdown, flags=re.IGNORECASE
             )
             if re_match:
                 # get the version number


### PR DESCRIPTION
Fix b/329846693

Add a fix to properly handle Python versions, otherwise it can't extract versions such as 3.10 or 3.11.