### PR TITLE
Fix typo in pytorch_gcs_data_training.ipynb

### DIFF
--- a/notebooks/official/training/pytorch_gcs_data_training.ipynb
+++ b/notebooks/official/training/pytorch_gcs_data_training.ipynb
@@ -86,7 +86,7 @@
         "The steps performed include:\n",
         "\n",
         "- Writing a custom training script that creates your train & test datasets and trains the model.\n",
-        "- Runing a `CustomTrainingJob` using Vertex AI SDK for Python."
+        "- Running a `CustomTrainingJob` using Vertex AI SDK for Python."
       ]
     },
     {


### PR DESCRIPTION
Fixed typo: runing --> running
