### PR TITLE
Update pandas version on xgboost_training component in kfp2_pipeline

### DIFF
--- a/notebooks/official/pipelines/kfp2_pipeline.ipynb
+++ b/notebooks/official/pipelines/kfp2_pipeline.ipynb
@@ -660,7 +660,7 @@
         "@component(\n",
         "    packages_to_install=[\n",
         "        \"xgboost==1.6.2\",\n",
-        "        \"pandas==1.3.5\",\n",
+        "        \"pandas==2.1.2\",\n",
         "        \"joblib==1.1.0\",\n",
         "        \"scikit-learn==1.0.2\",\n",
         "    ],\n",


### PR DESCRIPTION


**REQUIRED:** Add a summary of your PR here, typically including why the change is needed and what was changed. Include any design alternatives for discussion purposes.

<br>
The current version was causing a the below error when executing on xgboost_training component on vertex.

```
numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

Updating the pandas version as shown [here](https://github.com/numpy/numpy/issues/26710) resolved the issue.
<br><br><br>
