### PR TITLE
chore(egen): Replace matching-engine with vector search

### DIFF
--- a/notebooks/official/vector_search/README.md
+++ b/notebooks/official/vector_search/README.md
@@ -1,5 +1,5 @@
 
-[Using Vertex AI Multimodal Embeddings and Vector Search](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_multimodal_embeddings.ipynb)
+[Using Vertex AI Multimodal Embeddings and Vector Search](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_multimodal_embeddings.ipynb)
 
 ```
 Learn how to encode custom text embeddings, create an  Approximate Nearest Neighbor  index, and query against indexes.
@@ -16,7 +16,7 @@ The steps performed include:
 ```
 
 
-[Using Vertex AI Matching Engine for StackOverflow Questions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings.ipynb)
+[Using Vertex AI Vector Search for StackOverflow Questions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings.ipynb)
 
 ```
 Learn how to encode custom text embeddings, create an Approximate Nearest Neighbor  index, and query against indexes.
@@ -30,10 +30,10 @@ The steps performed include:
 
 ```
 
-&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Matching Engine](https://cloud.google.com/vertex-ai/docs/matching-engine/overview).
+&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview).
 
 
-[Using Vertex AI Vector Search and Vertex AI Embeddings for Text for StackOverflow Questions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings_vertex.ipynb)
+[Using Vertex AI Vector Search and Vertex AI Embeddings for Text for StackOverflow Questions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb)
 
 ```
 Learn how to encode text embeddings, create an Approximate Nearest Neighbor  index, and query against indexes.
@@ -49,12 +49,12 @@ The steps performed include:
 
 ```
 
-&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/matching-engine/overview).
+&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview).
 
 &nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Embeddings for Text](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings).
 
 
-[Using Vertex AI Matching Engine for Text-to-Image Embeddings](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_text_to_image_embeddings.ipynb)
+[Using Vertex AI Vector Search for Text-to-Image Embeddings](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_text_to_image_embeddings.ipynb)
 
 ```
 Learn how to encode custom text embeddings, create an  Approximate Nearest Neighbor  index, and query against indexes.
@@ -68,10 +68,10 @@ The steps performed include:
 
 ```
 
-&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Matching Engine](https://cloud.google.com/vertex-ai/docs/matching-engine/overview).
+&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview).
 
 
-[Using Vertex AI Vector Search for Text-to-Image Embeddings](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_text_to_image_embeddings.ipynb)
+[Using Vertex AI Vector Search for Text-to-Image Embeddings](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_text_to_image_embeddings.ipynb)
 
 ```
 Learn how to encode custom text embeddings, create an  Approximate Nearest Neighbor  index, and query against indexes.
@@ -85,10 +85,10 @@ The steps performed include:
 
 ```
 
-&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/matching-engine/overview).
+&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview).
 
 
-[Create Vertex AI Matching Engine index](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb)
+[Create Vertex AI Vector Search index](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb)
 
 ```
 Learn how to create Approximate Nearest Neighbor  Index, query against indexes, and validate the performance of the index.
@@ -103,5 +103,5 @@ The steps performed include:
 
 ```
 
-&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Matching Engine](https://cloud.google.com/vertex-ai/docs/matching-engine/overview).
+&nbsp;&nbsp;&nbsp;Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview).
 

--- a/notebooks/official/vector_search/sdk_vector_search_create_multimodal_embeddings.ipynb
+++ b/notebooks/official/vector_search/sdk_vector_search_create_multimodal_embeddings.ipynb
@@ -30,26 +30,26 @@
       },
       "source": [
         "# Using Vertex AI Multimodal Embeddings and Vector Search\n",
-        "![ ](https://www.google-analytics.com/collect?v=2&tid=G-L6X3ECH596&cid=1&en=page_view&sid=1&dt=sdk_matching_engine_create_multimodal_embeddings.ipynb&dl=notebooks%2Fofficial%2Fmatching_engine%2Fsdk_matching_engine_create_multimodal_embeddings.ipynb)\n",
+        "![ ](https://www.google-analytics.com/collect?v=2&tid=G-L6X3ECH596&cid=1&en=page_view&sid=1&dt=sdk_vector_search_create_multimodal_embeddings.ipynb&dl=notebooks%2Fofficial%2Fvector_search%2Fsdk_vector_search_create_multimodal_embeddings.ipynb)\n",
         "<table align=\"left\">\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_multimodal_embeddings.ipynb\">\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_multimodal_embeddings.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"><br> Run in Colab\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2fmatching_engine%2fsdk_matching_engine_create_multimodal_embeddings.ipynb.ipynb\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2fvector_search%2fsdk_vector_search_create_multimodal_embeddings.ipynb.ipynb\">\n",
         "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/matching_engine/sdk_matching_engine_create_multimodal_embeddings.ipynb\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/vector_search/sdk_vector_search_create_multimodal_embeddings.ipynb\">\n",
         "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br>\n",
         "      Open in Vertex AI Workbench\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_multimodal_embeddings.ipynb\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_multimodal_embeddings.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br>\n",
         "      View on GitHub\n",
         "    </a>\n",
@@ -1071,7 +1071,7 @@
         "id": "mglUPwHpJH98"
       },
       "source": [
-        "## Create MatchingEngineIndex\n"
+        "## Create Vector Search Index\n"
       ]
     },
     {
@@ -1103,7 +1103,7 @@
         "id": "fa5eb5cdb2f0"
       },
       "source": [
-        "#### Create the index configuration\n",
+        "#### Create the configuration\n",
         "\n",
         "For information on configuration settings, see the [Manage Indexes documentation](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index)"
       ]
