### PR TITLE
fix,chore,refactor(egen):  modifies the value of IMPORT_FILE, hardcodes TF version to 2.15.1, removes import os and os.getenv(IS_TESTING), refactors code as per the template guidelines.

### DIFF
--- a/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb
+++ b/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb
@@ -32,25 +32,27 @@
         "# AutoML training image classification model for batch prediction\n",
         "\n",
         "<table align=\"left\">\n",
-        "  <td>\n",
+        "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
         "    </a>\n",
         "  </td>\n",
-        "  <td>\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fautoml%2Fautoml_image_classification_batch_prediction.ipynb\">\n",
+        "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
+        "    </a>\n",
+        "  </td>    \n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb\">\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td style=\"text-align: center\">\n",
         "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/automl/automl_image_classification_batch_prediction.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
         "    </a>\n",
         "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/automl/automl_image_classification_online_prediction.ipynb\">\n",
-        "       <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "</table>\n",
-        "<br/><br/><br/>"
+        "</table>"
       ]
     },
     {
@@ -79,14 +81,14 @@
         "\n",
         "The steps performed include:\n",
         "\n",
-        "- Create a Vertex `Dataset` resource.\n",
+        "- Create a Vertex dataset resource.\n",
         "- Train the model.\n",
         "- View the model evaluation.\n",
         "- Make a batch prediction.\n",
         "\n",
-        "There is one key difference between using batch prediction and using online prediction:\n",
+        "There's one key difference between using batch prediction and using online prediction:\n",
         "\n",
-        "* Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
+        "* Online Prediction Service: Does an on-demand prediction for the entire set of instances (i.e., one or more data items) and returns the results in real-time.\n",
         "\n",
         "* Batch Prediction Service: Does a queued (batch) prediction for the entire set of instances in the background and stores the results in a Cloud Storage bucket when ready."
       ]
