### PR TITLE
chore, refactor(egen): hardcodes TF version to 2.15.1, refactors code as per template, changes future to present tense

### DIFF
--- a/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
+++ b/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
@@ -636,7 +636,7 @@
       "source": [
         "### List a specific custom model evaluation\n",
         "\n",
-        "Now that you have uploaded your custom evaluation metric to the corresponding model in the Vertex AI Model Registry, you can retrieve a specific evaluation by filtering using `display_name`."
+        "Now that you have uploaded your second custom evaluation metric to the corresponding model in the Vertex AI Model Registry, you can retrieve a specific evaluation by filtering using `display_name`."
       ]
     },
     {

--- a/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
+++ b/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
@@ -668,7 +668,7 @@
         "- `version_ailiases`: User defined list of alternative alias names for the model version, such as `production`.\n",
         "- `version_description`: User description of the model version.\n",
         "\n",
-        "When a subsequent model version is created in the Vertex AI Model Registry, the property `version_id` is automatically incremented. In this example, it is set to 2 (2nd version)."
+        "When a subsequent model version is created in the Vertex AI Model Registry, the property `version_id` is automatically incremented. In this example, it's set to 2 (2nd version)."
       ]
     },
     {

--- a/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
+++ b/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
@@ -87,7 +87,7 @@
       "source": [
         "### Objective\n",
         "\n",
-        "In this tutorial, you learn how to construct and upload a custom model evaluation, and upload the custom model evaluation to a Model resource entry in Vertex AI Model Registry.\n",
+        "In this tutorial, you learn how to construct and upload a custom model evaluation, and upload the custom model evaluation to a model resource entry in Vertex AI Model Registry.\n",
         "\n",
         "This tutorial uses the following Google Cloud ML services and resources:\n",
         "\n",
@@ -472,11 +472,11 @@
         "\n",
         "Finally, you upload the model artifacts from the TFHub model into a Vertex AI model resource using the `upload()` method, with the following parameters:\n",
         "\n",
-        "- `display_name`: A human readable name for the Model resource.\n",
+        "- `display_name`: A human readable name for the model resource.\n",
         "- `artifact_uri`: The Cloud Storage location of the model package.\n",
         "- `serving_container_image_uri`: The serving container image.\n",
         "\n",
-        "Uploading a model to a Vertex AI Model resource is a long-running operation that may take a few moments \n",
+        "Uploading a model to a Vertex AI model resource is a long running operation that may take a few moments \n",
         "\n",
         "*Note:* When you upload the model artifacts to a Vertex AI model resource, you specify the corresponding deployment container image."
       ]
@@ -508,7 +508,7 @@
       "source": [
         "## Introduction to custom model evaluations\n",
         "\n",
-        "When training a custom model, you generally performs some form of evaluation of the trained model. Your custom model evaluation can then be imported to the corresponding model in the Vertex AI Model Registry using the `import_model_evaluation()` method. Once imported, you can retreive the custom model evaluation with the `list_model_evaluations()` method. \n",
+        "When training a custom model, you generally perform some form of evaluation of the trained model. Your custom model evaluation can then be imported to the corresponding model in the Vertex AI Model Registry using the `import_model_evaluation()` method. Once imported, you can retreive the custom model evaluation with the `list_model_evaluations()` method. \n",
         "\n",
         "The Vertex AI Model Registry supports importing multiple model evaluations for a model where each evaluation is distinquished by a unique `display_name`.\n",
         "\n",
@@ -557,7 +557,7 @@
         "\n",
         "Next, upload the model's evaluation from the custom training job to the corresponding entry in the Vertex AI Model Registry.\n",
         "\n",
-        "Currently, there isn't yet support for this method in the SDK. Instead, you use the lower-level GAPIC API interface."
+        "Currently, there isn't yet support for this method in the SDK. Instead, you use the lower level GAPIC API interface."
       ]
     },
     {
@@ -636,7 +636,7 @@
       "source": [
         "### List a specific custom model evaluation\n",
         "\n",
-        "Now that you have uploaded your custom evaluation metric to the corresponding model in the Vertex AI Model Registry, you can retrieve a specific evaluation by filtering using `display_name` ."
+        "Now that you have uploaded your custom evaluation metric to the corresponding model in the Vertex AI Model Registry, you can retrieve a specific evaluation by filtering using `display_name`."
       ]
     },
     {
@@ -668,7 +668,7 @@
         "- `version_ailiases`: User defined list of alternative alias names for the model version, such as `production`.\n",
         "- `version_description`: User description of the model version.\n",
         "\n",
-        "When a subsequent model version is created in the Vertex AI Model Registry, the property version_id is automatically incremented. In this example, it is set to 2 (2nd version)."
+        "When a subsequent model version is created in the Vertex AI Model Registry, the property `version_id` is automatically incremented. In this example, it is set to 2 (2nd version)."
       ]
     },
     {

--- a/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
+++ b/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb
@@ -8,7 +8,7 @@
       },
       "outputs": [],
       "source": [
-        "# Copyright 2023 Google LLC\n",
+        "# Copyright 2024 Google LLC\n",
         "#\n",
         "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,24 +32,26 @@
         "# Get started with importing a custom model evaluation to the Vertex AI Model Registry\n",
         "\n",
         "<table align=\"left\">\n",
-        "\n",
-        "  <td>\n",
+        "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
         "    </a>\n",
         "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fmodel_evaluation%2Fget_started_with_custom_model_evaluation_import.ipynb\">\n",
+        "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
         "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
+        "  </td>    \n",
+        "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb\">\n",
-        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-        "      Open in Vertex AI Workbench\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
         "    </a>\n",
-        "  </td>                                                                                               \n",
+        "  </td>\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/model_evaluation/get_started_with_custom_model_evaluation_import.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },
@@ -59,7 +61,7 @@
         "id": "24743cf4a1e1"
       },
       "source": [
-        "**_NOTE_**: This notebook has been tested in the following environment:\n",
+        "**_NOTE_**: This notebook is tested in the following environment:\n",
         "\n",
         "* Python version = 3.9"
       ]