@@ -1147,7 +1147,7 @@
         "id": "0f1a9fbecabb"
       },
       "source": [
-        "Using the resource name, you can retrieve an existing MatchingEngineIndex."
+        "Using the resource name, you can retrieve an existing Index resource."
       ]
     },
     {
@@ -1193,7 +1193,7 @@
         "id": "qV2xjAnDDObD"
       },
       "source": [
-        "## Create an MatchingEngineIndexEndpoint"
+        "## Create a Vector Search IndexEndpoint"
       ]
     },
     {
@@ -1376,7 +1376,7 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "name": "sdk_matching_engine_create_multimodal_embeddings.ipynb",
+      "name": "sdk_vector_search_create_multimodal_embeddings.ipynb",
       "toc_visible": true
     },
     "kernelspec": {

--- a/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings.ipynb
+++ b/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings.ipynb
@@ -33,22 +33,22 @@
         "\n",
         "<table align=\"left\">\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings.ipynb\">\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fmatching_engine%2Fsdk_matching_engine_create_stack_overflow_embeddings.ipynb\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fvector_search%2Fsdk_vector_search_create_stack_overflow_embeddings.ipynb\">\n",
         "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
         "    </a>\n",
         "  </td>    \n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings.ipynb\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings.ipynb\">\n",
         "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings.ipynb\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
         "    </a>\n",
         "  </td>\n",
@@ -65,7 +65,7 @@
         "\n",
         "This example demonstrates how to encode custom text embeddings using the StackOverflow dataset and the sentence-T5 model. These are uploaded to the Vertex AI Vector Search service. It's a high scale, low latency solution, to find similar vectors (or more specifically \"embeddings\") for a large corpus. Moreover, it's a fully managed offering, further reducing operational overhead. The Vertex AI Vector Search service is built upon [Approximate Nearest Neighbor (ANN) technology](https://ai.googleblog.com/2020/07/announcing-scann-efficient-vector.html) developed by Google Research.\n",
         "\n",
-        "**Pre-requisite**: This notebook requires you to already have a VPC network set up. See the \"Prepare a VPC network\" section in [Create Vertex AI Vector Search index notebook](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb).\n",
+        "**Pre-requisite**: This notebook requires you to already have a VPC network set up. See the \"Prepare a VPC network\" section in [Create Vertex AI Vector Search index notebook](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb).\n",
         "\n",
         "Learn more about [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview)."
       ]
@@ -554,7 +554,7 @@
         "\n",
         "The data must be formatted in JSONL format, which means each embedding dictionary is written as a JSON string on its own line.\n",
         "\n",
