### PR TITLE
chore(Egen): Adds a deprecation note

### DIFF
--- a/notebooks/official/datasets/get_started_with_data_labeling.ipynb
+++ b/notebooks/official/datasets/get_started_with_data_labeling.ipynb
@@ -26,6 +26,17 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "8c66e93e6bc1"
+      },
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "<p>⚠️<b>Caution</b>: Vertex AI Data Labeling Service (requesting human labelers) is deprecated and will no longer be available on Google Cloud after July 1, 2024. For new labeling tasks, you can use <a href=\"https://cloud.google.com/vertex-ai/docs/datasets/label-using-console\">add labels using the Google Cloud console</a> or access data labeling solutions from our partners in the <a href=\"https://console.cloud.google.com/marketplace/?_ga=2.93811416.41160618.1722319853-1200834403.1721625480\">Google Cloud Console Marketplace</a>, such as Labelbox and Snorkel.</p>\n",
+        "</div>\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "title:generic,gcp"
       },
       "source": [


### PR DESCRIPTION
<br>
Vertex ai data lebeling job is now [Deprecated](https://cloud.google.com/vertex-ai/docs/datasets/data-labeling-job). This PR includes a caution note at the top of the notebook.
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [ ] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>