### PR TITLE
chore, fix(egen): corrections from template, guidelines, & fixes docker tag command

### DIFF
--- a/notebooks/official/prediction/get_started_with_tf_serving.ipynb
+++ b/notebooks/official/prediction/get_started_with_tf_serving.ipynb
@@ -4,10 +4,12 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "cellView": "form",
         "id": "ur8xi4C7S06n"
       },
       "outputs": [],
       "source": [
+        "# @title Copyright & License (click to expand)\n",
         "# Copyright 2022 Google LLC\n",
         "#\n",
         "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
@@ -32,25 +34,27 @@
         "# Get started with TensorFlow Serving with Vertex AI Prediction\n",
         "\n",
         "<table align=\"left\">\n",
-        "  <td>\n",
+        "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/prediction/get_started_with_tf_serving.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
         "    </a>\n",
         "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/prediction/get_started_with_tf_serving.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fprediction%2Fget_started_with_tf_serving.ipynb\">\n",
+        "      <img width=\"32px\" src=\"https://lh3.googleusercontent.com/JmcxdQi-qOpctIvWKgPtrzZdJJK-J3sWE1RsfjZNwshCFgE_9fULcNpuXYTilIR2hjwN\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
         "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
+        "  </td>    \n",
+        "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/prediction/get_started_with_tf_serving.ipynb\">\n",
-        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-        "      Open in Vertex AI Workbench\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
         "    </a>\n",
-        "  </td>        \n",
-        "</table>\n",
-        "<br/><br/><br/>"
+        "  </td>\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/prediction/get_started_with_tf_serving.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "</table>"
       ]
     },
     {
@@ -63,7 +67,7 @@
         "\n",
         "This tutorial demonstrates how to serve predictions from a `Vertex AI Endpoint` with `TensorFlow Serving` serving binary.\n",
         "\n",
-        "Learn more about [Get predictions from a custom trained model](https://cloud.google.com/vertex-ai/docs/predictions/get-predictions)."
+        "Learn more about [getting predictions from a custom trained model](https://cloud.google.com/vertex-ai/docs/predictions/get-predictions)."
       ]
     },
     {
@@ -76,7 +80,7 @@
         "\n",
         "In this tutorial, you learn how to use `Vertex AI Prediction` on a `Vertex AI Endpoint` resource with `TensorFlow Serving` serving binary.\n",
         "\n",
-        "This tutorial uses the following Google Cloud ML services and resources:\n",
+        "This tutorial uses the following Vertex AI services and resources:\n",
         "\n",
         "- `Vertex AI Prediction`\n",
         "- `Vertex AI Batch Prediction`\n",
@@ -130,12 +134,19 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "3b1ffd5ab768"
+      },
+      "source": [
+        "## Getting Started"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "install_aip"
       },
       "source": [
-        "## Installation\n",
-        "\n",
-        "Install the following packages to execute this notebook."
+        "### Install Vertex AI SDK and other required packages\n"
       ]
     },
     {
@@ -155,25 +166,69 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "58707a750154"
+        "id": "ff555b32bab8"
       },
       "source": [
-        "### Colab only: Uncomment the following cell to restart the kernel."
+        "### Restart runtime (Colab only)\n",
+        "\n",
+        "To use the newly installed packages, you must restart the runtime on Google Colab."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "f200f10a1da3"
+        "id": "f09b4dff629a"
       },
       "outputs": [],
       "source": [
-        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-        "# import IPython\n",
+        "import sys\n",
         "\n",
-        "# app = IPython.Application.instance()\n",
-        "# app.kernel.do_shutdown(True)"
+        "if \"google.colab\" in sys.modules:\n",
+        "\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "54c5ef8a8f43"
+      },
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>⚠️ The kernel is going to restart. Please wait until it is finished before continuing to the next step. ⚠️</b>\n",
+        "</div>\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "92e68cfc3a90"
+      },
+      "source": [
+        "### Authenticate your notebook environment (Colab only)\n",
+        "\n",
+        "Authenticate your environment on Google Colab.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "46604f70e831"
+      },
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "\n",
+        "if \"google.colab\" in sys.modules:\n",
+        "\n",
+        "    from google.colab import auth\n",
+        "\n",
+        "    auth.authenticate_user()"
       ]
     },
     {
@@ -182,12 +237,9 @@
         "id": "WReHDGG5g0XY"
       },
       "source": [
-        "#### Set your project ID\n",
+        "### Set Google Cloud project information\n",
         "\n",
-        "**If you don't know your project ID**, try the following:\n",
-        "* Run `gcloud config list`.\n",
-        "* Run `gcloud projects list`.\n",
-        "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+        "Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
       ]
     },
     {
@@ -199,92 +251,7 @@
       "outputs": [],
       "source": [
         "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-        "\n",
-        "# Set the project id\n",
-        "! gcloud config set project {PROJECT_ID}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Set the region\n",
-        "\n",
-        "**Optional**: Update the 'REGION' variable to specify the region that you want to use. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "nsN5NJKSu-GU"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sBCra4QMA2wR"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "To authenticate your Google Cloud account, follow the instructions for your Jupyter environment:\n",
-        "\n",
-        "**1. Vertex AI Workbench**\n",
-        "<br>You are already authenticated.\n",
-        "\n",
-        "**2. Local JupyterLab instance**\n",
-        "<br>Uncomment and run the following code:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "254614fa0c46"
-      },
-      "outputs": [],
-      "source": [
-        "# ! gcloud auth login"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ef21552ccea8"
-      },
-      "source": [
-        "**3. Colab**\n",
-        "<br>Uncomment and run the following code:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "603adbbf0532"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import auth\n",
-        "\n",
-        "# auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c13224697bfb"
-      },
-      "source": [
-        "**4. Service account or other**\n",
-        "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
+        "LOCATION = \"us-central1\"  # @param {type:\"string\"}"
       ]
     },
     {
@@ -326,7 +293,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l {REGION} -p {PROJECT_ID} {BUCKET_URI}"
+        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -335,10 +302,7 @@
         "id": "setup_vars"
       },
       "source": [
-        "### Set up variables\n",
-        "\n",
-        "Next, set up some variables used throughout the tutorial.\n",
-        "### Import libraries and define constants"
+        "### Import libraries"
       ]
     },
     {
@@ -349,11 +313,12 @@
       },
       "outputs": [],
       "source": [
+        "import json\n",
         "import os\n",
         "\n",
-        "import google.cloud.aiplatform as aip\n",
         "import tensorflow as tf\n",
-        "import tensorflow_hub as hub"
+        "import tensorflow_hub as hub\n",
+        "from google.cloud import aiplatform"
       ]
     },
     {
@@ -364,7 +329,8 @@
       "source": [
         "### Initialize Vertex AI SDK for Python\n",
         "\n",
-        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket."
+        "Initialize the Vertex AI SDK for Python for your project and corresponding bucket.\n",
+        "To get started using Vertex AI, you must have an existing Google Cloud project and [enable the Vertex AI API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com). "
       ]
     },
     {
@@ -375,7 +341,7 @@
       },
       "outputs": [],
       "source": [
-        "aip.init(project=PROJECT_ID, staging_bucket=BUCKET_URI)"
+        "aiplatform.init(project=PROJECT_ID, staging_bucket=BUCKET_URI)"
       ]
     },
     {
@@ -388,16 +354,16 @@
         "\n",
         "You can set hardware accelerators for training and prediction.\n",
         "\n",
-        "Set the variables `DEPLOY_GPU/DEPLOY_NGPU` to use a container image supporting a GPU and the number of GPUs allocated to the virtual machine (VM) instance. For example, to use a GPU container image with 4 Nvidia Telsa K80 GPUs allocated to each VM, you would specify:\n",
+        "Set the variables `DEPLOY_GPU/DEPLOY_NGPU` to use a container image supporting a GPU and the number of GPUs allocated to the virtual machine (VM) instance. For example, to use a GPU container image with 4 Nvidia Telsa T4 GPUs allocated to each VM, you would specify:\n",
         "\n",
-        "    (aip.gapic.AcceleratorType.NVIDIA_TESLA_K80, 4)\n",
+        "    (aiplatform.gapic.AcceleratorType.NVIDIA_TESLA_T4, 4)\n",
         "\n",
         "\n",
         "Otherwise specify `(None, None)` to use a container image to run on a CPU.\n",
         "\n",
         "Learn more about [hardware accelerator support for your region](https://cloud.google.com/vertex-ai/docs/general/locations#accelerators).\n",
         "\n",
-        "*Note*: TF releases before 2.3 for GPU support will fail to load the custom model in this tutorial. It is a known issue and fixed in TF 2.3. This is caused by static graph ops that are generated in the serving function. If you encounter this issue on your own custom models, use a container image for TF 2.3 with GPU support."
+        "*Note*: TF releases before 2.3 for GPU support fail to load the custom model in this tutorial. It is a known issue and fixed in TF 2.3. This is caused by static graph ops that are generated in the serving function. If you encounter this issue on your own custom models, use a container image for TF 2.3 with GPU support."
       ]
     },
     {
@@ -421,7 +387,7 @@
         "\n",
         "Next, set the machine type to use for prediction.\n",
         "\n",
-        "- Set the variable `DEPLOY_COMPUTE` to configure  the compute resources for the VMs you will use for for prediction.\n",
+        "- Set the variable `DEPLOY_COMPUTE` to configure  the compute resources for the VMs you use for for prediction.\n",
         " - `machine type`\n",
         "     - `n1-standard`: 3.75GB of memory per vCPU.\n",
         "     - `n1-highmem`: 6.5GB of memory per vCPU\n",
@@ -456,7 +422,7 @@
         "\n",
         "You must enable the Artifact Registry API service for your project.\n",
         "\n",
-        "Learn more about [Enabling service](https://cloud.google.com/artifact-registry/docs/enable-service)."
+        "Learn more about [enabling services](https://cloud.google.com/artifact-registry/docs/enable-service)."
       ]
     },
     {
@@ -499,7 +465,7 @@
       "source": [
         "PRIVATE_REPO = \"my-docker-repo\"\n",
         "\n",
-        "! gcloud artifacts repositories create {PRIVATE_REPO} --repository-format=docker --location={REGION} --description=\"Docker repository\"\n",
+        "! gcloud artifacts repositories create {PRIVATE_REPO} --repository-format=docker --location={LOCATION} --description=\"Docker repository\"\n",
         "\n",
         "! gcloud artifacts repositories list"
       ]
@@ -523,7 +489,7 @@
       },
       "outputs": [],
       "source": [
-        "! gcloud auth configure-docker {REGION}-docker.pkg.dev --quiet"
+        "! gcloud auth configure-docker {LOCATION}-docker.pkg.dev --quiet"
       ]
     },
     {
@@ -558,7 +524,7 @@
         "# Executes in Vertex AI Workbench\n",
         "if DEPLOY_GPU:\n",
         "    DEPLOY_IMAGE = (\n",
-        "        f\"{REGION}-docker.pkg.dev/\"\n",
+        "        f\"{LOCATION}-docker.pkg.dev/\"\n",
         "        + PROJECT_ID\n",
         "        + f\"/{PRIVATE_REPO}\"\n",
         "        + \"/tf_serving:gpu\"\n",
@@ -566,7 +532,7 @@
         "    TF_IMAGE = \"tensorflow/serving:2.5.4-gpu\"\n",
         "else:\n",
         "    DEPLOY_IMAGE = (\n",
-        "        f\"{REGION}-docker.pkg.dev/\"\n",
+        "        f\"{LOCATION}-docker.pkg.dev/\"\n",
         "        + PROJECT_ID\n",
         "        + f\"/{PRIVATE_REPO}\"\n",
         "        + \"/tf_serving:cpu\"\n",
@@ -683,7 +649,7 @@
       "source": [
         "## Upload the model for serving\n",
         "\n",
-        "Next, you will upload your TF.Keras model from the custom job to Vertex `Model` service, which will create a Vertex `Model` resource for your custom model. During upload, you need to define a serving function to convert data to the format your model expects. If you send encoded data to Vertex AI, your serving function ensures that the data is decoded on the model server before it is passed as input to your model.\n",
+        "Next, you upload your TF.Keras model from the custom job to Vertex `Model` service, which creates a Vertex `Model` resource for your custom model. During upload, you need to define a serving function to convert data to the format your model expects. If you send encoded data to Vertex AI, your serving function ensures that the data is decoded on the model server before it is passed as input to your model.\n",
         "\n",
         "### How does the serving function work\n",
         "\n",
@@ -700,7 +666,7 @@
         "\n",
         "Both the preprocessing and post-processing functions are converted to static graphs which are fused to the model. The output from the underlying model is passed to the post-processing function. The post-processing function passes the converted/packaged output back to the HTTP server. The HTTP server returns the output as the HTTP response content.\n",
         "\n",
-        "One consideration you need to consider when building serving functions for TF.Keras models is that they run as static graphs. That means, you cannot use TF graph operations that require a dynamic graph. If you do, you will get an error during the compile of the serving function which will indicate that you are using an EagerTensor which is not supported."
+        "One consideration you need to consider when building serving functions for TF.Keras models is that they run as static graphs. That means, you cannot use TF graph operations that require a dynamic graph. If you do, you get an error during the compile of the serving function which indicates that you are using an EagerTensor which is not supported."
       ]
     },
     {
@@ -778,9 +744,9 @@
         "\n",
         "You can get the signatures of your model's input and output layers by reloading the model into memory, and querying it for the signatures corresponding to each layer.\n",
         "\n",
-        "For your purpose, you need the signature of the serving function. Why? Well, when we send our data for prediction as a HTTP request packet, the image data is base64 encoded, and our TF.Keras model takes numpy input. Your serving function will do the conversion from base64 to a numpy array.\n",
+        "For your purpose, you need the signature of the serving function. Why? Well, when we send our data for prediction as a HTTP request packet, the image data is base64 encoded, and our TF.Keras model takes numpy input. Your serving function does the conversion from base64 to a numpy array.\n",
         "\n",
-        "When making a prediction request, you need to route the request to the serving function instead of the model, so you need to know the input layer name of the serving function -- which you will use later when you make a prediction request."
+        "When making a prediction request, you need to route the request to the serving function instead of the model, so you need to know the input layer name of the serving function -- which you use later when you make a prediction request."
       ]
     },
     {
@@ -815,13 +781,13 @@
         "    - `--model_base_name`: Where to store the model artifacts in the container. The Vertex service sets the variable $(AIP_STORAGE_URI) to where the service installed the model artifacts in the container.\n",
         "    - `--rest_api_port`: The port to which to send REST based prediction requests. Can either be 8080 or 8501 (default for TensorFlow Serving).\n",
         "    - `--port`: The port to which to send gRPC based prediction requests. Should be 8500 for TensorFlow Serving.\n",
-        "- `serving_container_health_route`: The URL for the service to periodically ping for a response to verify that the serving binary is running. For TensorFlow Serving, this will be /v1/models/\\<model_name\\>.\n",
-        "- `serving_container_predict_route`: The URL for the service to route REST-based prediction requests to. For TF Serving, this will be /v1/models/[model_name]:predict.\n",
+        "- `serving_container_health_route`: The URL for the service to periodically ping for a response to verify that the serving binary is running. For TensorFlow Serving, this is /v1/models/\\<model_name\\>.\n",
+        "- `serving_container_predict_route`: The URL for the service to route REST-based prediction requests to. For TF Serving, this is /v1/models/[model_name]:predict.\n",
         "- `serving_container_ports`: A list of ports for the HTTP server to listen for requests.\n",
         "\n",
         "Uploading a model into a Vertex Model resource returns a long running operation, since it may take a few moments. \n",
         "\n",
-        "*Note:* You drop the ending number subfolder (e.g., /1) from the model path to upload. The Vertex service will upload the parent folder above the subfolder with the model artifacts -- which is what TensorFlow Serving binary expects.\n",
+        "*Note:* You drop the ending number subfolder (e.g., /1) from the model path to upload. The Vertex service uploads the parent folder above the subfolder with the model artifacts -- which is what TensorFlow Serving binary expects.\n",
         "\n",
         "*Note:* When you upload the model artifacts to a `Vertex AI Model` resource, you specify the corresponding deployment container image."
       ]
