### PR TITLE
Fix typo in sdk_pytorch_torchrun_custom_container_training_imagenet.i…

### DIFF
--- a/notebooks/official/training/sdk_pytorch_torchrun_custom_container_training_imagenet.ipynb
+++ b/notebooks/official/training/sdk_pytorch_torchrun_custom_container_training_imagenet.ipynb
@@ -87,7 +87,7 @@
         "The steps performed include:\n",
         "\n",
         "    * Create a shell script to start an ETCD cluster on the master node\n",
-        "    * Create a training script using code from PyTorch Elastic's Github repository\n",
+        "    * Create a training script using code from PyTorch Elastic's GitHub repository\n",
         "    * Create containers that download the data, and start an ETCD cluster on the host\n",
         "    * Train the model using multiple nodes with GPUs"
       ]


### PR DESCRIPTION
…pynb

Fixed typo: Github --> GitHub
