### PR TITLE
Remove inaccurate description about length of training time automl_im…

### DIFF
--- a/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb
+++ b/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb
@@ -562,8 +562,6 @@
         "- `disable_early_stopping`: If `True`, training maybe completed before using the entire budget if the service believes it cannot further improve on the model objective measurements.\n",
         "\n",
         "The `run` method when completed returns the `Model` resource.\n",
-        "\n",
-        "The execution of the training pipeline will take upto 20 minutes."
       ]
     },
     {


### PR DESCRIPTION
This notebook said the training time could take up to 20 minutes, but for some it'll be much longer (over an hour). Simpler just to remove our time estimate since it varies so much.