@@ -836,7 +802,7 @@
       "source": [
         "MODEL_NAME = \"example_\"\n",
         "\n",
-        "model = aip.Model.upload(\n",
+        "model = aiplatform.Model.upload(\n",
         "    display_name=\"example_\",\n",
         "    artifact_uri=MODEL_DIR[:-2],\n",
         "    serving_container_image_uri=DEPLOY_IMAGE,\n",
@@ -862,7 +828,7 @@
         "id": "628de0914ba1"
       },
       "source": [
-        "## Creating an `Endpoint` resource\n",
+        "## Create an `Endpoint` resource\n",
         "\n",
         "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint. Optionally, you can specify the project and location (region); otherwise the settings are inherited by the values you set when you initialized the Vertex AI SDK with the `init()` method.\n",
         "\n",
@@ -886,10 +852,10 @@
       },
       "outputs": [],
       "source": [
-        "endpoint = aip.Endpoint.create(\n",
+        "endpoint = aiplatform.Endpoint.create(\n",
         "    display_name=\"example_\",\n",
         "    project=PROJECT_ID,\n",
-        "    location=REGION,\n",
+        "    location=LOCATION,\n",
         "    labels={\"your_key\": \"your_value\"},\n",
         ")\n",
         "\n",
@@ -902,9 +868,9 @@
         "id": "ca3fa3f6a894"
       },
       "source": [
-        "## Deploying `Model` resources to an `Endpoint` resource.\n",
+        "## Deploy `Model` resources to an `Endpoint` resource.\n",
         "\n",
-        "You can deploy one of more `Vertex AI Model` resource instances to the same endpoint. Each `Vertex AI Model` resource that is deployed will have its own deployment container for the serving binary. \n",
+        "You can deploy one of more `Vertex AI Model` resource instances to the same endpoint. Each `Vertex AI Model` resource that is deployed has its own deployment container for the serving binary. \n",
         "\n",
         "*Note:* For this example, you specified the deployment container for the TFHub model in the previous step of uploading the model artifacts to a `Vertex AI Model` resource.\n",
         "\n",
@@ -948,7 +914,7 @@
       "source": [
         "### Prepare test data for prediction\n",
         "\n",
-        "Next, you will load a compressed JPEG image into memory and then base64 encode it. For demonstration purposes, you use an image from the Flowers dataset."
+        "Next, you load a compressed JPEG image into memory and then base64 encode it. For demonstration purposes, you use an image from the Flowers dataset."
       ]
     },
     {
@@ -1032,7 +998,7 @@
         "\n",
         "Batch prediction provides the ability to do offline batch processing of large amounts of prediction requests. Resources are only provisioned during the batch process and then deprovisioned when the batch request is completed. The results are stored in Cloud Storage, in contrast to online prediction where the results are returned as a HTTP response packet.\n",
         "\n",
-        "The input format for your batch job is dependent on the format supported by your model server. Foremost, the web server in your model server must support a JSONL format, which the web server will convert to a format support either directly by the model input intertace or a serving function interface. For batch prediction, this JSONL format is referred to as the `pivot` format.\n",
+        "The input format for your batch job is dependent on the format supported by your model server. Foremost, the web server in your model server must support a JSONL format, which the web server converts to a format support either directly by the model input intertace or a serving function interface. For batch prediction, this JSONL format is referred to as the `pivot` format.\n",
         "\n",
         "### Input format for batch prediction jobs\n",
         "\n",
@@ -1063,7 +1029,7 @@
         "\n",
         "**CSV**\n",
         "\n",
-        "The csv header in the first line will always be ignored. String fields are required to be double quoted explicitly, otherwise the row is discarded and parsing error messages are outputted to error files. Non-quoted values are always transferred as floats.\n",
+        "The csv header in the first line is always ignored. String fields are required to be double quoted explicitly, otherwise the row is discarded and parsing error messages are outputted to error files. Non-quoted values are always transferred as floats.\n",
         "\n",
         "    col1,col2,col3\n",
         "    1,3,\"cat1\"\n",
@@ -1120,7 +1086,7 @@
         "id": "9ccd46a186da"
       },
       "source": [
-        "### Make the batch input file\n",
+        "## Make the batch input file\n",
         "\n",
         "Next, make a batch input file, which you store in your local Cloud Storage bucket. For custom models, you format the batch input file in JSONL format. Each JSON object entry in the JSONL file is specified in the same format as you specified for the online prediction request.\n",
         "\n",
@@ -1148,9 +1114,7 @@
       "outputs": [],
       "source": [
         "# For demonstration purposes, you write the same image (instance[0]) request twice to the JSONL file.\n",
-        "# You will receive back two predictions, one for each instance.\n",
-        "\n",
-        "import json\n",
+        "# You receive back two predictions, one for each instance.\n",
         "\n",
         "with open(\"test.jsonl\", \"w\") as f:\n",
         "    json.dump(instances[0], f)\n",
@@ -1166,7 +1130,7 @@
         "id": "batch_request:mbsdk,jsonl,custom"
       },
       "source": [
-        "### Make the batch prediction request\n",
+        "## Make the batch prediction request\n",
         "\n",
         "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
         "\n",
@@ -1178,7 +1142,7 @@
         "- `machine_type`: The type of machine to use for training.\n",
         "- `accelerator_type`: The hardware accelerator type.\n",
         "- `accelerator_count`: The number of accelerators to attach to a worker replica.\n",
-        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+        "- `sync`: If set to True, the call gets blocked while waiting for the asynchronous batch job to complete."
       ]
     },
     {
@@ -1214,7 +1178,7 @@
         "id": "batch_request_wait:mbsdk"
       },
       "source": [
-        "### Wait for completion of batch prediction job\n",
+        "## Wait for completion of batch prediction job\n",
         "\n",
         "Next, wait for the batch job to complete. Alternatively, one can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
       ]
