### PR TITLE
fix: remove --user from package install

### DIFF
--- a/notebooks/notebook_template.ipynb
+++ b/notebooks/notebook_template.ipynb
@@ -96,7 +96,7 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install --upgrade --user --quiet google-cloud-aiplatform"
+        "! pip3 install --upgrade --quiet google-cloud-aiplatform"
       ]
     },
     {


### PR DESCRIPTION
fix: remove --user from package install

CI/CD test error:
Step #5: Step #4: �[31mERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.�[0m�[31m
