### PR TITLE
add text-embedding-004 and text-mutilingual-embedding-002 to public

### DIFF
--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -72,7 +72,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This notebook is a code example for how to call our newly released text emebedding models (text-embedding-preview-0409 and text-multilingual-embedding-preview-0409).\n",
+        "This notebook is a code example for how to call our newly released text emebedding models (text-embedding-004, text-multilingual-embedding-002, text-embedding-preview-0409 and text-multilingual-embedding-preview-0409).\n",
         "\n",
         "Learn more about [text embedding api](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings#api_changes_to_models_released_in_or_after_august_2023)."
       ]
@@ -85,8 +85,8 @@
       "source": [
         "### Objective\n",
         "\n",
-        "In this tutorial, you learn how to call text embedding latest APIs on two\n",
-        "new models, text-embedding-preview-0409 and text-multilingual-embedding-preview-0409:\n",
+        "In this tutorial, you learn how to call text embedding latest APIs on two new GA models text-embedding-004 and text-multilingual-embedding-002 and two\n",
+        "new public preview models, text-embedding-preview-0409 and text-multilingual-embedding-preview-0409:\n",
         "\n",
         "This tutorial uses the following Google Cloud ML services and resources:\n",
         "\n",
@@ -328,6 +328,8 @@
         "### Generate embeddings\n",
         "\n",
         "1.   Set the model name. The latest models are\n",
+        "     * \"text-embedding-004\" for English.\n",
+        "     * \"text-multilingual-embedding-002\" for i18n.\n",
         "     * \"text-embedding-preview-0409\" for English.\n",
         "     * \"text-multilingual-embedding-preview-0409\" for i18n. See the [language coverage](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#language_coverage_for_textembedding-gecko-multilingual_models) for the list of supported languages.\n",
         "     \n",
@@ -353,7 +355,7 @@
       "outputs": [],
       "source": [
         "# @title { run: \"auto\" }\n",
-        "MODEL = \"text-embedding-preview-0409\"  # @param [\"text-embedding-preview-0409\", \"text-multilingual-embedding-preview-0409\", \"textembedding-gecko@003\", \"textembedding-gecko-multilingual@001\"]\n",
+        "MODEL = \"text-embedding-004\"  # @param [\"text-embedding-004\", \"text-multilingual-embedding-002\", \"text-embedding-preview-0409\", \"text-multilingual-embedding-preview-0409\", \"textembedding-gecko@003\", \"textembedding-gecko-multilingual@001\"]\n",
         "TASK = \"RETRIEVAL_DOCUMENT\"  # @param [\"RETRIEVAL_QUERY\", \"RETRIEVAL_DOCUMENT\", \"SEMANTIC_SIMILARITY\", \"CLASSIFICATION\", \"CLUSTERING\", \"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"]\n",
         "TEXT = \"Banana Muffin?\"  # @param {type:\"string\"}\n",
         "TITLE = \"\"  # @param {type:\"string\"}\n",
@@ -366,11 +368,15 @@
         "if TITLE and TASK != \"RETRIEVAL_DOCUMENT\":\n",
         "    raise ValueError(\"TITLE can only be specified for TASK 'RETRIEVAL_DOCUMENT'\")\n",
         "if OUTPUT_DIMENSIONALITY is not None and MODEL not in [\n",
+        "    \"text-embedding-004\",\n",
+        "    \"text-multilingual-embedding-002\",\n",
         "    \"text-embedding-preview-0409\",\n",
         "    \"text-multilingual-embedding-preview-0409\",\n",
         "]:\n",
         "    raise ValueError(f\"OUTPUT_DIMENTIONALITY cannot be specified for model '{MODEL}'.\")\n",
         "if TASK in [\"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"] and MODEL not in [\n",
+        "    \"text-embedding-004\",\n",
+        "    \"text-multilingual-embedding-002\",\n",
         "    \"text-embedding-preview-0409\",\n",
         "    \"text-multilingual-embedding-preview-0409\",\n",
         "]:\n",
@@ -445,4 +451,5 @@
   },
   "nbformat": 4,
   "nbformat_minor": 0
-}
+ }
+ 


### PR DESCRIPTION
<br>
Add two GA new models `text-embedding-004` and `text-multilingual-embedding-002` for Google I/O (2024) in public notebook.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>