@@ -1236,7 +1200,7 @@
         "id": "get_batch_prediction:mbsdk,custom,icn"
       },
       "source": [
-        "### Get the predictions\n",
+        "## Get the predictions\n",
         "\n",
         "Next, get the results from the completed batch prediction job.\n",
         "\n",
@@ -1254,8 +1218,6 @@
       },
       "outputs": [],
       "source": [
-        "import json\n",
-        "\n",
         "bp_iter_outputs = batch_predict_job.iter_outputs()\n",
         "\n",
         "prediction_results = list()\n",
@@ -1295,33 +1257,23 @@
       },
       "outputs": [],
       "source": [
-        "import os\n",
-        "\n",
+        "# set delete_bucket to True to delete your bucket\n",
         "delete_bucket = False\n",
-        "delete_model = True\n",
-        "delete_endpoint = True\n",
-        "delete_batch_job = True\n",
         "\n",
-        "if delete_endpoint:\n",
-        "    try:\n",
-        "        endpoint.undeploy_all()\n",
-        "        endpoint.delete()\n",
-        "    except Exception as e:\n",
-        "        print(e)\n",
+        "# undeploy the model from the endpoint\n",
+        "endpoint.undeploy_all()\n",
         "\n",
-        "if delete_model:\n",
-        "    try:\n",
-        "        model.delete()\n",
-        "    except Exception as e:\n",
-        "        print(e)\n",
+        "# delete the endpoint\n",
+        "endpoint.delete()\n",
         "\n",
+        "# delete the model\n",
+        "model.delete()\n",
+        "\n",
+        "# delete the batch job\n",
+        "batch_predict_job.delete()\n",
+        "\n",
+        "# delete the bucket\n",
         "if delete_bucket:\n",
-        "    try:\n",
-        "        batch_predict_job.delete()\n",
-        "    except Exception as e:\n",
-        "        print(e)\n",
-        "\n",
-        "if delete_bucket or os.getenv(\"IS_TESTING\"):\n",
         "    ! gsutil rm -rf {BUCKET_URI}"
       ]
     }

