### PR TITLE
Fix filename bug by appending suffix directly when a video doesn't have an extension

### DIFF
--- a/community-content/vertex_model_garden/model_oss/util/fileutils.py
+++ b/community-content/vertex_model_garden/model_oss/util/fileutils.py
@@ -232,10 +232,13 @@ def download_video_from_gcs_to_local(video_file_path: str) -> Tuple[str, str]:
   """
   _, local_video_file_name = os.path.split(video_file_path)
   file_extension = os.path.splitext(video_file_path)[1]
-  remote_video_file_name = local_video_file_name.replace(
-      file_extension, '_overlay.mp4'
-  )
-  local_file_path = generate_tmp_path(os.path.splitext(video_file_path)[1])
+  if file_extension:
+    remote_video_file_name = local_video_file_name.replace(
+        file_extension, '_overlay.mp4'
+    )
+  else:
+    remote_video_file_name = local_video_file_name + '_overlay.mp4'
+  local_file_path = generate_tmp_path(file_extension)
   logging.info('Downloading %s to %s...', video_file_path, local_file_path)
   download_gcs_file_to_local(video_file_path, local_file_path)
   return local_file_path, remote_video_file_name
@@ -251,7 +254,10 @@ def get_output_video_file(video_output_file_path: str) -> str:
     str: Local video output file path.
   """
   file_extension = os.path.splitext(video_output_file_path)[1]
-  out_local_video_file_name = video_output_file_path.replace(
-      file_extension, '_overlay' + file_extension
-  )
+  if file_extension:
+    out_local_video_file_name = video_output_file_path.replace(
+        file_extension, '_overlay' + file_extension
+    )
+  else:
+    out_local_video_file_name = video_output_file_path + '_overlay'
   return out_local_video_file_name


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>

In cases where a video file lacks an extension, the filenames generated by `download_video_from_gcs_to_local()` and `get_output_video_file()` functions do not format correctly. For instance, if we work with a video file named `/home/user/video` that does not have an extension, the `replace()` function receives an empty string as its argument. This leads to the replacement of every instance of an empty string in the filename with `_overlay.mp4`, causing an erroneous output like `_overlay.mp4v_overlay.mp4i_overlay.mp4d_overlay.mp4e_overlay.mp4o_overlay.mp4`.

For cases without extensions, we can just append the suffix directly to the filenames.

<br><br><br>

If you are opening a PR for `Community Content` under the [community-content](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/community-content) folder:
- [x] Make sure your main `Content Directory Name` is descriptive, informative, and includes some of the key products and attributes of your content, so that it is differentiable from other content
- [x] The main content directory has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/community-content/CODEOWNERS) file under the `Community Content` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
