### PR TITLE
Fix typo in get_started_with_custom_training_autologging_local_script.ipynb

### DIFF
--- a/notebooks/official/experiments/get_started_with_custom_training_autologging_local_script.ipynb
+++ b/notebooks/official/experiments/get_started_with_custom_training_autologging_local_script.ipynb
@@ -90,7 +90,7 @@
       "source": [
         "### Objective\n",
         "\n",
-        "In this tutorial, you learn how to autolog paramenters and metrics of an ML experiment running on Vertex AI Training by leveraging the integration with Vertex AI Experiments.\n",
+        "In this tutorial, you learn how to autolog parameters and metrics of an ML experiment running on Vertex AI Training by leveraging the integration with Vertex AI Experiments.\n",
         "\n",
         "This tutorial uses the following Google Cloud ML services and resources:\n",
         "\n",


### PR DESCRIPTION
Fixed typo: paramenters --> parameters
