### PR TITLE
Fix request format in model_garden_pytorch_llama3_1_deployment

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama3_1_deployment.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama3_1_deployment.ipynb
@@ -84,6 +84,21 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
+        "id": "6fe2644d854f"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Accept the model agreement to access the models\n",
+        "\n",
+        "# @markdown 1. Open the [Llama 3.1 model card](https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama3_1) from [Vertex AI Model Garden](https://cloud.google.com/model-garden).\n",
+        "\n",
+        "# @markdown 2. Review and accept the agreement in the pop-up window on the model card page. If you have previously accepted the model agreement, there will not be a pop-up window on the model card page and this step is not needed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
         "cellView": "form",
         "id": "ax7zWynUDcjk"
       },
@@ -546,19 +561,22 @@
         "# @markdown Example:\n",
         "\n",
         "# @markdown ```\n",
-        "# @markdown Human: What is a car?\n",
-        "# @markdown Assistant:  A car, or a motor car, is a road-connected human-transportation system used to move people or goods from one place to another. The term also encompasses a wide range of vehicles, including motorboats, trains, and aircrafts. Cars typically have four wheels, a cabin for passengers, and an engine or motor. They have been around since the early 19th century and are now one of the most popular forms of transportation, used for daily commuting, shopping, and other purposes.\n",
+        "# @markdown Q: What is a car?\n",
+        "# @markdown A:  A car, or a motor car, is a road-connected human-transportation system used to move people or goods from one place to another. The term also encompasses a wide range of vehicles, including motorboats, trains, and aircrafts. Cars typically have four wheels, a cabin for passengers, and an engine or motor. They have been around since the early 19th century and are now one of the most popular forms of transportation, used for daily commuting, shopping, and other purposes.\n",
         "# @markdown ```\n",
+        "\n",
         "# @markdown Additionally, you can moderate the generated text with Vertex AI. See [Moderate text documentation](https://cloud.google.com/natural-language/docs/moderating-text) for more details.\n",
         "\n",
-        "# @markdown Optionally, you can apply LoRA weights to prediction. Set `lora_weight` to be either a GCS URI or a HuggingFace repo containing the LoRA weight.\n",
+        "# @markdown NOTE: For the raw predict (non chat completion API), a template like \"Q:<question> A:\" is needed in the prompt to get a meaningful response for an instruct tuned model.\n",
         "\n",
-        "prompt = \"What is a car?\"  # @param {type: \"string\"}\n",
+        "prompt = \"Q:What is a car? A:\"  # @param {type: \"string\"}\n",
         "max_tokens = 50  # @param {type:\"integer\"}\n",
         "temperature = 1.0  # @param {type:\"number\"}\n",
         "top_p = 1.0  # @param {type:\"number\"}\n",
         "top_k = 1  # @param {type:\"integer\"}\n",
         "raw_response = False  # @param {type:\"boolean\"}\n",
+        "\n",
+        "# @markdown Optionally, you can apply LoRA weights to prediction. Set `lora_weight` to be either a GCS URI or a HuggingFace repo containing the LoRA weight.\n",
         "lora_weight = \"\"  # @param {type:\"string\", isTemplate: true}\n",
         "\n",
         "# Overides parameters for inferences.\n",
@@ -583,7 +601,7 @@
         "# @markdown You can also use the `@requestFormat` parameter to send the OpenAI chat completions request.\n",
         "\n",
         "message_role = \"user\"  # @param {type: \"string\"}\n",
-        "message_content = \"Why is a car?\"  # @param {type: \"string\"}\n",
+        "message_content = \"What is a car?\"  # @param {type: \"string\"}\n",
         "\n",
         "messages = [\n",
         "    {\n",


### PR DESCRIPTION
Fix request format in model_garden_pytorch_llama3_1_deployment

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [ y] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ y] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).