--- a/notebooks/official/prediction/get_started_with_tf_serving.ipynb
+++ b/notebooks/official/prediction/get_started_with_tf_serving.ipynb
@@ -156,10 +156,10 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install --upgrade google-cloud-aiplatform -q\n",
-        "! pip3 install --upgrade google-cloud-pipeline-components  -q\n",
-        "! pip3 install tensorflow==2.15.1 -q\n",
-        "! pip3 install tensorflow-hub -q"
+        "! pip3 install --upgrade google-cloud-aiplatform \\\n",
+        "                        google-cloud-pipeline-components \\\n",
+        "                        tensorflow==2.15.1 \\\n",
+        "                        tensorflow-hub -q"
       ]
     },
     {
@@ -313,7 +313,6 @@
       "outputs": [],
       "source": [
         "import json\n",
-        "import os\n",
         "\n",
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
@@ -432,11 +431,7 @@
       },
       "outputs": [],
       "source": [
-        "! gcloud services enable artifactregistry.googleapis.com\n",
-        "\n",
-        "if os.getenv(\"IS_TESTING\"):\n",
-        "    ! sudo apt-get update --yes && sudo apt-get --only-upgrade --yes install google-cloud-sdk-cloud-run-proxy google-cloud-sdk-harbourbridge google-cloud-sdk-cbt google-cloud-sdk-gke-gcloud-auth-plugin google-cloud-sdk-kpt google-cloud-sdk-local-extract google-cloud-sdk-minikube google-cloud-sdk-app-engine-java google-cloud-sdk-app-engine-go google-cloud-sdk-app-engine-python google-cloud-sdk-spanner-emulator google-cloud-sdk-bigtable-emulator google-cloud-sdk-nomos google-cloud-sdk-package-go-module google-cloud-sdk-firestore-emulator kubectl google-cloud-sdk-datastore-emulator google-cloud-sdk-app-engine-python-extras google-cloud-sdk-cloud-build-local google-cloud-sdk-kubectl-oidc google-cloud-sdk-anthos-auth google-cloud-sdk-app-engine-grpc google-cloud-sdk-pubsub-emulator google-cloud-sdk-datalab google-cloud-sdk-skaffold google-cloud-sdk google-cloud-sdk-terraform-tools google-cloud-sdk-config-connector\n",
-        "    ! gcloud components update --quiet"
+        "! gcloud services enable artifactregistry.googleapis.com"
       ]
     },
     {

--- a/notebooks/official/prediction/get_started_with_tf_serving.ipynb
+++ b/notebooks/official/prediction/get_started_with_tf_serving.ipynb
@@ -9,7 +9,6 @@
       },
       "outputs": [],
       "source": [
-        "# @title Copyright & License (click to expand)\n",
         "# Copyright 2022 Google LLC\n",
         "#\n",
         "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",

--- a/notebooks/official/prediction/get_started_with_tf_serving.ipynb
+++ b/notebooks/official/prediction/get_started_with_tf_serving.ipynb
@@ -870,7 +870,7 @@
       "source": [
         "## Deploy model to the endpoint\n",
         "\n",
-        "You can deploy one of more Vertex AI model resource instances to the same endpoint. Each model resource that is deployed has its own deployment container for the serving binary. \n",
+        "You can deploy one or more Vertex AI model resource instances to the same endpoint. Each model resource that is deployed has its own deployment container for the serving binary. \n",
         "\n",
         "**Note:** For this example, you specified the deployment container for the TFHub model in the previous step of uploading the model artifacts to a Vertex AI model resource.\n",
         "\n",

--- a/notebooks/official/prediction/get_started_with_tf_serving.ipynb
+++ b/notebooks/official/prediction/get_started_with_tf_serving.ipynb
@@ -579,7 +579,7 @@
         "dockerd -b none --iptables=0 -l warn &\n",
         "for i in $(seq 5); do [ ! -S \"/var/run/docker.sock\" ] && sleep 2 || break; done\n",
         "docker pull $3\n",
-        "docker tag tensorflow/serving $2\n",
+        "docker tag $3 $2\n",
         "docker push $2\n",
         "kill $(jobs -p)"
       ]

--- a/notebooks/official/prediction/get_started_with_tf_serving.ipynb
+++ b/notebooks/official/prediction/get_started_with_tf_serving.ipynb
@@ -41,7 +41,7 @@
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fprediction%2Fget_started_with_tf_serving.ipynb\">\n",
-        "      <img width=\"32px\" src=\"https://lh3.googleusercontent.com/JmcxdQi-qOpctIvWKgPtrzZdJJK-J3sWE1RsfjZNwshCFgE_9fULcNpuXYTilIR2hjwN\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
+        "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
         "    </a>\n",
         "  </td>    \n",
         "  <td style=\"text-align: center\">\n",
@@ -87,15 +87,15 @@
         "- `Vertex AI Models`\n",
         "- `Vertex AI Endpoints`\n",
         "\n",
-        "The steps performed include:\n",
+        "You perform the following steps:\n",
         "\n",
         "- Download a pretrained image classification model from TensorFlow Hub.\n",
         "- Create a serving function to receive compressed image data, and output decomopressed preprocessed data for the model input.\n",
-        "- Upload the TensorFlow Hub model and serving function as a `Vertex AI Model` resource.\n",
-        "- Creating an `Endpoint` resource.\n",
-        "- Deploying the `Model` resource to an `Endpoint` resource with `TensorFlow Serving` serving binary.\n",
-        "- Make an online prediction to the `Model` resource instance deployed to the `Endpoint` resource.\n",
-        "- Make a batch prediction to the `Model` resource instance."
+        "- Upload the TensorFlow Hub model and serving function as a Vertex AI model resource.\n",
+        "- Create a Vertex AI endpoint resource.\n",
+        "- Deploy the model resource to the endpoint resource with `TensorFlow Serving` serving binary.\n",
+        "- Make an online prediction with the deployed model.\n",
+        "- Make a batch prediction with the model."
       ]
     },
     {
@@ -137,7 +137,7 @@
         "id": "3b1ffd5ab768"
       },
       "source": [
-        "## Getting Started"
+        "## Get started"
       ]
     },
     {
@@ -146,7 +146,7 @@
         "id": "install_aip"
       },
       "source": [
-        "### Install Vertex AI SDK and other required packages\n"
+        "### Install Vertex AI SDK for Python and other required packages\n"
       ]
     },
     {
@@ -159,7 +159,7 @@
       "source": [
         "! pip3 install --upgrade google-cloud-aiplatform -q\n",
         "! pip3 install --upgrade google-cloud-pipeline-components  -q\n",
-        "! pip3 install --upgrade tensorflow -q\n",
+        "! pip3 install tensorflow==2.15.1 -q\n",
         "! pip3 install tensorflow-hub -q"
       ]
     },