-        "See more information in the docs for [input data format and structure](https://cloud.google.com/vertex-ai/docs/matching-engine/match-eng-setup#input-data-format)."
+        "See more information in the docs for [input data format and structure](https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure#data-file-formats)."
       ]
     },
     {
@@ -1133,7 +1133,7 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "name": "sdk_matching_engine_create_stack_overflow_embeddings.ipynb",
+      "name": "sdk_vector_search_create_stack_overflow_embeddings.ipynb",
       "toc_visible": true
     },
     "kernelspec": {

--- a/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb
+++ b/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb
@@ -30,21 +30,21 @@
       },
       "source": [
         "# Using Vertex AI Vector Search and Vertex AI embeddings for text for StackOverflow Questions \n",
-        "![ ](https://www.google-analytics.com/collect?v=2&tid=G-L6X3ECH596&cid=1&en=page_view&sid=1&dt=sdk_matching_engine_create_stack_overflow_embeddings_vertex.ipynb&dl=notebooks%2Fofficial%2Fmatching_engine%2Fsdk_matching_engine_create_stack_overflow_embeddings_vertex.ipynb)\n",
+        "![ ](https://www.google-analytics.com/collect?v=2&tid=G-L6X3ECH596&cid=1&en=page_view&sid=1&dt=sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb&dl=notebooks%2Fofficial%2Fvector_search%2Fsdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb)\n",
         "<table align=\"left\">\n",
         "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings_vertex.ipynb\">\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
         "    </a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings_vertex.ipynb\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
         "      View on GitHub\n",
         "    </a>\n",
         "  </td>\n",
         "      <td>\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/matching_engine/sdk_matching_engine_create_stack_overflow_embeddings_vertex\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/vector_search/sdk_vector_search_create_stack_overflow_embeddings_vertex\">\n",
         "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
         "      Open in Vertex AI Workbench\n",
         "    </a>\n",
@@ -649,7 +649,7 @@
         "\n",
         "The data must be formatted in JSONL format, which means each embedding dictionary is written as an individual JSON object on its own line.\n",
         "\n",
-        "For more information, see [Input data format and structure](https://cloud.google.com/vertex-ai/docs/matching-engine/match-eng-setup/format-structure#data-file-formats)."
+        "For more information, see [Input data format and structure](https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure#data-file-formats)."
       ]
     },
     {
@@ -856,7 +856,7 @@
         "id": "0f1a9fbecabb"
       },
       "source": [
-        "Use the resource name to retrieve an existing MatchingEngineIndex."
+        "Use the resource name to retrieve an existing Index resource."
       ]
     },
     {
@@ -1073,7 +1073,7 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "name": "sdk_matching_engine_create_stack_overflow_embeddings_vertex.ipynb",
+      "name": "sdk_vector_search_create_stack_overflow_embeddings_vertex.ipynb",
       "toc_visible": true
     },
     "kernelspec": {

--- a/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb
+++ b/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb
@@ -35,22 +35,22 @@
         "\n",
         "<table align=\"left\">\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb\">\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fmatching_engine%2Fsdk_matching_engine_for_indexing.ipynb\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fvector_search%2Fsdk_vector_search_for_indexing.ipynb\">\n",
         "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
         "    </a>\n",
         "  </td>    \n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb\">\n",
         "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
         "    </a>\n",
         "  </td>\n",
         "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/matching_engine/sdk_matching_engine_for_indexing.ipynb\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/vector_search/sdk_vector_search_for_indexing.ipynb\">\n",
         "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
         "    </a>\n",
         "  </td>\n",
@@ -471,7 +471,7 @@
         "The data must be formatted in JSONL format, which means each embedding dictionary is written as a JSON string on its own line.\n",
         "\n",
         "Additionally, to demonstrate the filtering functionality, the `restricts` key is set such that each embedding has a different `class`, `even` or `odd`. These are used during the later matching step to filter for results.\n",
-        "For additional information of filtering, see [Filter vector matches](https://cloud.google.com/vertex-ai/docs/matching-engine/filtering)"
+        "For additional information of filtering, see [Filter vector matches](https://cloud.google.com/vertex-ai/docs/vector-search/filtering)."
       ]
     },
     {
@@ -519,7 +519,7 @@
       },
       "outputs": [],
       "source": [
-        "EMBEDDINGS_INITIAL_URI = f\"{BUCKET_URI}/matching_engine/initial/\"\n",
+        "EMBEDDINGS_INITIAL_URI = f\"{BUCKET_URI}/vector_search/initial/\"\n",
         "! gsutil cp glove100.json {EMBEDDINGS_INITIAL_URI}"
       ]
     },
@@ -565,7 +565,7 @@
       "source": [
         "Create the ANN index configuration:\n",
         "\n",
-        "To learn more about configuring the index, see [Input data format and structure](https://cloud.google.com/vertex-ai/docs/matching-engine/match-eng-setup/format-structure).\n"
+        "To learn more about configuring the index, see [Input data format and structure](https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure).\n"
       ]
     },
     {
@@ -607,7 +607,7 @@
         "id": "0f1a9fbecabb"
       },
       "source": [
-        "Using the resource name, you can retrieve an existing MatchingEngineIndex."
+        "Using the resource name, you can retrieve an existing Vector Search Index."
       ]
     },
     {
@@ -732,7 +732,7 @@
       },
       "outputs": [],
       "source": [
-        "EMBEDDINGS_UPDATE_URI = f\"{BUCKET_URI}/matching-engine/incremental/\""
+        "EMBEDDINGS_UPDATE_URI = f\"{BUCKET_URI}/vector-search/incremental/\""
       ]
     },
     {
@@ -1045,7 +1045,7 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "name": "sdk_matching_engine_for_indexing.ipynb",
+      "name": "sdk_vector_search_for_indexing.ipynb",
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
<br>
This PR includes the following changes:

1. Replace "matching_engine" with "vector_search"
2. Replace "Matching Engine with "Vector Search"
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>