### PR TITLE
feat: Elastic Text-Embedding Model demo.

### DIFF
--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -347,8 +347,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "rHRZXoG0SVol",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "rHRZXoG0SVol"
       },
       "outputs": [],
       "source": [
@@ -389,14 +389,22 @@
         "\n",
         "\n",
         "def embed_text(\n",
-        "    model_name: str, task_type: str, text: str, title: str = \"\", output_dimensionality=None\n",
+        "    model_name: str,\n",
+        "    task_type: str,\n",
+        "    text: str,\n",
+        "    title: str = \"\",\n",
+        "    output_dimensionality=None,\n",
         ") -> list:\n",
         "    \"\"\"Generates a text embedding with a Large Language Model.\"\"\"\n",
         "    model = TextEmbeddingModel.from_pretrained(model_name)\n",
         "    text_embedding_input = TextEmbeddingInput(\n",
         "        task_type=task_type, title=title, text=text\n",
         "    )\n",
-        "    kwargs = dict(output_dimensionality=output_dimensionality) if output_dimensionality else {}\n",
+        "    kwargs = (\n",
+        "        dict(output_dimensionality=output_dimensionality)\n",
+        "        if output_dimensionality\n",
+        "        else {}\n",
+        "    )\n",
         "    embeddings = model.get_embeddings([text_embedding_input], **kwargs)\n",
         "    return embeddings[0].values\n",
         "\n",
@@ -427,8 +435,8 @@
   ],
   "metadata": {
     "colab": {
-      "toc_visible": true,
-      "provenance": []
+      "name": "text_embedding_new_api.ipynb",
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -330,43 +330,51 @@
         "1.   Set the model name. The latest models are\n",
         "     * \"text-embedding-preview-0409\" for English.\n",
         "     * \"text-multilingual-embedding-preview-0409\" for i18n. See the [language coverage](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#language_coverage_for_textembedding-gecko-multilingual_models) for the list of supported languages.\n",
-        "2.   Set the dimensionality (optional and valid only for the latest models).\n",
-        "3.   Set the task type, text, and title (optional and valid only for task type **\"RETRIEVAL_DOCUMENT\"**). The valid task types are:\n",
+        "     \n",
+        "     See [the public doc](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings) for the full list of supported models.\n",
+        "2.   Set the task type, text, and title (*optional and valid only for task type \"RETRIEVAL_DOCUMENT\"*). The valid task types are:\n",
         "     * \"RETRIEVAL_QUERY\"\n",
         "     * \"RETRIEVAL_DOCUMENT\"\n",
         "     * \"SEMANTIC_SIMILARITY\"\n",
         "     * \"CLASSIFICATION\"\n",
         "     * \"CLUSTERING\"\n",
-        "     * \"QUESTION_ANSWERING\"\n",
-        "     * \"FACT_VERIFICATION\""
+        "     * \"QUESTION_ANSWERING\" (*valid only for the latest models*)\n",
+        "     * \"FACT_VERIFICATION\" (*valid only for the latest models*)\n",
+        "3. Set the output dimensionality (*optional and valid only for the latest models*)."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "rHRZXoG0SVol"
+        "id": "rHRZXoG0SVol",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
         "# @title { run: \"auto\" }\n",
         "MODEL = \"text-embedding-preview-0409\"  # @param [\"text-embedding-preview-0409\", \"text-multilingual-embedding-preview-0409\", \"textembedding-gecko@003\", \"textembedding-gecko-multilingual@001\"]\n",
-        "DIMENSIONALITY = 256  # @param [1, 768, \"None\"] {type:\"raw\", allow-input:true}\n",
         "TASK = \"RETRIEVAL_DOCUMENT\"  # @param [\"RETRIEVAL_QUERY\", \"RETRIEVAL_DOCUMENT\", \"SEMANTIC_SIMILARITY\", \"CLASSIFICATION\", \"CLUSTERING\", \"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"]\n",
         "TEXT = \"Banana Muffin?\"  # @param {type:\"string\"}\n",
         "TITLE = \"\"  # @param {type:\"string\"}\n",
+        "OUTPUT_DIMENSIONALITY = 256  # @param [1, 768, \"None\"] {type:\"raw\", allow-input:true}\n",
         "\n",
         "if not MODEL:\n",
         "    raise ValueError(\"MODEL must be specified.\")\n",
-        "if DIMENSIONALITY is not None and MODEL not in [\n",
-        "    \"text-embedding-preview-0409\",\n",
-        "    \"text-multilingual-embedding-preview-0409\",\n",
-        "]:\n",
-        "    raise ValueError(f\"DIMENTIONALITY can only be None for model '{MODEL}'.\")\n",
         "if not TEXT:\n",
         "    raise ValueError(\"TEXT must be specified.\")\n",
         "if TITLE and TASK != \"RETRIEVAL_DOCUMENT\":\n",
-        "    raise ValueError(\"TITLE must be unspecified unless the TASK is RETRIEVAL_DOCUMENT\")"
+        "    raise ValueError(\"TITLE can only be specified for TASK 'RETRIEVAL_DOCUMENT'\")\n",
+        "if OUTPUT_DIMENSIONALITY is not None and MODEL not in [\n",
+        "    \"text-embedding-preview-0409\",\n",
+        "    \"text-multilingual-embedding-preview-0409\",\n",
+        "]:\n",
+        "    raise ValueError(f\"OUTPUT_DIMENTIONALITY cannot be specified for model '{MODEL}'.\")\n",
+        "if TASK in [\"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"] and MODEL not in [\n",
+        "    \"text-embedding-preview-0409\",\n",
+        "    \"text-multilingual-embedding-preview-0409\",\n",
+        "]:\n",
+        "    raise ValueError(f\"TASK '{TASK}' is not valid for model '{MODEL}'.\")"
       ]
     },
     {
@@ -379,18 +387,16 @@
       "source": [
         "from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel\n",
         "\n",
-        "# Generates a text embedding.\n",
-        "\n",
         "\n",
         "def embed_text(\n",
-        "    model_name: str, task_type: str, text: str, title: str = \"\", dimensionality=None\n",
+        "    model_name: str, task_type: str, text: str, title: str = \"\", output_dimensionality=None\n",
         ") -> list:\n",
-        "    \"\"\"Generate text embedding with a Large Language Model.\"\"\"\n",
+        "    \"\"\"Generates a text embedding with a Large Language Model.\"\"\"\n",
         "    model = TextEmbeddingModel.from_pretrained(model_name)\n",
         "    text_embedding_input = TextEmbeddingInput(\n",
         "        task_type=task_type, title=title, text=text\n",
         "    )\n",
-        "    kwargs = dict(output_dimensionality=dimensionality) if dimensionality else {}\n",
+        "    kwargs = dict(output_dimensionality=output_dimensionality) if output_dimensionality else {}\n",
         "    embeddings = model.get_embeddings([text_embedding_input], **kwargs)\n",
         "    return embeddings[0].values\n",
         "\n",
@@ -401,9 +407,9 @@
         "    task_type=TASK,\n",
         "    text=TEXT,\n",
         "    title=TITLE,\n",
-        "    dimensionality=DIMENSIONALITY,\n",
+        "    output_dimensionality=OUTPUT_DIMENSIONALITY,\n",
         ")\n",
-        "print(len(embedding))  # Expected value: {DIMENSIONALITY}."
+        "print(len(embedding))  # Expected value: {OUTPUT_DIMENSIONALITY}."
       ]
     },
     {
@@ -421,8 +427,8 @@
   ],
   "metadata": {
     "colab": {
-      "name": "text_embedding_new_api.ipynb",
-      "toc_visible": true
+      "toc_visible": true,
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
<br>
Elastic Text-Embedding demo for Google Cloud Next '24 (Apr. 9-11, 2024).
<br><br>
There is another public doc for Cloud Next 24 that shares this colab doc.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [X] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [X] Follow the style and grammar rules outlined in the above notebook template.
- [X] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [X] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [X] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [X] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.