@@ -199,7 +199,7 @@
       },
       "source": [
         "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Please wait until it is finished before continuing to the next step. ⚠️</b>\n",
+        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
         "</div>\n"
       ]
     },
@@ -282,7 +282,7 @@
         "id": "create_bucket"
       },
       "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+        "**If your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
       ]
     },
     {
@@ -363,7 +363,7 @@
         "\n",
         "Learn more about [hardware accelerator support for your region](https://cloud.google.com/vertex-ai/docs/general/locations#accelerators).\n",
         "\n",
-        "*Note*: TF releases before 2.3 for GPU support fail to load the custom model in this tutorial. It is a known issue and fixed in TF 2.3. This is caused by static graph ops that are generated in the serving function. If you encounter this issue on your own custom models, use a container image for TF 2.3 with GPU support."
+        "**Note**: TF releases before 2.3 for GPU support fail to load the custom model in this tutorial. It's a known issue and fixed in TF 2.3. This is caused by static graph ops that are generated in the serving function. If you encounter this issue on your own custom models, use a container image for TF 2.3 with GPU support."
       ]
     },
     {
@@ -394,7 +394,7 @@
         "     - `n1-highcpu`: 0.9 GB of memory per vCPU\n",
         " - `vCPUs`: number of \\[2, 4, 8, 16, 32, 64, 96 \\]\n",
         "\n",
-        "*Note: You may also use n2 and e2 machine types for training and deployment, but they do not support GPUs*."
+        "**Note**: You may also use n2 and e2 machine types for training and deployment, but they do not support GPUs."
       ]
     },
     {
@@ -592,7 +592,7 @@
       "source": [
         "## Get pretrained model from TensorFlow Hub\n",
         "\n",
-        "For demonstration purposes, this tutorial uses a pretrained model from TensorFlow Hub (TFHub), which is then uploaded to a `Vertex AI Model` resource. Once you have a `Vertex AI Model` resource, the model can be deployed to a `Vertex AI Endpoint` resource.\n",
+        "For demonstration purposes, this tutorial uses a pretrained model from TensorFlow Hub (TFHub), which is then uploaded to a Vertex AI model resource. Once you have a Vertex AI model resource created, the model can then be deployed to a Vertex AI endpoint resource.\n",
         "\n",
         "### Download the pretrained model\n",
         "\n",
@@ -626,7 +626,7 @@
         "\n",
         "At this point, the model is in memory. Next, you save the model artifacts to a Cloud Storage location.\n",
         "\n",
-        "*Note:* For TF Serving, the MODEL_DIR must end in a subfolder that is a number, e.g., 1."
+        "**Note:** For TF Serving, the MODEL_DIR must end in a subfolder that is a number, e.g., 1."
       ]
     },
     {
@@ -649,7 +649,7 @@
       "source": [
         "## Upload the model for serving\n",
         "\n",
-        "Next, you upload your TF.Keras model from the custom job to Vertex `Model` service, which creates a Vertex `Model` resource for your custom model. During upload, you need to define a serving function to convert data to the format your model expects. If you send encoded data to Vertex AI, your serving function ensures that the data is decoded on the model server before it is passed as input to your model.\n",
+        "Next, you upload your TF.Keras model from the custom job to Vertex AI model service, which creates a model resource for your custom model. During upload, you need to define a serving function to convert data to the format your model expects. If you send encoded data to Vertex AI, your serving function ensures that the data is decoded on the model server before it's passed as input to your model.\n",
         "\n",
         "### How does the serving function work\n",
         "\n",
@@ -666,7 +666,7 @@
         "\n",
         "Both the preprocessing and post-processing functions are converted to static graphs which are fused to the model. The output from the underlying model is passed to the post-processing function. The post-processing function passes the converted/packaged output back to the HTTP server. The HTTP server returns the output as the HTTP response content.\n",
         "\n",
-        "One consideration you need to consider when building serving functions for TF.Keras models is that they run as static graphs. That means, you cannot use TF graph operations that require a dynamic graph. If you do, you get an error during the compile of the serving function which indicates that you are using an EagerTensor which is not supported."
+        "One consideration you need to consider when building serving functions for TF.Keras models is that they run as static graphs. That means, you can't use TF graph operations that require a dynamic graph. If you do, you get an error during the compile of the serving function which indicates that you're using an EagerTensor which isn't supported."
       ]
     },
     {
@@ -679,7 +679,7 @@
         "\n",
         "#### Preprocessing\n",
         "\n",
-        "To pass images to the prediction service, you encode the compressed (e.g., JPEG) image bytes into base 64 -- which makes the content safe from modification while transmitting binary data over the network. Since this deployed model expects input data as raw (uncompressed) bytes, you need to ensure that the base 64 encoded data gets converted back to raw bytes, and then preprocessed to match the model input requirements, before it is passed as input to the deployed model.\n",
+        "To pass images to the prediction service, you encode the compressed (e.g., JPEG) image bytes into base 64 -- which makes the content safe from modification while transmitting binary data over the network. Since this deployed model expects input data as raw (uncompressed) bytes, you need to ensure that the base 64 encoded data gets converted back to raw bytes, and then preprocessed to match the model input requirements, before it's passed as input to the deployed model.\n",
         "\n",
         "To resolve this, you define a serving function (`serving_fn`) and attach it to the model as a preprocessing step. Add a `@tf.function` decorator so the serving function is fused to the underlying model (instead of upstream on a CPU).\n",
         "\n",
@@ -744,7 +744,7 @@
         "\n",
         "You can get the signatures of your model's input and output layers by reloading the model into memory, and querying it for the signatures corresponding to each layer.\n",
         "\n",
-        "For your purpose, you need the signature of the serving function. Why? Well, when we send our data for prediction as a HTTP request packet, the image data is base64 encoded, and our TF.Keras model takes numpy input. Your serving function does the conversion from base64 to a numpy array.\n",
+        "For your purpose, you need the signature of the serving function. Why? Well, when you send our data for prediction as a HTTP request packet, the image data is base64 encoded, and our TF.Keras model takes numpy input. Your serving function does the conversion from base64 to a numpy array.\n",
         "\n",
         "When making a prediction request, you need to route the request to the serving function instead of the model, so you need to know the input layer name of the serving function -- which you use later when you make a prediction request."
       ]
