### PR TITLE
moving some data from personal bucket to 'cloud-samples-data' bucket

### DIFF
--- a/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_automl_tabular.ipynb
@@ -549,7 +549,7 @@
       "outputs": [],
       "source": [
         "TRAIN_FILE_NAME = \"california_housing_train.csv\"\n",
-        "! gsutil cp gs://aju-dev-demos-codelabs/sample_data/california_housing_train.csv {PIPELINE_ROOT}/data/\n",
+        "! gsutil cp gs://cloud-samples-data/vertex-ai/pipeline-deployment/datasets/california_housing/california_housing_train.csv {PIPELINE_ROOT}/data/\n",
         "\n",
         "gcs_csv_path = f\"{PIPELINE_ROOT}/data/{TRAIN_FILE_NAME}\"\n",
         "\n",

--- a/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
+++ b/notebooks/official/pipelines/google_cloud_pipeline_components_model_train_upload_deploy.ipynb
@@ -557,7 +557,7 @@
       "outputs": [],
       "source": [
         "hp_dict: str = '{\"num_hidden_layers\": 3, \"hidden_size\": 32, \"learning_rate\": 0.01, \"epochs\": 1, \"steps_per_epoch\": -1}'\n",
-        "data_dir: str = \"gs://aju-dev-demos-codelabs/bikes_weather/\"\n",
+        "data_dir: str = \"gs://cloud-samples-data/vertex-ai/pipeline-deployment/datasets/bikes_weather/\"\n",
         "TRAINER_ARGS = [\"--data-dir\", data_dir, \"--hptune-dict\", hp_dict]\n",
         "\n",
         "# create working dir to pass to job spec\n",


### PR DESCRIPTION
A couple of these older notebooks were using a (now-personal) bucket of mine.  I'm belatedly moving the data to 'cloud-samples-data'.  No other changes.
(I'm about to switch the personal bucket to 'requester pays', so once I do that, these notebooks and their tests will break unless this PR is merged in).
