### PR TITLE
Switch movinet serving notebooks to use port 8080

### DIFF
--- a/notebooks/community/model_garden/model_garden_movinet_action_recognition.ipynb
+++ b/notebooks/community/model_garden/model_garden_movinet_action_recognition.ipynb
@@ -265,7 +265,7 @@
         "# Prediction constants.\n",
         "# You can adjust accelerator types and machine types to get faster predictions.\n",
         "PREDICTION_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/movinet-serve\"\n",
-        "PREDICTION_PORT = 8501\n",
+        "PREDICTION_PORT = 8080\n",
         "PREDICTION_ACCELERATOR_COUNT = 1\n",
         "PREDICTION_ACCELERATOR_TYPE = \"NVIDIA_TESLA_T4\"\n",
         "PREDICTION_MACHINE_TYPE = \"n1-standard-4\"\n",

--- a/notebooks/community/model_garden/model_garden_movinet_clip_classification.ipynb
+++ b/notebooks/community/model_garden/model_garden_movinet_clip_classification.ipynb
@@ -250,7 +250,7 @@
         "# Prediction constants.\n",
         "# You can adjust accelerator types and machine types to get faster predictions.\n",
         "PREDICTION_CONTAINER_URI = f\"{REGION_PREFIX}-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/movinet-serve\"\n",
-        "PREDICTION_PORT = 8501\n",
+        "PREDICTION_PORT = 8080\n",
         "PREDICTION_ACCELERATOR_COUNT = 1\n",
         "PREDICTION_ACCELERATOR_TYPE = \"NVIDIA_TESLA_T4\"\n",
         "PREDICTION_MACHINE_TYPE = \"n1-standard-4\"\n",


### PR DESCRIPTION
**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
Switch movinet serving notebooks to use port 8080
<br><br><br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

<br>