### PR TITLE
feat: add resize image function to common util

### DIFF
--- a/community-content/vertex_model_garden/model_oss/notebook_util/common_util.py
+++ b/community-content/vertex_model_garden/model_oss/notebook_util/common_util.py
@@ -233,6 +233,22 @@ def download_image(url: str) -> str:
   return Image.open(io.BytesIO(response.content))
 
 
+def resize_image(image: Any, new_width: int = 1000) -> Any:
+  """Resizes an image to a certain width.
+
+  Args:
+    image: The image which has to be resized.
+    new_width: New width of the image.
+
+  Returns:
+    New resized image.
+  """
+  width, height = image.size
+  new_height = int(height * new_width / width)
+  new_img = image.resize((new_width, new_height))
+  return new_img
+
+
 def load_img(path: str) -> Any:
   """Reads image from path and return PIL.Image instance.
 
@@ -433,3 +449,4 @@ def check_quota(
         f"Quota not enough for {resource_id} in {region}: {quota} <"
         f" {accelerator_count}. {quota_request_instruction}"
     )
+


### PR DESCRIPTION
Add resize image function to common util

2. If you are opening a PR for `Community Notebooks` under the [notebooks/community](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/community) folder:
- [x] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/community/CODEOWNERS) file under the `Community Notebooks` section, pointing to the author or the author's team.
- [x] Passes all the required formatting and linting checks. You can locally test with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
