### PR TITLE
Add hugging face token to mixtral example colab.

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_mistral.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_mistral.ipynb
@@ -208,7 +208,11 @@
         "# Please go to https://cloud.google.com/iam/docs/service-accounts-create#iam-service-accounts-create-console\n",
         "# and create service account with `Vertex AI User` and `Storage Object Admin` roles.\n",
         "# The service account for deploying fine tuned model.\n",
-        "SERVICE_ACCOUNT = \"\"  # @param {type:\"string\"}"
+        "SERVICE_ACCOUNT = \"\"  # @param {type:\"string\"}",
+        "# HuggingFace access token.\n",
+        "# Create a token at https://huggingface.co/settings/tokens.\n",
+        "# Accept the model terms of service for the model you wish to use.\n",
+        "HF_TOKEN = \"\"  # @param {type:\"string\"}"
       ]
     },
     {
@@ -296,6 +300,7 @@
         "    gpu_memory_utilization: float = 0.9,\n",
         "    use_openai_server: bool = False,\n",
         "    use_chat_completions_if_openai_server: bool = False,\n",
+        "    huggingface_token: str = \"\",\n",
         ") -> Tuple[aiplatform.Model, aiplatform.Endpoint]:\n",
         "    \"\"\"Deploys Mistral models with vLLM on Vertex AI.\n",
         "\n",
@@ -326,6 +331,7 @@
         "            messages that can represent a multi-turn chat conversation. The\n",
         "            response includes a \"choices\" field that contains the generated\n",
         "            message from a role and a \"usage\" field that contains token counts.\n",
+        "        huggingface_token: Huggingface token for accessing the model.\n",
         "\n",
         "    Returns:\n",
         "        Model instance and endpoint instance.\n",
@@ -350,6 +356,7 @@
         "    serving_env = {\n",
         "        \"MODEL_ID\": model_id,\n",
         "        \"DEPLOY_SOURCE\": \"notebook\",\n",
+        "        \"HF_TOKEN\": huggingface_token,\n",
         "    }\n",
         "    if use_openai_server:\n",
         "        if use_chat_completions_if_openai_server:\n",
@@ -528,6 +535,7 @@
         "    gpu_memory_utilization=gpu_memory_utilization,\n",
         "    use_openai_server=False,\n",
         "    use_chat_completions_if_openai_server=False,\n",
+        "    huggingface_token=HF_TOKEN,\n",
         ")"
       ]
     },
@@ -679,6 +687,7 @@
         "    gpu_memory_utilization=gpu_memory_utilization,\n",
         "    use_openai_server=False,\n",
         "    use_chat_completions_if_openai_server=False,\n",
+        "    huggingface_token=HF_TOKEN,\n",
         ")"
       ]
     },


### PR DESCRIPTION
Add HuggingFace tokens to Mistral example colab. HuggingFace now requires an access token to fetch the Mistral models.
<br><br><br>



2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [X] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [X] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

Test mode: false
Checking for changed notebooked using git
Checking notebook: notebooks/community/model_garden/model_garden_pytorch_mistral.ipynb
Running black...
All done! ✨ 🍰 ✨
1 file left unchanged.
Running pyupgrade...
WARNING: pyupgrade will default to --py3-plus in 3.x
Running isort...
Running nbfmt...
Format notebook: notebooks/community/model_garden/model_garden_pytorch_mistral.ipynb
Running flake8...
Notebook lint finished with return code = 0

All tests finished. Exiting with return code = 0