### PR TITLE
Fix machine_type in model_garden_pytorch_llama3_1_deployment

### DIFF
--- a/notebooks/community/model_garden/model_garden_pytorch_llama3_1_deployment.ipynb
+++ b/notebooks/community/model_garden/model_garden_pytorch_llama3_1_deployment.ipynb
@@ -512,7 +512,7 @@
         "\n",
         "if \"70\" in base_model_name:\n",
         "    accelerator_type = \"NVIDIA_L4\"\n",
-        "    machine_type = \"g2-standard-8\"\n",
+        "    machine_type = \"g2-standard-96\"\n",
         "    accelerator_count = 8\n",
         "elif \"405\" in base_model_name:\n",
         "    accelerator_type = \"NVIDIA_H100_80GB\"\n",


### PR DESCRIPTION
Fix machine_type in model_garden_pytorch_llama3_1_deployment

**REQUIRED:** Fill out the below checklists or remove if irrelevant

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [y ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [ y] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).

