### PR TITLE
feat: Getting tuned embeddings using text-embedding-005.

### DIFF
--- a/notebooks/official/generative_ai/tuned_text-embeddings.ipynb
+++ b/notebooks/official/generative_ai/tuned_text-embeddings.ipynb
@@ -72,7 +72,7 @@
       "source": [
         "### Objective\n",
         "\n",
-        "In this tutorial, you learn how to tune a text-embedding model, textembedding-gecko.\n",
+        "In this tutorial, you learn how to tune a text-embedding model.\n",
         "\n",
         "This tutorial uses the following Google Cloud ML services and resources:\n",
         "\n",
@@ -131,18 +131,18 @@
       "source": [
         "## Installation\n",
         "\n",
-        "This tutorial requires you to install the `google-cloud-aiplatform` package."
+        "This tutorial requires you to install `google-cloud-aiplatform` package, either the official release, or the unstable build from the source, `--force-reinstall git+https://github.com/googleapis/python-aiplatform.git`."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "ARIslNGX4IR3"
+        "id": "Nn6Ze-c4IZyt"
       },
       "outputs": [],
       "source": [
-        "! pip3 install --upgrade --user --quiet google-cloud-aiplatform"
+        "!pip3 install --quiet --upgrade google-cloud-aiplatform  # the latest, official release."
       ]
     },
     {
@@ -210,9 +210,9 @@
         "id": "0SG0ZnxmM1Ev"
       },
       "source": [
-        "### Initialize Vertex AI Platform\n",
+        "### Initialize Vertex AI SDK\n",
         "\n",
-        "Import and Initialize AI platform for your project and region.\n",
+        "Import and Initialize the SDK for your project and region.\n",
         "\n",
         "**If you don't know your project ID**, try the following:\n",
         "* Run `gcloud config list`.\n",
@@ -226,7 +226,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "id": "SWbf4r0tLUvA"
       },
       "outputs": [],
@@ -328,7 +327,7 @@
         "\n",
         "(Optionally), to resume this tutorial from where you left off with your previous tuning session, set **`TUNING_JOB_ID`** accordingly. Or, clear **`TUNING_JOB_ID`** to start over a fresh tuning session.\n",
         "\n",
-        "This tutorial creates a tuning job of a Vertex AI pipeline for tuning a text-embedding model within your project. See also [creating tuning jobs with parameters and defaults](https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-embeddings#create-embedding-tuning-job), the latest [text-embedding models and eligible tasks](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#api_changes_to_models_released_on_or_after_august_2023)."
+        "This tutorial creates a tuning job of a Vertex AI pipeline for tuning a text-embedding model within your project. See also [creating tuning jobs with parameters and defaults](https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-embeddings#create-embedding-tuning-job), and the latest [text-embedding models and eligible tasks](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#api_changes_to_models_released_on_or_after_august_2023)."
       ]
     },
     {
@@ -348,7 +347,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
         "id": "G1i__mAHNY9U"
       },
       "outputs": [],
@@ -377,10 +375,10 @@
         "batch_size = 128  # @param {type: \"number\"}\n",
         "# @markdown ---\n",
         "# @markdown `base_model_version_id`: Optional. Use this to specify what text embedding model to tune. This must be a stable version, for example `text-embedding-004`. To learn more, see [Supported Models](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#supported-models).\n",
-        "base_model_version_id = \"text-embedding-004\"  # @param [\"textembedding-gecko@003\", \"text-embedding-004\", \"textembedding-gecko-multilingual@001\", \"text-multilingual-embedding-002\"]\n",
+        "base_model_version_id = \"text-embedding-005\"  # @param [\"text-embedding-005\", \"text-embedding-004\", \"text-multilingual-embedding-002\"]\n",
         "# @markdown ---\n",
         "# @markdown `task_type`: Optional. The task type expected to be used during inference. See the [embedding API reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#request_body) to learn more.\n",
-        "task_type = \"DEFAULT\"  # @param [\"DEFAULT\", \"RETRIEVAL_QUERY\", \"RETRIEVAL_DOCUMENT\", \"SEMANTIC_SIMILARITY\", \"CLASSIFICATION\", \"CLUSTERING\", \"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"]\n",
+        "task_type = \"DEFAULT\"  # @param [\"DEFAULT\", \"RETRIEVAL_QUERY\", \"RETRIEVAL_DOCUMENT\", \"SEMANTIC_SIMILARITY\", \"CLASSIFICATION\", \"CLUSTERING\", \"QUESTION_ANSWERING\", \"FACT_VERIFICATION\", \"CODE_RETRIEVAL_QUERY\"]\n",
         "# @markdown ---\n",
         "# @markdown `learning_rate_multiplier`: Optional. A multiplier to apply to the recommended learning rate. To train with the recommended learning rate, use 1.0.\n",
         "learning_rate_multiplier = 1.0  # @param {type: \"number\"}\n",
@@ -389,12 +387,24 @@
         "output_dimensionality = 768  # @param {type: \"number\"}\n",
         "\n",
         "# Synchronously validate some edge cases that will cause async validation to fail.\n",
-        "if base_model_version_id not in [\"text-embedding-004\", \"text-multilingual-embedding-002\"]:\n",
+        "if base_model_version_id not in [\"text-embedding-005\"]:\n",
+        "    if task_type in [\"CODE_RETRIEVAL_QUERY\"]:\n",
+        "        raise ValueError(\n",
+        "            f\"task_type '{task_type}' is not valid for model '{base_model_version_id}'.\"\n",
+        "        )\n",
+        "if base_model_version_id not in [\n",
+        "    \"text-embedding-005\",\n",
+        "    \"text-embedding-004\",\n",
+        "    \"text-multilingual-embedding-002\",\n",
+        "]:\n",
         "    if task_type in [\"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"]:\n",
-        "        raise ValueError(f\"task_type '{task_type}' is not valid for model '{base_model_version_id}'.\")\n",
-        "\n",
+        "        raise ValueError(\n",
+        "            f\"task_type '{task_type}' is not valid for model '{base_model_version_id}'.\"\n",
+        "        )\n",
         "    if output_dimensionality not in [-1, 768]:\n",
-        "        raise ValueError(f\"Model '{base_model_version_id}' does not support the output_dimensionality parameter.\")\n",
+        "        raise ValueError(\n",
+        "            f\"Model '{base_model_version_id}' does not support the output_dimensionality parameter.\"\n",
+        "        )\n",
         "\n",
         "base_model = TextEmbeddingModel.from_pretrained(base_model_version_id)\n",
         "if \"TUNING_JOB_ID\" in locals() and TUNING_JOB_ID:\n",


### PR DESCRIPTION
**REQUIRED:** Demonstrate how to get tuned embeddings using text-embedding-005 model.

<br>
--- Make text-embedding-005 the default ---
<br><br><br>

**REQUIRED:** Fill out the below checklists or remove if irrelevant
1. If you are opening a PR for `Official Notebooks` under the [notebooks/official](https://github.com/GoogleCloudPlatform/vertex-ai-samples/tree/main/notebooks/official) folder, follow this mandatory checklist:
- [X] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [X] Follow the style and grammar rules outlined in the above notebook template.
- [X] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [X] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [X] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the [CODEOWNERS](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/CODEOWNERS) file under the `Official Notebooks` section, pointing to the author or the author's team.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.