@@ -140,12 +142,19 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "i7EUnXsZhAGF"
+        "id": "61RBz8LLbxCR"
       },
       "source": [
-        "## Installation\n",
-        "\n",
-        "Install the following packages required to execute this notebook. "
+        "## Get started"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "No17Cw5hgx12"
+      },
+      "source": [
+        "### Install Vertex AI SDK for Python and other required packages\n"
       ]
     },
     {
@@ -159,67 +168,87 @@
         "# Install the packages\n",
         "USER=''\n",
         "! pip3 install {USER} --upgrade google-cloud-aiplatform \\\n",
-        "                                tensorflow==2.5 \\\n",
+        "                                tensorflow==2.15.1 \\\n",
         "                                tensorflow-hub"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "58707a750154"
+        "id": "R5Xep4W9lq-Z"
       },
       "source": [
-        "### Colab only: Uncomment the following cell to restart the kernel."
+        "### Restart runtime (Colab only)\n",
+        "\n",
+        "To use the newly installed packages, you must restart the runtime on Google Colab."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "f200f10a1da3"
+        "id": "XRvKdaPDTznN"
       },
       "outputs": [],
       "source": [
-        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-        "# import IPython\n",
+        "import sys\n",
         "\n",
-        "# app = IPython.Application.instance()\n",
-        "# app.kernel.do_shutdown(True)"
+        "if \"google.colab\" in sys.modules:\n",
+        "\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "BF1j6f9HApxa"
+        "id": "SbmM4z7FOBpM"
       },
       "source": [
-        "## Before you begin\n",
-        "\n",
-        "### Set up your Google Cloud project\n",
-        "\n",
-        "**The following steps are required, regardless of your notebook environment.**\n",
-        "\n",
-        "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 free credit towards your compute/storage costs.\n",
-        "\n",
-        "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
-        "\n",
-        "3. [Enable the Vertex AI API]\n",
-        "\n",
-        "4. If you are running this notebook locally, you need to install the [Cloud SDK](https://cloud.google.com/sdk)."
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
+        "</div>\n"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "WReHDGG5g0XY"
+        "id": "dmWOrTJ3gx13"
       },
       "source": [
-        "#### Set your project ID\n",
+        "### Authenticate your notebook environment (Colab only)\n",
         "\n",
-        "**If you don't know your project ID**, try the following:\n",
-        "* Run `gcloud config list`.\n",
-        "* Run `gcloud projects list`.\n",
-        "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+        "Authenticate your environment on Google Colab.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NyKGtVQjgx13"
+      },
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "\n",
+        "if \"google.colab\" in sys.modules:\n",
+        "\n",
+        "    from google.colab import auth\n",
+        "\n",
+        "    auth.authenticate_user()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DF4l8DTdWgPY"
+      },
+      "source": [
+        "### Set Google Cloud project information\n",
+        "\n",
+        "To get started using Vertex AI, you must have an existing Google Cloud project. Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
       ]
     },
     {
@@ -231,103 +260,7 @@
       "outputs": [],
       "source": [
         "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-        "\n",
-        "# Set the project id\n",
-        "! gcloud config set project {PROJECT_ID}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sBCra4QMA2wR"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "74ccc9e52986"
-      },
-      "source": [
-        "**1. Vertex AI Workbench**\n",
-        "* Do nothing as you are already authenticated."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "de775a3773ba"
-      },
-      "source": [
-        "**2. Local JupyterLab instance, uncomment and run:**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "254614fa0c46"
-      },
-      "outputs": [],
-      "source": [
-        "# ! gcloud auth login"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ef21552ccea8"
-      },
-      "source": [
-        "**3. Colab, uncomment and run:**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "603adbbf0532"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import auth\n",
-        "# auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "f6b2ccc891ed"
-      },
-      "source": [
-        "**4. Service account or other**\n",
-        "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
+        "LOCATION = \"us-central1\"  # @param {type:\"string\"}"
       ]
     },
     {
@@ -371,7 +304,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l $REGION -p $PROJECT_ID $BUCKET_URI"
+        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -416,7 +349,7 @@
       },
       "outputs": [],
       "source": [
-        "aiplatform.init(project=PROJECT_ID, location=REGION, staging_bucket=BUCKET_URI)"
+        "aiplatform.init(project=PROJECT_ID, location=LOCATION, staging_bucket=BUCKET_URI)"
       ]
     },
     {
@@ -429,9 +362,9 @@
         "\n",
         "You can set hardware accelerators for prediction.\n",
         "\n",
-        "Set the variables `DEPLOY_GPU/DEPLOY_NGPU` to use a container image supporting a GPU and the number of GPUs allocated to the virtual machine (VM) instance. For example, to use a GPU container image with 4 Nvidia Telsa K80 GPUs allocated to each VM, you would specify:\n",
+        "Set the variables `DEPLOY_GPU/DEPLOY_NGPU` to use a container image supporting a GPU and the number of GPUs allocated to the virtual machine (VM) instance. For example, to use a GPU container image with 4 Nvidia Telsa T4 GPUs allocated to each VM, you would specify:\n",
         "\n",
-        "    (aip.gapic.AcceleratorType.NVIDIA_TESLA_K80, 4)\n",
+        "    (aip.gapic.AcceleratorType.NVIDIA_TESLA_T4, 4)\n",
         "\n",
         "\n",
         "Otherwise specify `(None, None)` to use a container image to run on a CPU.\n",
@@ -471,7 +404,7 @@
       },
       "outputs": [],
       "source": [
-        "TF = \"2.5\".replace(\".\", \"-\")\n",
+        "TF = \"2.15.1\".replace(\".\", \"-\")\n",
         "\n",
         "if DEPLOY_GPU:\n",
         "    DEPLOY_VERSION = \"tf2-gpu.{}\".format(TF)\n",
@@ -479,7 +412,7 @@
         "    DEPLOY_VERSION = \"tf2-cpu.{}\".format(TF)\n",
         "\n",
         "DEPLOY_IMAGE = \"{}-docker.pkg.dev/vertex-ai/prediction/{}:latest\".format(\n",
-        "    REGION.split(\"-\")[0], DEPLOY_VERSION\n",
+        "    LOCATION.split(\"-\")[0], DEPLOY_VERSION\n",
         ")\n",
         "\n",
         "print(\"Deployment:\", DEPLOY_IMAGE, DEPLOY_GPU, DEPLOY_NGPU)"
@@ -493,7 +426,7 @@
       "source": [
         "## Get pretrained model from TensorFlow Hub\n",
         "\n",
-        "For demonstration purposes, this tutorial uses a pretrained model from TensorFlow Hub (TFHub), which is then uploaded to a `Vertex AI Model` resource. Once you have a `Vertex AI Model` resource, the model can be deployed to a `Vertex AI Endpoint` resource.\n",
+        "For demonstration purposes, this tutorial uses a pretrained model from TensorFlow Hub (TFHub), which is then uploaded to a Vertex AI model resource. Once you have a Vertex AI model resource, the model can be deployed to a Vertex AI endpoint resource.\n",
         "\n",
         "### Download the pretrained model\n",
         "\n",
@@ -535,17 +468,17 @@
         "id": "e8ce91147c93"
       },
       "source": [
-        "### Upload the TensorFlow Hub model to a `Vertex AI Model` resource\n",
+        "### Upload the TensorFlow Hub model to a Vertex AI model resource\n",
         "\n",
-        "Finally, you upload the model artifacts from the TFHub model into a `Vertex AI Model` resource using the method `upload()`, with the following parameters:\n",
+        "Finally, you upload the model artifacts from the TFHub model into a Vertex AI model resource using the `upload()` method, with the following parameters:\n",
         "\n",
-        "- `display_name`: A human readable name for the `Model` resource.\n",
+        "- `display_name`: A human readable name for the Model resource.\n",
         "- `artifact_uri`: The Cloud Storage location of the model package.\n",
         "- `serving_container_image_uri`: The serving container image.\n",
         "\n",
-        "Uploading a model into a Vertex AI Model resource returns a long running operation, since it may take a few moments. \n",
+        "Uploading a model to a Vertex AI Model resource is a long-running operation that may take a few moments \n",
         "\n",
-        "*Note:* When you upload the model artifacts to a `Vertex AI Model` resource, you specify the corresponding deployment container image."
+        "*Note:* When you upload the model artifacts to a Vertex AI model resource, you specify the corresponding deployment container image."
       ]
     },
     {
@@ -575,7 +508,7 @@
       "source": [
         "## Introduction to custom model evaluations\n",
         "\n",
-        "When training a custom model, one generally performs some form of an evaluation of the trained model. Your custom model evaluation can then be imported to the corresponding model in the Vertex AI Model Registry using the `import_model_evaluation()` method. Once imported, the custom model evaluation can be subsequently retreived with the `list_model_evaluations()` method. \n",
+        "When training a custom model, you generally performs some form of evaluation of the trained model. Your custom model evaluation can then be imported to the corresponding model in the Vertex AI Model Registry using the `import_model_evaluation()` method. Once imported, you can retreive the custom model evaluation with the `list_model_evaluations()` method. \n",
         "\n",
         "The Vertex AI Model Registry supports importing multiple model evaluations for a model where each evaluation is distinquished by a unique `display_name`.\n",
         "\n",
@@ -624,7 +557,7 @@
         "\n",
         "Next, upload the model's evaluation from the custom training job to the corresponding entry in the Vertex AI Model Registry.\n",
         "\n",
-        "Currently, there is not yet support for this method in the SDK. Instead, you use the lower level GAPIC API interface."
+        "Currently, there isn't yet support for this method in the SDK. Instead, you use the lower-level GAPIC API interface."
       ]
     },
     {
@@ -635,7 +568,7 @@
       },
       "outputs": [],
       "source": [
-        "API_ENDPOINT = f\"{REGION}-aiplatform.googleapis.com\"\n",
+        "API_ENDPOINT = f\"{LOCATION}-aiplatform.googleapis.com\"\n",
         "client = gapic.ModelServiceClient(client_options={\"api_endpoint\": API_ENDPOINT})\n",
         "\n",
         "client.import_model_evaluation(parent=model.resource_name, model_evaluation=model_eval)"
@@ -649,7 +582,7 @@
       "source": [
         "### List the custom model evaluation\n",
         "\n",
-        "Now that your custom metric has been uploaded to the corresponding model in the Vertex AI Model Registry, you can retriv"
+        "Now that you have uploaded your custom evaluation metric to the corresponding model in the Vertex AI Model Registry, you can retrieve it using the `list_model_evaluations()` method."
       ]
     },
     {
@@ -703,7 +636,7 @@
       "source": [
         "### List a specific custom model evaluation\n",
         "\n",
-        "Now that your custom second metric has been uploaded to the corresponding model in the Vertex AI Model Registry, you can retrieve this specific evaluation by filtering using the `display_name`:"
+        "Now that you have uploaded your custom evaluation metric to the corresponding model in the Vertex AI Model Registry, you can retrieve a specific evaluation by filtering using `display_name` ."
       ]
     },
     {
@@ -726,16 +659,16 @@
         "id": "b3a3993dc813"
       },
       "source": [
-        "### Upload version 2 of the TFHub model to the `Vertex AI Model Registry`\n",
+        "### Upload version 2 of the TFHub model to the Vertex AI Model Registry\n",
         "\n",
-        "Next, you upload the second version of the TFHub model as a `Model` resource in the `Vertex AI Model Registry`, with the additional following parameters:\n",
+        "Next, you upload the second version of the TFHub model as a model resource in the Vertex AI Model Registry, with the additional following parameters:\n",
         "\n",
-        "- `parent_model`: The existing `Model` resource for which to add this model as the next model version.\n",
-        "- `is_default_version`: Whether this will be the default version for the `Model` resource. In this example, you change from the default from the first version to the second version of the model.\n",
+        "- `parent_model`: The resource name or model ID of an existing model that the newly-uploaded model is a version of. Only set this field when uploading a new version of an existing model.\n",
+        "- `is_default_version`:  When set to `True`, the newly uploaded model version automatically includes the alias \"default\".\n",
         "- `version_ailiases`: User defined list of alternative alias names for the model version, such as `production`.\n",
         "- `version_description`: User description of the model version.\n",
         "\n",
-        "When a subsequent model version is created in the `Vertex AI Model Registry`, the property `version_id` will automatically be incremented. In this example, it will be set to 2 (2nd version)."
+        "When a subsequent model version is created in the Vertex AI Model Registry, the property version_id is automatically incremented. In this example, it is set to 2 (2nd version)."
       ]
     },
     {
@@ -765,9 +698,9 @@
         "id": "68870bd8194d"
       },
       "source": [
-        "### Upload an evaluation metrics for version 2 of the model to the Model Registry\n",
+        "#### Upload an evaluation metrics for version 2 of the model to the Model Registry\n",
         "\n",
-        "Next, upload a model evaluation to the corresponding model version in the Vertex AI Model Registry. Note, you referenced `model_v2.resource_name` to refer to version 2 of this model."
+        "Next, upload a model evaluation to the corresponding model version in the Vertex AI Model Registry. *Note*, use `model_v2.resource_name` to refer to version 2 of this model."
       ]
     },
     {
@@ -839,14 +772,12 @@
       },
       "outputs": [],
       "source": [
-        "import os\n",
-        "\n",
         "# Delete model resource\n",
         "model.delete()\n",
         "\n",
         "# Delete Cloud Storage objects that were created\n",
-        "delete_bucket = False\n",
-        "if delete_bucket or os.getenv(\"IS_TESTING\"):\n",
+        "delete_bucket = False  # set True for deletion\n",
+        "if delete_bucket:\n",
         "    ! gsutil -m rm -r $BUCKET_URI"
       ]
     }


### PR DESCRIPTION
This PR includes the following updates:

1. Fixes the TF version to 2.15.1.
2. Adds Colab Enterprise link and other structural changes from the new template.
3. Changes REGION variable name to LOCATION.
4. Replaces K80 GPU with T4 GPU (as K80 is deprecated).
5. Removes IS_TESTING from the cleaning up section.
6. Adds comments for cells needed.
7. Removes the usage of future tense.
8. Contracts words like is not, do not, You are, etc


**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