@@ -99,7 +101,7 @@
       "source": [
         "### Dataset\n",
         "\n",
-        "The dataset used for this tutorial is the [Flowers dataset](https://www.tensorflow.org/datasets/catalog/tf_flowers) from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). The version of the dataset you will use in this tutorial is stored in a public Cloud Storage bucket. The trained model predicts the type of flower an image is from a class of five flowers: daisy, dandelion, rose, sunflower, or tulip."
+        "The dataset used for this tutorial is the [Flowers dataset](https://www.tensorflow.org/datasets/catalog/tf_flowers) from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/overview). The version of the dataset you use in this tutorial is stored in a public Cloud Storage bucket. The trained model predicts the type of flower an image is from a class of five flowers: *daisy*, *dandelion*, *rose*, *sunflower*, or *tulip*."
       ]
     },
     {
@@ -125,12 +127,19 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "install_aip:mbsdk"
+        "id": "61RBz8LLbxCR"
       },
       "source": [
-        "## Installation\n",
-        "\n",
-        "Install the latest version of Vertex AI SDK for Python."
+        "## Get started"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "No17Cw5hgx12"
+      },
+      "source": [
+        "### Install Vertex AI SDK for Python and other required packages\n"
       ]
     },
     {
@@ -141,59 +150,87 @@
       },
       "outputs": [],
       "source": [
-        "import os\n",
-        "\n",
-        "! pip3 install --upgrade --quiet google-cloud-aiplatform\n",
-        "\n",
-        "if os.environ[\"IS_TESTING\"]:\n",
-        "    ! pip3 install --upgrade --quiet tensorflow"
+        "! pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
+        "                                 tensorflow==2.15.1"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "restart"
+        "id": "R5Xep4W9lq-Z"
       },
       "source": [
-        "### Colab only: Uncomment the following cell to restart the kernel"
+        "### Restart runtime (Colab only)\n",
+        "\n",
+        "To use the newly installed packages, you must restart the runtime on Google Colab."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "D-ZBOjErv5mM"
+        "id": "XRvKdaPDTznN"
       },
       "outputs": [],
       "source": [
-        "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-        "# import IPython\n",
+        "import sys\n",
         "\n",
-        "# app = IPython.Application.instance()\n",
-        "# app.kernel.do_shutdown(True)"
+        "if \"google.colab\" in sys.modules:\n",
+        "\n",
+        "    import IPython\n",
+        "\n",
+        "    app = IPython.Application.instance()\n",
+        "    app.kernel.do_shutdown(True)"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "before_you_begin:nogpu"
+        "id": "SbmM4z7FOBpM"
       },
       "source": [
-        "## Before you begin"
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
+        "</div>\n"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "before_you_begin:nogpu"
+        "id": "dmWOrTJ3gx13"
       },
       "source": [
-        "### Set your project ID\n",
+        "### Authenticate your notebook environment (Colab only)\n",
         "\n",
-        "**If you don't know your project ID**, try the following:\n",
-        "* Run `gcloud config list`.\n",
-        "* Run `gcloud projects list`.\n",
-        "* See the support page: [Locate the project ID](https://support.google.com/googleapi/answer/7014113)"
+        "Authenticate your environment on Google Colab.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NyKGtVQjgx13"
+      },
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "\n",
+        "if \"google.colab\" in sys.modules:\n",
+        "\n",
+        "    from google.colab import auth\n",
+        "\n",
+        "    auth.authenticate_user()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DF4l8DTdWgPY"
+      },
+      "source": [
+        "### Set Google Cloud project information\n",
+        "\n",
+        "To get started using Vertex AI, you must have an existing Google Cloud project. Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
       ]
     },
     {
@@ -205,103 +242,10 @@
       "outputs": [],
       "source": [
         "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+        "LOCATION = \"us-central1\"  # @param {type:\"string\"}\n",
         "\n",
         "# Set the project id\n",
         "! gcloud config set project {PROJECT_ID}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "region"
-      },
-      "source": [
-        "#### Region\n",
-        "\n",
-        "You can also change the `REGION` variable used by Vertex AI. Learn more about [Vertex AI regions](https://cloud.google.com/vertex-ai/docs/general/locations)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "region"
-      },
-      "outputs": [],
-      "source": [
-        "REGION = \"us-central1\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gcp_authenticate"
-      },
-      "source": [
-        "### Authenticate your Google Cloud account\n",
-        "\n",
-        "Depending on your Jupyter environment, you may have to manually authenticate. Follow the relevant instructions below."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FvQeFm3Gv5mR"
-      },
-      "source": [
-        "**1. Vertex AI Workbench**\n",
-        "* Do nothing as you are already authenticated."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ad1138a125ea"
-      },
-      "source": [
-        "**2. Local JupyterLab instance, uncomment and run:**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ce6043da7b33"
-      },
-      "outputs": [],
-      "source": [
-        "# ! gcloud auth login"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0367eac06a10"
-      },
-      "source": [
-        "**3. Colab, uncomment and run:**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "21ad4dbb4a61"
-      },
-      "outputs": [],
-      "source": [
-        "# from google.colab import auth\n",
-        "# auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c13224697bfb"
-      },
-      "source": [
-        "**4. Service account or other**\n",
-        "* See how to grant Cloud Storage permissions to your service account at https://cloud.google.com/storage/docs/gsutil/commands/iam#ch-examples."
       ]
     },
     {
@@ -332,7 +276,7 @@
         "id": "create_bucket"
       },
       "source": [
-        "**Only if your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
+        "**If your bucket doesn't already exist**: Run the following cell to create your Cloud Storage bucket."
       ]
     },
     {
@@ -343,7 +287,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l $REGION $BUCKET_URI"
+        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -366,7 +310,7 @@
       },
       "outputs": [],
       "source": [
-        "import google.cloud.aiplatform as aiplatform"
+        "from google.cloud import aiplatform"
       ]
     },
     {
@@ -397,9 +341,9 @@
         "id": "tutorial_start:automl"
       },
       "source": [
-        "# Tutorial\n",
+        "## Tutorial\n",
         "\n",
-        "Now you are ready to start creating your own AutoML image classification model."
+        "Now you're ready to start creating your own AutoML image classification model."
       ]
     },
     {
@@ -421,9 +365,7 @@
       },
       "outputs": [],
       "source": [
-        "IMPORT_FILE = (\n",
-        "    \"gs://cloud-samples-data/vision/automl_classification/flowers/all_data_v2.csv\"\n",
-        ")"
+        "IMPORT_FILE = \"gs://cloud-samples-data/ai-platform/flowers/flowers.csv\""
       ]
     },
     {
@@ -436,7 +378,7 @@
         "\n",
         "This tutorial uses a version of the Flowers dataset that is stored in a public Cloud Storage bucket, using a CSV index file.\n",
         "\n",
-        "Start by doing a quick peek at the data. You count the number of examples by counting the number of rows in the CSV index file  (`wc -l`) and then peek at the first few rows."
+        "Begin by taking a quick look at the data. First, count the number of examples by determining the number of rows in the CSV index file using the (`wc -l`) command. Then, preview the first few rows of the file."
       ]
     },
     {
@@ -467,10 +409,10 @@
       "source": [
         "### Create the Dataset\n",
         "\n",
-        "Next, create the `Dataset` resource using the `create` method for the `ImageDataset` class, which takes the following parameters:\n",
+        "Next, create the dataset resource using the `create` method for the `ImageDataset` class, which takes the following parameters:\n",
         "\n",
-        "- `display_name`: The human readable name for the `Dataset` resource.\n",
-        "- `gcs_source`: A list of one or more dataset index files to import the data items into the `Dataset` resource.\n",
+        "- `display_name`: The human readable name for the dataset resource.\n",
+        "- `gcs_source`: A list of one or more dataset index files to import the data items into the dataset resource.\n",
         "- `import_schema_uri`: The data labeling schema for the data items.\n",
         "\n",
         "This operation may take several minutes."
@@ -507,11 +449,11 @@
         "\n",
         "An AutoML training pipeline is created with the `AutoMLImageTrainingJob` class, with the following parameters:\n",
         "\n",
-        "- `display_name`: The human readable name for the `TrainingJob` resource.\n",
-        "- `prediction_type`: The type task to train the model for.\n",
+        "- `display_name`: The human readable name for the training job resource.\n",
+        "- `prediction_type`: The type of task for which the model is trained.\n",
         "  - `classification`: An image classification model.\n",
         "  - `object_detection`: An image object detection model.\n",
-        "- `multi_label`: If a classification task, whether single (`False`) or multi-labeled (`True`).\n",
+        "- `multi_label`: For a classification task, specify whether it's multi-labeled (`True`) or single-labeled (`False`).\n",
         "- `model_type`: The type of model for deployment.\n",
         "  - `CLOUD`: Deployment on Google Cloud\n",
         "  - `CLOUD_HIGH_ACCURACY_1`: Optimized for accuracy over latency for deployment on Google Cloud.\n",
@@ -519,7 +461,7 @@
         "  - `MOBILE_TF_VERSATILE_1`: Deployment on an edge device.\n",
         "  - `MOBILE_TF_HIGH_ACCURACY_1`:Optimized for accuracy over latency for deployment on an edge device.\n",
         "  - `MOBILE_TF_LOW_LATENCY_1`: Optimized for latency over accuracy for deployment on an edge device.\n",
-        "- `base_model`: (optional) Transfer learning from existing `Model` resource -- supported for image classification only.\n",
+        "- `base_model`: (optional) Transfer learning from existing model resource -- supported for image classification only.\n",
         "\n",
         "The instantiated object is the DAG (directed acyclic graph) for the training job."
       ]
@@ -551,17 +493,17 @@
       "source": [
         "#### Run the training pipeline\n",
         "\n",
-        "Next, you run the DAG to start the training job by invoking the method `run`, with the following parameters:\n",
+        "Next, run the DAG to start the training job by invoking the `run` method, with the following parameters:\n",
         "\n",
-        "- `dataset`: The `Dataset` resource to train the model.\n",
+        "- `dataset`: The dataset resource to train the model.\n",
         "- `model_display_name`: The human readable name for the trained model.\n",
         "- `training_fraction_split`: The percentage of the dataset to use for training.\n",
         "- `test_fraction_split`: The percentage of the dataset to use for test (holdout data).\n",
         "- `validation_fraction_split`: The percentage of the dataset to use for validation.\n",
         "- `budget_milli_node_hours`: (optional) Maximum training time specified in unit of millihours (1000 = hour).\n",
-        "- `disable_early_stopping`: If `True`, training maybe completed before using the entire budget if the service believes it cannot further improve on the model objective measurements.\n",
+        "- `disable_early_stopping`: By default, the model training stops early if the model performance doesn't improve. Setting `disable_early_stopping` = `True` overrides this behavior, allowing the model to train for the entire specified duration.\n",
         "\n",
-        "The `run` method when completed returns the `Model` resource."
+        "The `run` method, upon completion, returns the model resource"
       ]
     },
     {
@@ -591,7 +533,7 @@
       "source": [
         "## Review model evaluation scores\n",
         "\n",
-        "After your model training has finished, you can review the evaluation scores for it using the `list_model_evaluations()` method. This method will return an iterator for each evaluation slice."
+        "After your model training is complete, you can review the evaluation scores for it using the `list_model_evaluations()` method. This method returns an iterator for each evaluation slice."
       ]
     },
     {
@@ -627,7 +569,7 @@
       "source": [
         "### Get test item(s)\n",
         "\n",
-        "Now do a batch prediction to your Vertex model. You will use arbitrary examples out of the dataset as a test items. Don't be concerned that the examples were likely used in training the model -- we just want to demonstrate how to make a prediction."
+        "Now generate a batch prediction for your Vertex AI model. Use arbitrary examples from the dataset as test items. Don't be concerned that the example was likely used in training the model -- the point is to demonstrate how to make a prediction."
       ]
     },
     {
@@ -685,12 +627,12 @@
         "id": "make_batch_file:automl,image"
       },
       "source": [
-        "### Make the batch input file\n",
+        "### Create the batch input file\n",
         "\n",
-        "Now make a batch input file, which you will store in your local Cloud Storage bucket. The batch input file can be either CSV or JSONL. You will use JSONL in this tutorial. For JSONL file, you make one dictionary entry per line for each data item (instance). The dictionary contains the key/value pairs:\n",
+        "Now make a batch input file, which is stored in your local Cloud Storage bucket. The batch input file can be either CSV or JSONL. Use JSONL in this tutorial. For JSONL file, make one dictionary entry per line for each data item (instance). The dictionary contains the key/value pairs:\n",
         "\n",
         "- `content`: The Cloud Storage path to the image.\n",
-        "- `mime_type`: The content type. In our example, it is a `jpeg` file.\n",
+        "- `mime_type`: The content type. In our example, it's a `jpeg` file.\n",
         "\n",
         "For example:\n",
         "\n",
@@ -728,12 +670,12 @@
       "source": [
         "### Make the batch prediction request\n",
         "\n",
-        "Now that your Model resource is trained, you can make a batch prediction by invoking the batch_predict() method, with the following parameters:\n",
+        "Now that your model resource is trained, make a batch prediction by invoking the `batch_predict()` method, with the following parameters:\n",
         "\n",
         "- `job_display_name`: The human readable name for the batch prediction job.\n",
         "- `gcs_source`: A list of one or more batch request input files.\n",
-        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction resuls.\n",
-        "- `sync`: If set to True, the call will block while waiting for the asynchronous batch job to complete."
+        "- `gcs_destination_prefix`: The Cloud Storage location for storing the batch prediction results.\n",
+        "- `sync`: Set `True` to wait until the completion of the job."
       ]
     },
     {
@@ -762,7 +704,7 @@
       "source": [
         "### Wait for completion of batch prediction job\n",
         "\n",
-        "Next, wait for the batch job to complete. Alternatively, one can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
+        "Next, wait for the batch job to complete. Alternatively, you can set the parameter `sync` to `True` in the `batch_predict()` method to block until the batch prediction job is completed."
       ]
     },
     {
@@ -786,11 +728,11 @@
         "\n",
         "Next, get the results from the completed batch prediction job.\n",
         "\n",
-        "The results are written to the Cloud Storage output bucket you specified in the batch prediction request. You call the method iter_outputs() to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a JSON format:\n",
+        "The results are written to the Cloud Storage output bucket specified in the batch prediction request. Call the `iter_outputs()` method to get a list of each Cloud Storage file generated with the results. Each file contains one or more prediction requests in a JSON format:\n",
         "\n",
         "- `content`: The prediction request.\n",
         "- `prediction`: The prediction response.\n",
-        " - `ids`: The internal assigned unique identifiers for each prediction request.\n",
+        " - `ids`: The internally assigned unique identifiers for each prediction request.\n",
         " - `displayNames`: The class names for each class label.\n",
         " - `confidences`: The predicted confidence, between 0 and 1, per class label."
       ]
@@ -846,8 +788,6 @@
       },
       "outputs": [],
       "source": [
-        "delete_bucket = False\n",
-        "\n",
         "# Delete the dataset using the Vertex dataset object\n",
         "dataset.delete()\n",
         "\n",
@@ -860,7 +800,9 @@
         "# Delete the batch prediction job\n",
         "batch_predict_job.delete()\n",
         "\n",
-        "if delete_bucket or os.getenv(\"IS_TESTING\"):\n",
+        "# Delete the cloud storage bucket\n",
+        "delete_bucket = False  # set True for deletion\n",
+        "if delete_bucket:\n",
         "    ! gsutil rm -r $BUCKET_URI"
       ]
     }


### PR DESCRIPTION
This PR includes the following changes:

1. Adds Colab Enterprise link and other structural changes from the new template.
2. Changes  REGION variable name to LOCATION.
3. Changes aiplatform import statement
4. Modifies the value of IMPORT_FILE.
5. Hardcodes TF==2.1.51 .
6. Removes import os and os.getenv("IS_TESTING") .
7. Adds code highlight.
8. Contracts words like is not, do not, You are, does not, will not etc.
9. Changes future tense sentences to present tense.

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.
