### PR TITLE
Fix export error

### DIFF
--- a/notebooks/community/model_garden/model_garden_jax_paligemma_finetuning.ipynb
+++ b/notebooks/community/model_garden/model_garden_jax_paligemma_finetuning.ipynb
@@ -267,7 +267,7 @@
         "\n",
         "def get_quota(project_id: str, region: str, resource_id: str) -> int:\n",
         "    \"\"\"Returns the quota for a resource in a region. Returns -1 if can not figure out the quota.\"\"\"\n",
-        "    ! export service_endpoint=\"aiplatform.googleapis.com\"\n",
+        "    service_endpoint = \"aiplatform.googleapis.com\"\n",
         "    quota_list_output = !gcloud alpha services quota list --service=$service_endpoint  --consumer=projects/$project_id --filter=\"$service_endpoint/$resource_id\" --format=json\n",
         "    # Use '.s' on the command output because it is an SList type.\n",
         "    quota_data = json.loads(quota_list_output.s)\n",


### PR DESCRIPTION

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ ] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

Please note that linter fails because Colab Enterprise needs `@param` definition to be in one line even if it is a long line.