### PR TITLE
chore(egen) : Adds the note to the deprecation of notebook and performs linter test

### DIFF
--- a/notebooks/official/migration/sdk-automl-text-classification-batch-prediction.ipynb
+++ b/notebooks/official/migration/sdk-automl-text-classification-batch-prediction.ipynb
@@ -30,7 +30,7 @@
       },
       "source": [
         "Starting on September 15, 2024, you can only customize classification, entity extraction, and sentiment analysis models by moving to Vertex AI Gemini prompts and tuning. Training or updating models for Vertex AI AutoML for Text classification, entity extraction, and sentiment analysis objectives will no longer be available. You can continue using existing Vertex AI AutoML Text objectives until June 15, 2025. For more information about how Gemini offers enhanced user experience through improved prompting capabilities, see \n",
-        "[Overview of model tuning for Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-gemini-overview)"
+        "[Introduction to tuning](https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-gemini-overview)"
       ]
     },
     {

--- a/notebooks/official/migration/sdk-automl-text-classification-batch-prediction.ipynb
+++ b/notebooks/official/migration/sdk-automl-text-classification-batch-prediction.ipynb
@@ -26,6 +26,16 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "90a6064798e9"
+      },
+      "source": [
+        "Starting on September 15, 2024, you can only customize classification, entity extraction, and sentiment analysis models by moving to Vertex AI Gemini prompts and tuning. Training or updating models for Vertex AI AutoML for Text classification, entity extraction, and sentiment analysis objectives will no longer be available. You can continue using existing Vertex AI AutoML Text objectives until June 15, 2025. For more information about how Gemini offers enhanced user experience through improved prompting capabilities, see \n",
+        "[Overview of model tuning for Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-gemini-overview)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "title:migration,new"
       },
       "source": [


### PR DESCRIPTION
This PR, adds a note to the deprecated notebooks and performs linter test.

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [ ] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [ ] Follow the style and grammar rules outlined in the above notebook template.
- [ ] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.