@@ -771,9 +771,9 @@
         "id": "e8ce91147c93"
       },
       "source": [
-        "### Upload the TensorFlow Hub model to a `Vertex AI Model` resource\n",
+        "### Upload the TensorFlow Hub model to a Vertex AI model resource\n",
         "\n",
-        "Finally, you upload the model artifacts from the TFHub model and serving function into a `Vertex AI Model` resource. Since you are using a non Google pre-built serving binary -- i.e., TensorFlow Serving, you need to specify the following additional serving configuration settings:\n",
+        "Finally, you upload the model artifacts from the TFHub model and serving function into a Vertex AI model resource. Since you're using a non Google pre-built serving binary -- i.e., TensorFlow Serving, you need to specify the following additional serving configuration settings:\n",
         "\n",
         "- `serving_container_command`: The serving binary (HTTP Server) to start up.\n",
         "- `serving_container_args`: The arguments to pass to the serving binary. For TensorFlow Serving, the required arguments are:\n",
@@ -785,11 +785,11 @@
         "- `serving_container_predict_route`: The URL for the service to route REST-based prediction requests to. For TF Serving, this is /v1/models/[model_name]:predict.\n",
         "- `serving_container_ports`: A list of ports for the HTTP server to listen for requests.\n",
         "\n",
-        "Uploading a model into a Vertex Model resource returns a long running operation, since it may take a few moments. \n",
+        "Uploading a model into a Vertex model resource returns a long running operation, since it may take a few moments. \n",
         "\n",
-        "*Note:* You drop the ending number subfolder (e.g., /1) from the model path to upload. The Vertex service uploads the parent folder above the subfolder with the model artifacts -- which is what TensorFlow Serving binary expects.\n",
+        "**Note:** You drop the ending number subfolder (e.g., /1) from the model path to upload. The Vertex service uploads the parent folder above the subfolder with the model artifacts -- which is what TensorFlow Serving binary expects.\n",
         "\n",
-        "*Note:* When you upload the model artifacts to a `Vertex AI Model` resource, you specify the corresponding deployment container image."
+        "**Note:** When you upload the model artifacts to a Vertex AI model resource, you specify the corresponding deployment container image."
       ]
     },
     {
@@ -828,18 +828,18 @@
         "id": "628de0914ba1"
       },
       "source": [
-        "## Create an `Endpoint` resource\n",
+        "## Create a Vertex AI endpoint resource\n",
         "\n",
-        "You create an `Endpoint` resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint. Optionally, you can specify the project and location (region); otherwise the settings are inherited by the values you set when you initialized the Vertex AI SDK with the `init()` method.\n",
+        "You create a Vertex AI endpoint resource using the `Endpoint.create()` method. At a minimum, you specify the display name for the endpoint. Optionally, you can specify the project and location (region); otherwise the settings are inherited by the values you set when you initialized the Vertex AI SDK with the `init()` method.\n",
         "\n",
         "In this example, the following parameters are specified:\n",
         "\n",
-        "- `display_name`: A human readable name for the `Endpoint` resource.\n",
+        "- `display_name`: A human readable name for the endpoint resource.\n",
         "- `project`: Your project ID.\n",
         "- `location`: Your region.\n",
-        "- `labels`: (optional) User defined metadata for the `Endpoint` in the form of key/value pairs.\n",
+        "- `labels`: (optional) User defined metadata for the endpoint in the form of key/value pairs.\n",
         "\n",
-        "This method returns an `Endpoint` object.\n",
+        "This method returns a Vertex AI endpoint object.\n",
         "\n",
         "Learn more about [Vertex AI Endpoints](https://cloud.google.com/vertex-ai/docs/predictions/deploy-model-api)."
       ]
