### PR TITLE
Tune llama-2-7b with RLHF.

### DIFF
--- a/notebooks/official/generative_ai/rlhf_tune_llm.ipynb
+++ b/notebooks/official/generative_ai/rlhf_tune_llm.ipynb
@@ -59,7 +59,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates how to use Vertex AI RLHF to tune a large-language model (LLM). This workflow improves a model's accuracy by fine-tuning a base model with a training dataset.\n",
+        "This tutorial demonstrates how to use reinforcement learning from human feedback (RLHF) on Vertex AI to tune a large-language model (LLM). This workflow uses feedback gathered from humans to improve a model's accuracy.\n",
         "\n",
         "*Preview releases are covered by the Pre-GA Offerings Terms of the Google Cloud Platform Terms of Service. They are not intended for production use or covered by any SLA, support obligation, or deprecation policy and might be subject to backward-incompatible changes.*\n",
         "\n",
@@ -76,19 +76,17 @@
         "\n",
         "In this tutorial, you will use `Vertex AI RLHF` to tune and deploy a large language model model.\n",
         "\n",
-        "\n",
         "This tutorial uses the following Google Cloud ML services:\n",
         "\n",
         "- `Vertex AI RLHF`\n",
         "- `Vertex AI Pipelines`\n",
         "\n",
-        "\n",
         "The steps performed include:\n",
         "\n",
         "- Set the number of model tuning steps.\n",
-        "- Create Vertex AI Pipeline job using a predefined template for tuning.\n",
+        "- Create a Vertex AI Pipeline job using a predefined tuning template.\n",
         "- Execute the pipeline using `Vertex AI Pipelines`.\n",
-        "- Perform online prediction with the tuned model."
+        "- Get predictions from the tuned model."
       ]
     },
     {
@@ -99,7 +97,7 @@
       "source": [
         "### Prepare your inputs\n",
         "\n",
-        "In the sample below, you will run RLHF training on Google PaLM 2 Bison model. A list of supported models, hardware and regions can be found as follows. Tuning jobs that run in us-central1 will use 8 Nvidia A100 80GB. Jobs that run in europe-west4 will use 64 v3 TPUs.\n",
+        "In the sample below, you will run RLHF training on open source Llama-2-7b model. Table 1 (shown below) outlines supported models, hardware and regions. GPU jobs run in us-central1 with 8 Nvidia A100 80GB. TPU jobs run in europe-west4 with 64 v3 TPUs.\n",
         "\n",
         "**Table 1. Supported models, hardware and regions**\n",
         "\n",
@@ -171,9 +169,9 @@
         "\n",
         "Choosing a suitable value for the number of train steps can help avoid overfitting.\n",
         "\n",
-        "* **reward_model_train_steps**: This depends on the size of your \"comparison dataset\". Usually, the model should train over the comparison dataset for 20-30 times for best results.\n",
+        "* **reward_model_train_steps**: This depends on the size of your \"comparison dataset\". Usually, the model should train over the comparison dataset for 20-30 epochs for best results.\n",
         "\n",
-        "* **reinforcement_learning_train_steps**: This depends on the size of your prompt dataset. Usually, the model should train over the prompt dataset for roughly 10-20 times, but beware, if given too many training steps, the policy model may figure out a way exploit the reward and exhibit undesired behavior (i.e. \"reward hacking\").\n",
+        "* **reinforcement_learning_train_steps**: This depends on the size of your prompt dataset. Usually, the model should train over the prompt dataset for roughly 10-20 epochs, but beware, if given too many training steps, the policy model may figure out a way exploit the reward and exhibit undesired behavior (i.e. \"reward hacking\").\n",
         "\n",
         "The calculator below can help you compute these numbers."
       ]
@@ -610,6 +608,39 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "c53703554ef6"
+      },
+      "source": [
+        "## (Optional) Define `tensorboard_resource_id` to upload train-time metrics\n",
+        "\n",
+        "A `tensorboard_resource_id` is needed to upload metrics at training time. Follow these steps to [manually create a Vertex AI Tensorboard instance](https://cloud.google.com/vertex-ai/docs/experiments/tensorboard-setup#google-cloud-cli) (if you do not have one already). The tensorboard instance must be in the same region as the training job, i.e. us-central1 if `accelerator_type` (defined below) is `GPU` or europe-west4 if `accelerator_type` is `TPU`. If a `tensorboard_resource_id` is not provided, train-time metrics will not be uploaded.\n",
+        "\n",
+        "After following those steps you should receive an id in the format `projects/{project_number}/locations/{location}/tensorboards/{tensorboard_id}`. Replace `None` with the integer tensorboard id and run the following cell."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fca702359f51"
+      },
+      "outputs": [],
+      "source": [
+        "# Replace `None` with your tensorboard id (if you created one)\n",
+        "TENSORBOARD_ID = None\n",
+        "\n",
+        "if TENSORBOARD_ID:\n",
+        "    # Note, the tensorboard instance must be in the same project and region as the tuning job.\n",
+        "    tensorboard_resource_id = (\n",
+        "        f\"projects/{project_number}/locations/{REGION}/tensorboards/{TENSORBOARD_ID}\"\n",
+        "    )\n",
+        "else:\n",
+        "    tensorboard_resource_id = None"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "3o6EaTXJ4JEY"
       },
       "source": [
@@ -638,7 +669,7 @@
         "        \"preference_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/summarize_from_feedback_tfds/comparisons/train/*.jsonl\",\n",
         "        \"prompt_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/reddit_tfds/train/*.jsonl\",\n",
         "        \"eval_dataset\": \"gs://vertex-ai/generative-ai/rlhf/text_small/summarize_from_feedback_tfds/comparisons/valid1/*.jsonl\",\n",
-        "        \"large_model_reference\": \"text-bison@001\",  # See table 1 for values\n",
+        "        \"large_model_reference\": \"llama-2-7b\",  # See table 1 for values\n",
         "        \"model_display_name\": \"my_rlhf_tutorial_model\",  # Optional. If omitted, a default model_display_name will be created.\n",
         "        \"reward_model_train_steps\": 100,  # Please remember to read \"A Note on choosing train_steps\" section.\n",
         "        \"reinforcement_learning_train_steps\": 100,  # Please remember to read \"A Note on choosing train_steps\" section.\n",
@@ -648,6 +679,8 @@
         "        \"reinforcement_learning_rate_multiplier\": 1.0,\n",
         "        \"kl_coeff\": 0.1,\n",
         "        \"instruction\": \"Summarize in less than 50 words.\",\n",
+        "        \"accelerator_type\": \"TPU\",\n",
+        "        \"tensorboard_resource_id\": tensorboard_resource_id,\n",
         "    },\n",
         ")"
       ]
