### PR TITLE
refactor: remove runtime reboot

### DIFF
--- a/notebooks/official/custom/sdk-custom-image-classification-online.ipynb
+++ b/notebooks/official/custom/sdk-custom-image-classification-online.ipynb
@@ -153,7 +153,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
+        "%pip install --upgrade --quiet google-cloud-aiplatform \\\n",
         "                                 google-cloud \\\n",
         "                                 google-cloud-storage \\\n",
         "                                 pillow \\\n",

--- a/notebooks/official/custom/sdk-custom-image-classification-online.ipynb
+++ b/notebooks/official/custom/sdk-custom-image-classification-online.ipynb
@@ -153,7 +153,7 @@
       },
       "outputs": [],
       "source": [
-        "% pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
+        "%pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
         "                                 google-cloud \\\n",
         "                                 google-cloud-storage \\\n",
         "                                 pillow \\\n",

--- a/notebooks/official/custom/sdk-custom-image-classification-online.ipynb
+++ b/notebooks/official/custom/sdk-custom-image-classification-online.ipynb
@@ -153,51 +153,11 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
+        "% pip3 install --upgrade --quiet google-cloud-aiplatform \\\n",
         "                                 google-cloud \\\n",
         "                                 google-cloud-storage \\\n",
         "                                 pillow \\\n",
         "                                 numpy"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ff555b32bab8"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f09b4dff629a"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "54c5ef8a8f43"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
       ]
     },
     {

--- a/notebooks/official/generative_ai/anthropic_claude_3_intro.ipynb
+++ b/notebooks/official/generative_ai/anthropic_claude_3_intro.ipynb
@@ -137,47 +137,7 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install -U -q httpx"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "b9f4c57a43f6"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3b9119a60525"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "e767418763cd"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
+        "% pip3 install -U -q httpx"
       ]
     },
     {

--- a/notebooks/official/generative_ai/anthropic_claude_3_intro.ipynb
+++ b/notebooks/official/generative_ai/anthropic_claude_3_intro.ipynb
@@ -137,7 +137,7 @@
       },
       "outputs": [],
       "source": [
-        "% pip3 install -U -q httpx"
+        "%pip3 install -U -q httpx"
       ]
     },
     {

--- a/notebooks/official/generative_ai/anthropic_claude_3_intro.ipynb
+++ b/notebooks/official/generative_ai/anthropic_claude_3_intro.ipynb
@@ -137,7 +137,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip3 install -U -q httpx"
+        "%pip install -U -q httpx"
       ]
     },
     {

--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -132,7 +132,7 @@
       },
       "outputs": [],
       "source": [
-        "% pip3 install --quiet --upgrade google-cloud-aiplatform"
+        "%pip3 install --quiet --upgrade google-cloud-aiplatform"
       ]
     },
     {

--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -132,7 +132,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip3 install --quiet --upgrade google-cloud-aiplatform"
+        "%pip install --quiet --upgrade google-cloud-aiplatform"
       ]
     },
     {

--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -132,48 +132,7 @@
       },
       "outputs": [],
       "source": [
-        "# Install Vertex AI SDK for Python\n",
-        "!pip3 install --quiet --upgrade google-cloud-aiplatform"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6e0c0cdffff3"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "dcc98768955f"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7b49231643e4"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
+        "% pip3 install --quiet --upgrade google-cloud-aiplatform"
       ]
     },
     {

--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -185,7 +185,8 @@
         "    google-cloud-aiplatform[full] \\\n",
         "    google-cloud-bigquery \\\n",
         "    explainable_ai_sdk \\\n",
-        "    tensorflow"
+        "    tensorflow \\\n",
+        "    \"numpy<2.0\""
       ]
     },
     {

--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -786,7 +786,7 @@
         "MONITOR_INTERVAL = 1  # @param {type:\"number\"}\n",
         "\n",
         "# URI to training dataset.\n",
-        "DATASET_BQ_URI = \"bq://mco-mm.bqmlga4.train\"  # @param {type:\"string\"}\n",
+        "DATASET_BQ_URI = \"bq://storage-samples.bqmlga4.train\"  # @param {type:\"string\"}\n",
         "# Prediction target column name in training dataset.\n",
         "TARGET = \"churned\"\n",
         "\n",

--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -181,7 +181,7 @@
         "# Don't bother installing tensorflow or explainable_ai_sdk on Colab\n",
         "\n",
         "# Install required packages.\n",
-        "% pip3 install --upgrade --quiet \\\n",
+        "%pip3 install --upgrade --quiet \\\n",
         "    google-cloud-aiplatform[full] \\\n",
         "    google-cloud-bigquery \\\n",
         "    explainable_ai_sdk \\\n",

--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -554,7 +554,7 @@
       },
       "outputs": [],
       "source": [
-        "MODEL_PATH = \"gs://mco-mm/churn\"\n",
+        "MODEL_PATH = \"gs://cloud-samples-data/vertex-ai/model-deployment/models/churn\"\n",
         "\n",
         "params = {\"sampled_shapley_attribution\": {\"path_count\": 10}}\n",
         "EXPLAIN_PARAMS = aiplatform.explain.ExplanationParameters(params)\n",

--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -181,7 +181,7 @@
         "# Don't bother installing tensorflow or explainable_ai_sdk on Colab\n",
         "\n",
         "# Install required packages.\n",
-        "%pip3 install --upgrade --quiet \\\n",
+        "%pip install --upgrade --quiet \\\n",
         "    google-cloud-aiplatform[full] \\\n",
         "    google-cloud-bigquery \\\n",
         "    explainable_ai_sdk \\\n",

--- a/notebooks/official/model_monitoring/model_monitoring.ipynb
+++ b/notebooks/official/model_monitoring/model_monitoring.ipynb
@@ -181,51 +181,11 @@
         "# Don't bother installing tensorflow or explainable_ai_sdk on Colab\n",
         "\n",
         "# Install required packages.\n",
-        "! pip3 install --upgrade --quiet \\\n",
+        "% pip3 install --upgrade --quiet \\\n",
         "    google-cloud-aiplatform[full] \\\n",
         "    google-cloud-bigquery \\\n",
         "    explainable_ai_sdk \\\n",
         "    tensorflow"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "restart"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "D-ZBOjErv5mM"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ee775571c2b5"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
       ]
     },
     {

--- a/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
+++ b/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
@@ -136,7 +136,7 @@
       "outputs": [],
       "source": [
         "# Install the packages\n",
-        "%pip3 install --upgrade google-cloud-aiplatform \\\n",
+        "%pip install --upgrade google-cloud-aiplatform \\\n",
         "                         google-cloud-storage \\\n",
         "                         kfp \\\n",
         "                         google-cloud-pipeline-components"

--- a/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
+++ b/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
@@ -136,7 +136,7 @@
       "outputs": [],
       "source": [
         "# Install the packages\n",
-        "% pip3 install --upgrade google-cloud-aiplatform \\\n",
+        "%pip3 install --upgrade google-cloud-aiplatform \\\n",
         "                         google-cloud-storage \\\n",
         "                         kfp \\\n",
         "                         google-cloud-pipeline-components"

--- a/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
+++ b/notebooks/official/pipelines/pipelines_intro_kfp.ipynb
@@ -136,50 +136,10 @@
       "outputs": [],
       "source": [
         "# Install the packages\n",
-        "! pip3 install --upgrade google-cloud-aiplatform \\\n",
+        "% pip3 install --upgrade google-cloud-aiplatform \\\n",
         "                         google-cloud-storage \\\n",
         "                         kfp \\\n",
         "                         google-cloud-pipeline-components"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "blGlVGFYW9Pt"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0JrvuK6LUYnQ"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ffcde4d56c00"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
       ]
     },
     {

--- a/notebooks/official/ray_on_vertex_ai/get_started_with_pytorch_rov.ipynb
+++ b/notebooks/official/ray_on_vertex_ai/get_started_with_pytorch_rov.ipynb
@@ -164,9 +164,9 @@
       },
       "outputs": [],
       "source": [
-        "%pip3 install google-cloud-aiplatform[ray]==1.56.0 ray[data,train,tune,serve] google-cloud-bigquery-storage pyarrow gcsfs setuptools==69.5.1 \"numpy<2\" -q --no-warn-conflicts\n",
-        "%pip3 install torch==2.1.2 torchvision==0.16.2 torchmetrics==1.2.1 torchserve==0.9.0 torch-model-archiver==0.9.0 -q --no-warn-conflicts\n",
-        "%pip3 install google-auth==2.27.0 etils==1.5.2 -q --no-warn-conflicts"
+        "%pip install google-cloud-aiplatform[ray]==1.56.0 ray[data,train,tune,serve] google-cloud-bigquery-storage pyarrow gcsfs setuptools==69.5.1 \"numpy<2\" -q --no-warn-conflicts\n",
+        "%pip install torch==2.1.2 torchvision==0.16.2 torchmetrics==1.2.1 torchserve==0.9.0 torch-model-archiver==0.9.0 -q --no-warn-conflicts\n",
+        "%pip install google-auth==2.27.0 etils==1.5.2 -q --no-warn-conflicts"
       ]
     },
     {

--- a/notebooks/official/ray_on_vertex_ai/get_started_with_pytorch_rov.ipynb
+++ b/notebooks/official/ray_on_vertex_ai/get_started_with_pytorch_rov.ipynb
@@ -164,9 +164,9 @@
       },
       "outputs": [],
       "source": [
-        "% pip3 install google-cloud-aiplatform[ray]==1.56.0 ray[data,train,tune,serve] google-cloud-bigquery-storage pyarrow gcsfs setuptools==69.5.1 \"numpy<2\" -q --no-warn-conflicts\n",
-        "% pip3 install torch==2.1.2 torchvision==0.16.2 torchmetrics==1.2.1 torchserve==0.9.0 torch-model-archiver==0.9.0 -q --no-warn-conflicts\n",
-        "% pip3 install google-auth==2.27.0 etils==1.5.2 -q --no-warn-conflicts"
+        "%pip3 install google-cloud-aiplatform[ray]==1.56.0 ray[data,train,tune,serve] google-cloud-bigquery-storage pyarrow gcsfs setuptools==69.5.1 \"numpy<2\" -q --no-warn-conflicts\n",
+        "%pip3 install torch==2.1.2 torchvision==0.16.2 torchmetrics==1.2.1 torchserve==0.9.0 torch-model-archiver==0.9.0 -q --no-warn-conflicts\n",
+        "%pip3 install google-auth==2.27.0 etils==1.5.2 -q --no-warn-conflicts"
       ]
     },
     {

--- a/notebooks/official/ray_on_vertex_ai/get_started_with_pytorch_rov.ipynb
+++ b/notebooks/official/ray_on_vertex_ai/get_started_with_pytorch_rov.ipynb
@@ -164,49 +164,9 @@
       },
       "outputs": [],
       "source": [
-        "! pip3 install google-cloud-aiplatform[ray]==1.56.0 ray[data,train,tune,serve] google-cloud-bigquery-storage pyarrow gcsfs setuptools==69.5.1 \"numpy<2\" -q --no-warn-conflicts\n",
-        "! pip3 install torch==2.1.2 torchvision==0.16.2 torchmetrics==1.2.1 torchserve==0.9.0 torch-model-archiver==0.9.0 -q --no-warn-conflicts\n",
-        "! pip3 install google-auth==2.27.0 etils==1.5.2 -q --no-warn-conflicts"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "16220914acc5"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "157953ab28f0"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c87a2a5d7e35"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
+        "% pip3 install google-cloud-aiplatform[ray]==1.56.0 ray[data,train,tune,serve] google-cloud-bigquery-storage pyarrow gcsfs setuptools==69.5.1 \"numpy<2\" -q --no-warn-conflicts\n",
+        "% pip3 install torch==2.1.2 torchvision==0.16.2 torchmetrics==1.2.1 torchserve==0.9.0 torch-model-archiver==0.9.0 -q --no-warn-conflicts\n",
+        "% pip3 install google-auth==2.27.0 etils==1.5.2 -q --no-warn-conflicts"
       ]
     },
     {


### PR DESCRIPTION
Remove runtime reboot from some notebooks to support automated tests.

Using %pip install instead to install libraries on the current kernel. 