### PR TITLE
Add variant in Llama 3.1 deployment notebook.

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama3_1_deployment.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama3_1_deployment.ipynb
@@ -504,7 +504,7 @@
         "\n",
         "# @markdown Set the model to deploy.\n",
         "\n",
-        "base_model_name = \"Meta-Llama-3.1-70B\"  # @param [\"Meta-Llama-3.1-70B\", \"Meta-Llama-3.1-70B-Instruct\", \"Meta-Llama-3.1-405B-Instruct-FP8\"] {isTemplate:true}\n",
+        "base_model_name = \"Meta-Llama-3.1-70B\"  # @param [\"Meta-Llama-3.1-70B\", \"Meta-Llama-3.1-70B-Instruct\", \"Meta-Llama-3.1-405B-FP8\", \"Meta-Llama-3.1-405B-Instruct-FP8\"] {isTemplate:true}\n",
         "model_id = os.path.join(MODEL_BUCKET, base_model_name)\n",
         "\n",
         "# @markdown Find Vertex AI prediction supported accelerators and regions at https://cloud.google.com/vertex-ai/docs/predictions/configure-compute.\n",


### PR DESCRIPTION
Add variant in Llama 3.1 deployment notebook.

<br>

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