@@ -693,9 +726,9 @@
         "id": "QgKNkUuWOIff"
       },
       "source": [
-        "### Look at train-time metrics using TensorBoard\n",
+        "### View train-time metrics using Vertex AI Experiments\n",
         "\n",
-        "The **Reward Model Trainer** and **Reinforcer** report train-time metrics like `rank_loss`, `reward`, and `kl_loss` to the `tensorboard_id` provided to the pipeline. To view metrics, click on either the **Reward Model Trainer** or **Reinforcer** in the UI. Then click `Open TensorBoard` in the side panel (shown below). It will take a few seconds after clicking the component for the `Open Tensorboard` button to appear."
+        "The **Reward Model Trainer** and **Reinforcer** report train-time metrics like `rank_loss`, `reward`, and `kl_loss` to the `tensorboard_resource_id` provided to the pipeline. To view metrics, click on either the **Reward Model Trainer** or **Reinforcer** in the UI. Then click `Open TensorBoard` in the side panel (shown below). It will take a few seconds after clicking the component for the `Open Tensorboard` button to appear. Note, tensorboard metrics will only be reported if a `tensorboard_resource_id` was "
       ]
     },
     {
@@ -726,7 +759,7 @@
         "The recommened way to get predictions from tuned models depends on whether you are working with a first-party or third-party model. For first-party models, e.g. `text-bison@001`, you can get predictions using [Batch Prediction](https://cloud.google.com/vertex-ai/docs/predictions/get-batch-predictions) or [Online Prediction](https://cloud.google.com/vertex-ai/docs/predictions/get-online-predictions), and for third-party models, we provide a bulk inference pipeline that can be used with the tuned-model checkpoint. Examples for both model types are in subsequent sections below.\n",
         "\n",
         "### Bulk Inference for Third-Party Models\n",
-        "In this section we show how to use the bulk inference pipeline to get predictions from a tuned `t5-small` model. This method will not work for first-party models, e.g. `text-bison@001`. Follow the example in the next section to get predictions from those models.\n",
+        "In this section we show how to use the bulk inference pipeline to get predictions from a tuned `t5` or `llama2` model. This method will not work for first-party models, e.g. `text-bison@001`. Follow the example in the next section to get predictions from those models.\n",
         "\n",
         "To perform bulk inference you will need the path to your tuned third-party model, which can be found in the Vertex Pipelines UI under **Reinforcer** > **Output Parameters** > `output_model_path`. Once you have the model path, follow the directions in the [Bulk Inference notebook](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/batch_eval_llm.ipynb) to generate offline predictions from a tuned model checkpoint."
       ]


### PR DESCRIPTION
These changes switch the tuned model from text-bison to llama2. (We'll release an updated notebook with instructions to tune bison in the future.)

We also revised text in some sections to improve clarity.