@@ -868,13 +868,13 @@
         "id": "ca3fa3f6a894"
       },
       "source": [
-        "## Deploy `Model` resources to an `Endpoint` resource.\n",
+        "## Deploy model to the endpoint\n",
         "\n",
-        "You can deploy one of more `Vertex AI Model` resource instances to the same endpoint. Each `Vertex AI Model` resource that is deployed has its own deployment container for the serving binary. \n",
+        "You can deploy one of more Vertex AI model resource instances to the same endpoint. Each model resource that is deployed has its own deployment container for the serving binary. \n",
         "\n",
-        "*Note:* For this example, you specified the deployment container for the TFHub model in the previous step of uploading the model artifacts to a `Vertex AI Model` resource.\n",
+        "**Note:** For this example, you specified the deployment container for the TFHub model in the previous step of uploading the model artifacts to a Vertex AI model resource.\n",
         "\n",
-        "In the next example, you deploy the `Vertex AI Model` resource to a `Vertex AI Endpoint` resource. The `Vertex AI Model` resource already has defined for it the deployment container image. To deploy, you specify the following additional configuration settings:\n",
+        "In the next example, you deploy the Vertex AI model resource to a Vertex AI endpoint resource. The model resource already has a container image defined for deployment. To deploy, you specify the following additional configuration settings:\n",
         "\n",
         "- The machine type.\n",
         "- The (if any) type and number of GPUs.\n",
@@ -882,7 +882,7 @@
         "\n",
         "In this example, you deploy the model with the minimal amount of specified parameters, as follows:\n",
         "\n",
-        "- `model`: The `Model` resource.\n",
+        "- `model`: The Vertex AI model resource.\n",
         "- `deployed_model_displayed_name`: The human readable name for the deployed model instance.\n",
         "- `machine_type`: The machine type for each VM instance.\n",
         "\n",
@@ -951,7 +951,7 @@
       "source": [
         "### Make the prediction\n",
         "\n",
-        "Now that your `Model` resource is deployed to an `Endpoint` resource, you can do online predictions by sending prediction requests to the Endpoint resource.\n",
+        "Now that your model resource is deployed to an endpoint resource, you can do online predictions by sending prediction requests to the Endpoint resource.\n",
         "\n",
         "#### Request\n",
         "\n",
@@ -994,11 +994,11 @@
         "id": "11e16f54bc90"
       },
       "source": [
-        "## Introduction to Batch Prediction\n",
+        "## Introduction to batch prediction\n",
         "\n",
         "Batch prediction provides the ability to do offline batch processing of large amounts of prediction requests. Resources are only provisioned during the batch process and then deprovisioned when the batch request is completed. The results are stored in Cloud Storage, in contrast to online prediction where the results are returned as a HTTP response packet.\n",
         "\n",
-        "The input format for your batch job is dependent on the format supported by your model server. Foremost, the web server in your model server must support a JSONL format, which the web server converts to a format support either directly by the model input intertace or a serving function interface. For batch prediction, this JSONL format is referred to as the `pivot` format.\n",
+        "The input format for your batch job is dependent on the format supported by your model server. Foremost, the web server in your model server must support a JSONL format, which the web server converts to a format support either directly by the model input interface or a serving function interface. For batch prediction, this JSONL format is referred to as the `pivot` format.\n",
         "\n",
         "### Input format for batch prediction jobs\n",
         "\n",
@@ -1180,7 +1180,7 @@
       "source": [
         "## Wait for completion of batch prediction job\n",
         "\n",
-        "Next, wait for the batch job to complete. Alternatively, one can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+        "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
       ]
     },
     {


### PR DESCRIPTION
<br>
The docker tag command fails to run when the existing tag is not provided in Colab. The fix resolves it by considering the image name along with the tag from the arguments. 

Additionally, this PR includes the following updates:

1. Adds collapsed license comment.
2. Adds a link for Colab enterprise.
3. Replaces aip with aiplatform, Cloud ML with Vertex AI, & REGION with LOCATION (as per the template).
4. Reduces the future tense usage.
5. Heading style corrections.
6. Removes IS_TESTING from the cleaning up section.
7. Replaces K80 with T4 in the explanation about GPUs.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>