### PR TITLE
Revert "Bump deepspeed from 0.14.4 to 0.15.1 in /community-content/vertex_model_garden/model_oss/peft/train/vmg/dockerfile"

### DIFF
--- a/community-content/vertex_model_garden/model_oss/peft/train/vmg/dockerfile/requirements.txt
+++ b/community-content/vertex_model_garden/model_oss/peft/train/vmg/dockerfile/requirements.txt
@@ -11,7 +11,7 @@ autoawq==0.2.5
 bitsandbytes==0.43.2
 cloudml-hypertune==0.1.0.dev6
 datasets==2.19.2
-deepspeed==0.15.1
+deepspeed==0.14.4
 diffusers==0.25.1
 fsspec==2024.3.1
 gcsfs==2024.3.1


### PR DESCRIPTION
Reverts GoogleCloudPlatform/vertex-ai-samples#3658

It breaks the model garden docker images.