### PR TITLE
Add Mistral OCR notebook

### DIFF
--- a/notebooks/official/generative_ai/mistralai_intro.ipynb
+++ b/notebooks/official/generative_ai/mistralai_intro.ipynb
@@ -1,1646 +1,1552 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "9A9NkTRTfo2I"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2024 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "IPprg6Oz0QDs"
-      },
-      "source": [
-        "# Getting Started with Mistral AI Models\n",
-        "<table align=\"left\">\n",
-        "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_intro.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fgenerative_ai%2Fmistralai_intro.ipynb\">\n",
-        "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td style=\"text-align: center\">                                                                             \n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/notebooks/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/generative_ai/mistralai_intro.ipynb\">\n",
-        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td style=\"text-align: center\">\n",
-        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_intro.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  \n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dFkhRcsaqToV"
-      },
-      "source": [
-        "NOTE: This notebook has been tested in the following environment:\n",
-        "\n",
-        "Python version = 3.10"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8fK_rdvvx1iZ"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "### Mistral AI on Vertex AI\n",
-        "\n",
-        "Mistral AI models on Vertex AI offer fully managed and serverless models are offered as managed APIs. To use a Mistral AI model on Vertex AI, send a request directly to the Vertex AI API endpoint.\n",
-        "\n",
-        "You can stream your Mistral AI model responses to reduce the end-user latency perception. A streamed response uses server-sent events (SSE) to incrementally stream the response.\n",
-        "\n",
-        "Learn more about [Vertex AI](https://cloud.google.com/vertex-ai).\n",
-        "\n",
-        "### Available Mistral AI models\n",
-        "\n",
-        "*   ### Mistral OCR (25.05)\n",
-        "Mistral OCR (25.05) is a model specialized in extracting text and images from documents. It is specifically built to preserve the structure of the document pages and automatically formats the extracted text in Markdown.\n",
-        "\n",
-        "*   ### Mistral Small 3.1 (25.03)\n",
-        "Mistral Small 3.1 (25.03) is the enhanced version of Mistral Small 3, featuring multimodal capabilities and an extended context length of up to 128k.\n",
-        "\n",
-        "*   ### Codestral (25.01)\n",
-        "A cutting-edge model specifically designed for code generation, including fill-in-the-middle and code completion.\n",
-        "\n",
-        "*   ### Mistral Large (24.11)\n",
-        "Mistral Large (24.11) is the latest version of the Mistral Large model now with improved reasoning and function calling capabilities.\n",
-        "\n",
-        "*   ### Mistral Nemo\n",
-        "Reasoning, world knowledge, and coding performance are state-of-the-art in its size category.\n",
-        "\n",
-        "\n",
-        "## Objective\n",
-        "\n",
-        "This notebook shows how to use **Vertex AI API** to call the Mistral AI models.\n",
-        "\n",
-        "For more information, see the [Use Mistral's](https://docs.mistral.ai/) documentation and [Mistral's models](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral) on Google Cloud.\n",
-        "\n",
-        "- Mistral on Model Garden supports the same API calls as Mistral’s own API endpoints, except for the `safe_prompt` parameter that will return an error if specified in the input. So do not include `safe_prompt` in input requests.\n",
-        "- Documentation links\n",
-        "  - [Mistral APIs](https://docs.mistral.ai/api/)\n",
-        "  - [Chat Completion](https://docs.mistral.ai/api/#operation/createChatCompletion) operations supported by Mistral Large, Mistral Nemo and Codestral\n",
-        "  - [Fill-in-the-middle](https://docs.mistral.ai/api/#operation/createFIMCompletion) operations supported by Codestral"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HcJCV6Dw5usD"
-      },
-      "source": [
-        "## Vertex AI API"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nwYvaaW25jYS"
-      },
-      "source": [
-        "## Get Started - Required first steps\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6a5bea26f60f"
-      },
-      "source": [
-        "### Authenticate your notebook environment (Colab only)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "c97be6a73155"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "    from google.colab import auth\n",
-        "\n",
-        "    auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2fxZn4SAbxdl"
-      },
-      "source": [
-        "#### Select one of Mistral AI models"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Y8X70FTSbx7U"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL = \"mistral-small-2503\"  # @param [\"mistral-small-2503\", \"codestral-2501\", \"mistral-large-2411\", \"mistral-nemo\", \"mistral-ocr-2505\"]\n",
-        "if MODEL == \"mistral-small-2503\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\"]\n",
-        "elif MODEL == \"mistral-large-2411\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\"]\n",
-        "elif MODEL == \"mistral-ocr-2505\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\"]\n",
-        "elif MODEL == \"mistral-nemo\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"2407\"]\n",
-        "elif MODEL == \"codestral-2501\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bpuX3sKtexlK"
-      },
-      "source": [
-        "#### Select a location and a version from the dropdown"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "dHl8xW45ex_O"
-      },
-      "outputs": [],
-      "source": [
-        "import ipywidgets as widgets\n",
-        "from IPython.display import display\n",
-        "\n",
-        "dropdown_loc = widgets.Dropdown(\n",
-        "    options=available_regions,\n",
-        "    description=\"Select a location:\",\n",
-        "    font_weight=\"bold\",\n",
-        "    style={\"description_width\": \"initial\"},\n",
-        ")\n",
-        "\n",
-        "dropdown_ver = widgets.Dropdown(\n",
-        "    options=available_versions,\n",
-        "    description=\"Select the model version (optional):\",\n",
-        "    font_weight=\"bold\",\n",
-        "    style={\"description_width\": \"initial\"},\n",
-        ")\n",
-        "\n",
-        "\n",
-        "def dropdown_loc_eventhandler(change):\n",
-        "    global LOCATION\n",
-        "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
-        "        LOCATION = change.new\n",
-        "        print(\"Selected:\", change.new)\n",
-        "\n",
-        "\n",
-        "def dropdown_ver_eventhandler(change):\n",
-        "    global MODEL_VERSION\n",
-        "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
-        "        MODEL_VERSION = change.new\n",
-        "        print(\"Selected:\", change.new)\n",
-        "\n",
-        "\n",
-        "LOCATION = dropdown_loc.value\n",
-        "dropdown_loc.observe(dropdown_loc_eventhandler, names=\"value\")\n",
-        "display(dropdown_loc)\n",
-        "\n",
-        "MODEL_VERSION = dropdown_ver.value\n",
-        "dropdown_ver.observe(dropdown_ver_eventhandler, names=\"value\")\n",
-        "display(dropdown_ver)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3q58icinBjoK"
-      },
-      "source": [
-        "#### Set Google Cloud project and model information\n",
-        "\n",
-        "To get started using Vertex AI, you must have an existing Google Cloud project and [enable the Vertex AI API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com). Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hltNx33t6cSZ"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-        "ENDPOINT = f\"https://{LOCATION}-aiplatform.googleapis.com\"\n",
-        "SELECTED_MODEL_VERSION = \"\" if MODEL_VERSION == \"latest\" else f\"@{MODEL_VERSION}\"\n",
-        "\n",
-        "if not PROJECT_ID or PROJECT_ID == \"[your-project-id]\":\n",
-        "    raise ValueError(\"Please set your PROJECT_ID\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4NAstKRFBt4N"
-      },
-      "source": [
-        "#### Import required libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "QZEFLE6a6bqy"
-      },
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "import subprocess\n",
-        "\n",
-        "import requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Y_8xeTfWqToW"
-      },
-      "source": [
-        "To try the OCR model, please refer to the section \"Performing OCR\"."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vVVnOhvE_PA6"
-      },
-      "source": [
-        "### Sample Requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5ahw-uFjCAbo"
-      },
-      "source": [
-        "#### Text generation"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "61107099357a"
-      },
-      "source": [
-        "##### Unary call\n",
-        "\n",
-        "Sends a POST request to the specified API endpoint to get a response from the model using the provided payload."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4zFz260B50oi"
-      },
-      "outputs": [],
-      "source": [
-        "PAYLOAD = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"messages\": [{\"role\": \"user\", \"content\": \"who is the best French painter?\"}],\n",
-        "    \"max_tokens\": 100,\n",
-        "    \"stream\": False,\n",
-        "}\n",
-        "\n",
-        "request = json.dumps(PAYLOAD)\n",
-        "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:rawPredict -d '{request}'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tf56XLe1EZos"
-      },
-      "source": [
-        "With a pretty response"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "L90Kdr-PEYr3"
-      },
-      "outputs": [],
-      "source": [
-        "# Get the access token\n",
-        "process = subprocess.Popen(\n",
-        "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
-        ")\n",
-        "(access_token_bytes, err) = process.communicate()\n",
-        "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
-        "\n",
-        "# Define query headers\n",
-        "headers = {\n",
-        "    \"Authorization\": f\"Bearer {access_token}\",\n",
-        "    \"Accept\": \"application/json\",\n",
-        "}\n",
-        "\n",
-        "# Replace with your actual values\n",
-        "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:rawPredict\"\n",
-        "data = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"messages\": [{\"role\": \"user\", \"content\": \"who is the best French painter?\"}],\n",
-        "    \"stream\": False,\n",
-        "}\n",
-        "\n",
-        "# Make the POST request\n",
-        "response = requests.post(url, headers=headers, json=data)\n",
-        "\n",
-        "# Check status code and try to parse the response as JSON\n",
-        "if response.status_code == 200:\n",
-        "    try:\n",
-        "        response_dict = response.json()\n",
-        "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
-        "    except json.JSONDecodeError as e:\n",
-        "        print(\"Error decoding JSON:\", e)\n",
-        "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
-        "else:\n",
-        "    print(f\"Request failed with status code: {response.status_code}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "e6f52fae9379"
-      },
-      "source": [
-        "##### Streaming call\n",
-        "\n",
-        "Sends a POST request to the specified API endpoint to stream a response from the model using the provided payload."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "c99761dcd7da"
-      },
-      "outputs": [],
-      "source": [
-        "PAYLOAD = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"messages\": [{\"role\": \"user\", \"content\": \"who is the best French painter?\"}],\n",
-        "    \"max_tokens\": 100,\n",
-        "    \"stream\": True,\n",
-        "}\n",
-        "\n",
-        "request = json.dumps(PAYLOAD)\n",
-        "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:streamRawPredict -d '{request}'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "X6HolebUhShT"
-      },
-      "source": [
-        "#### Code generation\n",
-        "\n",
-        "Mistral Large, Mistral Nemo and Codestral support code generation with the Chat Completion operations covered above.\n",
-        "\n",
-        "With Codestral, you can also do Fill-in-the-middle operations."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "deUZQwgSheEr"
-      },
-      "source": [
-        "##### Fill-in-the-middle (FIM)\n",
-        "With this feature, users can define the starting point of the code using a `prompt`, and the ending point of the code using an optional `suffix` and an optional `stop`.\n",
-        "\n",
-        "The Codestral model will then generate the code that fits in between, making it ideal for tasks that require a specific piece of code to be generated.\n",
-        "\n",
-        "More information on FIM:\n",
-        "- [Mistral API Documentation FIM](https://docs.mistral.ai/api/#operation/createFIMCompletion)\n",
-        "- [Mistral FIM Documentation](https://docs.mistral.ai/capabilities/code_generation/#fill-in-the-middle-endpoint)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5JzsH7TmujqR"
-      },
-      "source": [
-        "Example 1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "0zXL4RrnhRLG"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL = \"codestral-2501\"  # use \"codestral\" for Codestral (24.05)\n",
-        "SELECTED_MODEL_VERSION = \"\"  # use \"@2405\" for Codestral (24.05)\n",
-        "\n",
-        "PAYLOAD = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"prompt\": \"def say_hello(name: str) -> str\",\n",
-        "    \"suffix\": \"return n_words\",\n",
-        "}\n",
-        "\n",
-        "request = json.dumps(PAYLOAD)\n",
-        "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:streamRawPredict -d '{request}'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "n6kMTcg5ulJD"
-      },
-      "source": [
-        "Example 2 with pretty response"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ciJKueNfDman"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL = \"codestral-2501\"  # use \"codestral\" for Codestral (24.05)\n",
-        "SELECTED_MODEL_VERSION = \"\"  # use \"@2405\" for Codestral (24.05)\n",
-        "\n",
-        "# Get the access token\n",
-        "process = subprocess.Popen(\n",
-        "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
-        ")\n",
-        "(access_token_bytes, err) = process.communicate()\n",
-        "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
-        "\n",
-        "# Define query headers\n",
-        "headers = {\n",
-        "    \"Authorization\": f\"Bearer {access_token}\",\n",
-        "    \"Accept\": \"application/json\",\n",
-        "}\n",
-        "\n",
-        "# Replace with your actual values\n",
-        "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:rawPredict\"\n",
-        "data = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"prompt\": \"def f(\",\n",
-        "    \"suffix\": \"return a + b\",\n",
-        "    \"max_tokens\": 64,\n",
-        "    \"temperature\": 0,\n",
-        "}\n",
-        "\n",
-        "# Make the POST request\n",
-        "response = requests.post(url, headers=headers, json=data)\n",
-        "\n",
-        "# Check status code and try to parse the response as JSON\n",
-        "if response.status_code == 200:\n",
-        "    try:\n",
-        "        response_dict = response.json()\n",
-        "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
-        "    except json.JSONDecodeError as e:\n",
-        "        print(\"Error decoding JSON:\", e)\n",
-        "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
-        "else:\n",
-        "    print(f\"Request failed with status code: {response.status_code}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-G8kI3S_FUjM"
-      },
-      "source": [
-        "## Using Mistral AI's Vertex SDK for *Python*"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pdzqqcJKOYHa"
-      },
-      "source": [
-        "## Get Started"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_TGDKo-vFn5F"
-      },
-      "source": [
-        "### Install Mistral's Vertex SDK for Python and other required packages"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2AdfzWYfFw3u"
-      },
-      "outputs": [],
-      "source": [
-        "! pip3 install -U -q 'mistralai[gcp]>=1.2.4'\n",
-        "! pip3 install -U -q httpx"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mTbP9RNlF1nO"
-      },
-      "source": [
-        "### Restart runtime (Colab only)\n",
-        "\n",
-        "To use the newly installed packages, you must restart the runtime on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "FCjYtEc8F437"
-      },
-      "outputs": [],
-      "source": [
-        "# Restart kernel after installs so that your environment can access the new packages\n",
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "    import IPython\n",
-        "\n",
-        "    app = IPython.Application.instance()\n",
-        "    app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Fgq8ZhyuF8wx"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "d3nepikRF_Gt"
-      },
-      "source": [
-        "### Authenticate your notebook environment (Colab only)\n",
-        "\n",
-        "Authenticate your environment on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Z9EvH5iez_n_"
-      },
-      "outputs": [],
-      "source": [
-        "# Get the access token\n",
-        "import subprocess\n",
-        "\n",
-        "process = subprocess.Popen(\n",
-        "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
-        ")\n",
-        "(access_token_bytes, err) = process.communicate()\n",
-        "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
-        "\n",
-        "headers = {\n",
-        "    \"Authorization\": f\"Bearer {access_token}\",\n",
-        "    \"Content-Type\": \"application/json\",\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-qgHPk0IGBZX"
-      },
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "\n",
-        "if \"google.colab\" in sys.modules:\n",
-        "\n",
-        "    from google.colab import auth\n",
-        "\n",
-        "    auth.authenticate_user()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7ICjT5ZNGF2c"
-      },
-      "source": [
-        "#### Select one of Mistral AI models"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-oqhRyb5-g6I"
-      },
-      "source": [
-        "**Note**: New Mistral Models will have python SDK supported in the upcoming versions."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NBRTMXhmGIlN"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL = \"mistral-small-2503\"  # @param [\"mistral-small-2503\", \"mistral-large\", \"mistral-nemo\", \"codestral-2501\"]\n",
-        "\n",
-        "if MODEL == \"mistral-small-2503\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\"]\n",
-        "elif MODEL == \"mistral-large\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\", \"2411\"]\n",
-        "elif MODEL == \"mistral-nemo\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\", \"2407\"]\n",
-        "elif MODEL == \"codestral-2501\":\n",
-        "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
-        "    available_versions = [\"latest\"]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "227_bG2OGNec"
-      },
-      "source": [
-        "#### Select a location and a version from the dropdown"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "uoP1c89sGP7k"
-      },
-      "outputs": [],
-      "source": [
-        "import ipywidgets as widgets\n",
-        "from IPython.display import display\n",
-        "\n",
-        "dropdown_loc = widgets.Dropdown(\n",
-        "    options=available_regions,\n",
-        "    description=\"Select a location:\",\n",
-        "    font_weight=\"bold\",\n",
-        "    style={\"description_width\": \"initial\"},\n",
-        ")\n",
-        "\n",
-        "dropdown_ver = widgets.Dropdown(\n",
-        "    options=available_versions,\n",
-        "    description=\"Select the model version (optional):\",\n",
-        "    font_weight=\"bold\",\n",
-        "    style={\"description_width\": \"initial\"},\n",
-        ")\n",
-        "\n",
-        "\n",
-        "def dropdown_loc_eventhandler(change):\n",
-        "    global LOCATION\n",
-        "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
-        "        LOCATION = change.new\n",
-        "        print(\"Selected:\", change.new)\n",
-        "\n",
-        "\n",
-        "def dropdown_ver_eventhandler(change):\n",
-        "    global MODEL_VERSION\n",
-        "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
-        "        MODEL_VERSION = change.new\n",
-        "        print(\"Selected:\", change.new)\n",
-        "\n",
-        "\n",
-        "LOCATION = dropdown_loc.value\n",
-        "dropdown_loc.observe(dropdown_loc_eventhandler, names=\"value\")\n",
-        "display(dropdown_loc)\n",
-        "\n",
-        "MODEL_VERSION = dropdown_ver.value\n",
-        "dropdown_ver.observe(dropdown_ver_eventhandler, names=\"value\")\n",
-        "display(dropdown_ver)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mghCnsVbK5YP"
-      },
-      "source": [
-        "#### Set Google Cloud project and model information\n",
-        "\n",
-        "To get started using Vertex AI, you must have an existing Google Cloud project and [enable the Vertex AI API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com). Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NB-_kGiJLDcT"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-        "ENDPOINT = f\"https://{LOCATION}-aiplatform.googleapis.com\"\n",
-        "\n",
-        "if not PROJECT_ID or PROJECT_ID == \"[your-project-id]\":\n",
-        "    raise ValueError(\"Please set your PROJECT_ID\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yD9oKNOGMA18"
-      },
-      "source": [
-        "#### Import required libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hgmj4wwLMYgd"
-      },
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "\n",
-        "import requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pQnpW1WLO3uX"
-      },
-      "source": [
-        "### Sample Requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tH0QFYIXMZNZ"
-      },
-      "source": [
-        "#### Text generation"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tm2rUyXtPgp2"
-      },
-      "source": [
-        "##### Unary call\n",
-        "\n",
-        "Initializes a client for Mistral AI's Vertex AI, sends a request to generate the content, and prints the response in a formatted JSON"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cRqiGVUdMgXs"
-      },
-      "outputs": [],
-      "source": [
-        "import subprocess\n",
-        "\n",
-        "from mistralai_gcp import MistralGoogleCloud\n",
-        "\n",
-        "client = MistralGoogleCloud(\n",
-        "    access_token=access_token, region=LOCATION, project_id=PROJECT_ID\n",
-        ")\n",
-        "\n",
-        "try:\n",
-        "    resp = client.chat.complete(\n",
-        "        model=f\"{MODEL}\",\n",
-        "        messages=[\n",
-        "            {\n",
-        "                \"role\": \"user\",\n",
-        "                \"content\": \"Who is the best French painter? Answer in one short sentence.\",\n",
-        "            }\n",
-        "        ],\n",
-        "    )\n",
-        "    print(resp.choices[0].message.content)\n",
-        "\n",
-        "except Exception as e:\n",
-        "    print(f\"An error occurred: {e}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EWkLsn5GQrqu"
-      },
-      "source": [
-        "##### Streaming call\n",
-        "\n",
-        "Initializes a client for Mistral AI's Vertex AI, sends a streaming request to generate the content, and continuously prints the received text as it is streamed."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "2uOfrmmRQ-rJ"
-      },
-      "outputs": [],
-      "source": [
-        "from mistralai_gcp import MistralGoogleCloud\n",
-        "\n",
-        "client = MistralGoogleCloud(\n",
-        "    access_token=access_token, region=LOCATION, project_id=PROJECT_ID\n",
-        ")\n",
-        "\n",
-        "try:\n",
-        "    stream = client.chat.stream(\n",
-        "        model=f\"{MODEL}\",\n",
-        "        max_tokens=1024,\n",
-        "        messages=[\n",
-        "            {\n",
-        "                \"role\": \"user\",\n",
-        "                \"content\": \"Who is the best French painter? Answer in one short sentence.\",\n",
-        "            }\n",
-        "        ],\n",
-        "    )\n",
-        "\n",
-        "    for chunk in stream:\n",
-        "        print(chunk.data.choices[0].delta.content)\n",
-        "\n",
-        "except Exception as e:\n",
-        "    print(f\"An error occurred: {e}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PEZcdznmRxT6"
-      },
-      "source": [
-        "#### Code generation\n",
-        "\n",
-        "Mistral Large, Mistral Nemo and Codestral support code generation with the Chat Completion operations covered above.\n",
-        "\n",
-        "With Codestral, you can also do Fill-in-the-middle operations."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BWl3pMDOXdEZ"
-      },
-      "source": [
-        "##### Fill-in-the-middle (FIM)\n",
-        "With this feature, users can define the starting point of the code using a `prompt`, and the ending point of the code using an optional `suffix` and an optional `stop`.\n",
-        "\n",
-        "The Codestral model will then generate the code that fits in between, making it ideal for tasks that require a specific piece of code to be generated.\n",
-        "\n",
-        "More information on FIM:\n",
-        "- [Mistral API Documentation FIM](https://docs.mistral.ai/api/#operation/createFIMCompletion)\n",
-        "- [Mistral FIM Documentation](https://docs.mistral.ai/capabilities/code_generation/#fill-in-the-middle-endpoint)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "o61l9pOsTUc-"
-      },
-      "outputs": [],
-      "source": [
-        "from mistralai_gcp import MistralGoogleCloud\n",
-        "\n",
-        "client = MistralGoogleCloud(\n",
-        "    access_token=access_token, region=LOCATION, project_id=PROJECT_ID\n",
-        ")\n",
-        "\n",
-        "MODEL = \"codestral-2501\"\n",
-        "MODEL_VERSION = \"2501\"\n",
-        "\n",
-        "try:\n",
-        "    resp = client.fim.complete(\n",
-        "        model=f\"{MODEL}\",\n",
-        "        prompt=\"def count_words_in_file(file_path: str) -> int\",\n",
-        "        suffix=\"return n_words\",\n",
-        "    )\n",
-        "\n",
-        "    print(resp.choices[0].message.content)\n",
-        "\n",
-        "except Exception as e:\n",
-        "    print(f\"An error occurred: {e}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qsJLkqyyztR_"
-      },
-      "source": [
-        "## Model Capabilities"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TfmwOYBXxcQG"
-      },
-      "source": [
-        "### Function Calling with Mistral Large\n",
-        "\n",
-        "Function calling allows Mistral models to connect to external tools. By integrating Mistral models with external tools such as user defined functions or APIs, users can easily build applications catering to specific use cases and practical problems.\n",
-        "\n",
-        "This guide is the one Mistral provides [here](https://docs.mistral.ai/capabilities/function_calling/). We write two functions for tracking payment status and payment date. We can use these two tools to provide answers for payment-related queries."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nLmoam_z0OfN"
-      },
-      "source": [
-        "#### Step 1. User: specify tools\n",
-        "\n",
-        "Define sample data like this was stored in a sample database."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Oak2cRcgx7VB"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "# Assuming we have the following data\n",
-        "data = {\n",
-        "    \"transaction_id\": [\"T1001\", \"T1002\", \"T1003\", \"T1004\", \"T1005\"],\n",
-        "    \"customer_id\": [\"C001\", \"C002\", \"C003\", \"C002\", \"C001\"],\n",
-        "    \"payment_amount\": [125.50, 89.99, 120.00, 54.30, 210.20],\n",
-        "    \"payment_date\": [\n",
-        "        \"2021-10-05\",\n",
-        "        \"2021-10-06\",\n",
-        "        \"2021-10-07\",\n",
-        "        \"2021-10-05\",\n",
-        "        \"2021-10-08\",\n",
-        "    ],\n",
-        "    \"payment_status\": [\"Paid\", \"Unpaid\", \"Paid\", \"Paid\", \"Pending\"],\n",
-        "}\n",
-        "\n",
-        "# Create DataFrame\n",
-        "df = pd.DataFrame(data)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cxb7_m9UxxmW"
-      },
-      "source": [
-        "Define the functions that will be used as tools."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pfOuDWlYxdvL"
-      },
-      "outputs": [],
-      "source": [
-        "def retrieve_payment_status(df: data, transaction_id: str) -> str:\n",
-        "    if transaction_id in df.transaction_id.values:\n",
-        "        return json.dumps(\n",
-        "            {\"status\": df[df.transaction_id == transaction_id].payment_status.item()}\n",
-        "        )\n",
-        "    return json.dumps({\"error\": \"transaction id not found.\"})\n",
-        "\n",
-        "\n",
-        "def retrieve_payment_date(df: data, transaction_id: str) -> str:\n",
-        "    if transaction_id in df.transaction_id.values:\n",
-        "        return json.dumps(\n",
-        "            {\"date\": df[df.transaction_id == transaction_id].payment_date.item()}\n",
-        "        )\n",
-        "    return json.dumps({\"error\": \"transaction id not found.\"})"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "66OSfAKVyJnn"
-      },
-      "source": [
-        "Define the tools for those functions following the right JSON format."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "o5xBTtIGxzRS"
-      },
-      "outputs": [],
-      "source": [
-        "tools = [\n",
-        "    {\n",
-        "        \"type\": \"function\",\n",
-        "        \"function\": {\n",
-        "            \"name\": \"retrieve_payment_status\",\n",
-        "            \"description\": \"Get payment status of a transaction\",\n",
-        "            \"parameters\": {\n",
-        "                \"type\": \"object\",\n",
-        "                \"properties\": {\n",
-        "                    \"transaction_id\": {\n",
-        "                        \"type\": \"string\",\n",
-        "                        \"description\": \"The transaction id.\",\n",
-        "                    }\n",
-        "                },\n",
-        "                \"required\": [\"transaction_id\"],\n",
-        "            },\n",
-        "        },\n",
-        "    },\n",
-        "    {\n",
-        "        \"type\": \"function\",\n",
-        "        \"function\": {\n",
-        "            \"name\": \"retrieve_payment_date\",\n",
-        "            \"description\": \"Get payment date of a transaction\",\n",
-        "            \"parameters\": {\n",
-        "                \"type\": \"object\",\n",
-        "                \"properties\": {\n",
-        "                    \"transaction_id\": {\n",
-        "                        \"type\": \"string\",\n",
-        "                        \"description\": \"The transaction id.\",\n",
-        "                    }\n",
-        "                },\n",
-        "                \"required\": [\"transaction_id\"],\n",
-        "            },\n",
-        "        },\n",
-        "    },\n",
-        "]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9DCJP8hN2X-c"
-      },
-      "source": [
-        "#### Step 2. Model: Generate the right tool and arguments with Mistral Large"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "fmhX-3FDy1vS"
-      },
-      "outputs": [],
-      "source": [
-        "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}:rawPredict\"\n",
-        "data = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"messages\": [\n",
-        "        {\"role\": \"user\", \"content\": \"What is the status of my transaction T1001?\"}\n",
-        "    ],\n",
-        "    \"tools\": tools,\n",
-        "    \"tool_choice\": \"any\",\n",
-        "}\n",
-        "function_name = None\n",
-        "function_params = None\n",
-        "\n",
-        "# Make the POST request\n",
-        "response = requests.post(url, headers=headers, json=data)\n",
-        "\n",
-        "# Check status code and try to parse the response as JSON\n",
-        "if response.status_code == 200:\n",
-        "    try:\n",
-        "        response_dict = response.json()\n",
-        "        tool_call = response_dict[\"choices\"][0][\"message\"][\"tool_calls\"][0]\n",
-        "        function_name = tool_call[\"function\"][\"name\"]\n",
-        "        function_params = json.loads(tool_call[\"function\"][\"arguments\"])\n",
-        "    except json.JSONDecodeError as e:\n",
-        "        print(\"Error decoding JSON:\", e)\n",
-        "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
-        "else:\n",
-        "    print(f\"Request failed with status code: {response.status_code}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EkG59Jsg1hnE"
-      },
-      "source": [
-        "#### Step 3. User: Extract the tool function name, the params and execute the tool function"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rQHeV3Qz032W"
-      },
-      "outputs": [],
-      "source": [
-        "if function_name and function_params:\n",
-        "    print(\"\\nfunction_name: \", function_name, \"\\nfunction_params: \", function_params)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5-nOJR6hCpYz"
-      },
-      "source": [
-        "Map function names returned by Mistral model to the actual function object in the environment."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "W30ACckn2N_F"
-      },
-      "outputs": [],
-      "source": [
-        "import functools\n",
-        "\n",
-        "names_to_functions = {\n",
-        "    \"retrieve_payment_status\": functools.partial(retrieve_payment_status, df=df),\n",
-        "    \"retrieve_payment_date\": functools.partial(retrieve_payment_date, df=df),\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "78S2e-TOCyQn"
-      },
-      "source": [
-        "Call the right function with the parameters suggested by Mistral's model."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "5Pk7XszE1nXI"
-      },
-      "outputs": [],
-      "source": [
-        "if function_name and function_params:\n",
-        "    function_result = names_to_functions[function_name](**function_params)\n",
-        "    function_result"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nbEuWr3M922W"
-      },
-      "source": [
-        "### JSON Output Mode\n",
-        "\n",
-        "You can force the response format to JSON by adding `\"response_format\": {\"type\": \"json_object\"}` in the JSON payload of the request\n",
-        "See Mistral's documentation on JSON mode\n",
-        "\n",
-        "*   See Mistral's [documentation](https://docs.mistral.ai/capabilities/json_mode/) on JSON mode\n",
-        "*   See Mistral's API [documentation](https://docs.mistral.ai/api/#operation/createChatCompletion)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Y-695Dyt-Q9V"
-      },
-      "outputs": [],
-      "source": [
-        "PAYLOAD = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"messages\": [\n",
-        "        {\n",
-        "            \"role\": \"user\",\n",
-        "            \"content\": \"What is the best French cheese? Return the product and produce location in JSON format\",\n",
-        "        }\n",
-        "    ],\n",
-        "    \"response_format\": {\"type\": \"json_object\"},\n",
-        "}\n",
-        "\n",
-        "request = json.dumps(PAYLOAD)\n",
-        "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}:rawPredict -d '{request}'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7DQlJjz7DXDu"
-      },
-      "source": [
-        "Pretty response"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ky1TDqhc-bur"
-      },
-      "outputs": [],
-      "source": [
-        "# Get the access token\n",
-        "process = subprocess.Popen(\n",
-        "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
-        ")\n",
-        "(access_token_bytes, err) = process.communicate()\n",
-        "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
-        "\n",
-        "# Replace with your actual values\n",
-        "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}:rawPredict\"\n",
-        "data = {\n",
-        "    \"model\": MODEL,\n",
-        "    \"messages\": [\n",
-        "        {\n",
-        "            \"role\": \"user\",\n",
-        "            \"content\": \"What is the best French cheese? Return the product and produce location in JSON format\",\n",
-        "        }\n",
-        "    ],\n",
-        "    \"response_format\": {\"type\": \"json_object\"},\n",
-        "}\n",
-        "headers = {\n",
-        "    \"Authorization\": f\"Bearer {access_token}\",\n",
-        "    \"Content-Type\": \"application/json\",\n",
-        "}\n",
-        "\n",
-        "# Make the POST request\n",
-        "response = requests.post(url, headers=headers, json=data)\n",
-        "\n",
-        "# Check status code and try to parse the response as JSON\n",
-        "if response.status_code == 200:\n",
-        "    try:\n",
-        "        response_dict = response.json()\n",
-        "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
-        "    except json.JSONDecodeError as e:\n",
-        "        print(\"Error decoding JSON:\", e)\n",
-        "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
-        "else:\n",
-        "    print(f\"Request failed with status code: {response.status_code}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JEbcSlVTqToe"
-      },
-      "source": [
-        "### Leveraging multimodal inputs (images and text)\n",
-        "\n",
-        "When using a multimodal model like `mistral-small-2503` it is possible to pass images as input in addition to text. To do so, you will need to encode the image in base64 and pass it inside an `image_url` content block:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "SRckVQXkqToe"
-      },
-      "outputs": [],
-      "source": [
-        "MM_MODEL = \"mistral-small-2503\"\n",
-        "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MM_MODEL}:rawPredict\"\n",
-        "data = {\n",
-        "    \"model\": MM_MODEL,\n",
-        "    \"messages\": [\n",
-        "        {\n",
-        "            \"role\": \"user\",\n",
-        "            \"content\": [\n",
-        "                {\"type\": \"text\", \"text\": \"What is in this image ?\"},\n",
-        "                {\n",
-        "                    \"type\": \"image_url\",\n",
-        "                    \"image_url\": \"data:image/jpeg;base64,<your_base64_image>\",\n",
-        "                },\n",
-        "            ],\n",
-        "        }\n",
-        "    ],\n",
-        "}\n",
-        "headers = {\n",
-        "    \"Authorization\": f\"Bearer {access_token}\",\n",
-        "    \"Content-Type\": \"application/json\",\n",
-        "}\n",
-        "\n",
-        "# Make the POST request\n",
-        "response = requests.post(url, headers=headers, json=data)\n",
-        "\n",
-        "# Check status code and try to parse the response as JSON\n",
-        "if response.status_code == 200:\n",
-        "    try:\n",
-        "        response_dict = response.json()\n",
-        "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
-        "    except json.JSONDecodeError as e:\n",
-        "        print(\"Error decoding JSON:\", e)\n",
-        "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
-        "else:\n",
-        "    print(f\"Request failed with status code: {response.status_code}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "znQtFeXUqToe"
-      },
-      "source": [
-        "### Performing OCR\n",
-        "\n",
-        "Mistral OCR (`mistral-ocr-2505`) is an Optical Character Recognition API that sets a new standard in document understanding. Unlike other models, Mistral OCR comprehends each element of documents: images, text, tables, equations, etc. It takes images and PDFs as input and extracts content in an ordered interleaved text and images.\n",
-        "\n",
-        "The following example showcases the application of the OCR API on a PDF file."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "KRaYEGJ1qToe"
-      },
-      "outputs": [],
-      "source": [
-        "import base64\n",
-        "\n",
-        "# The URL you provided\n",
-        "pdf_url = \"https://arxiv.org/pdf/2501.12948\"\n",
-        "\n",
-        "# 1. Download the file\n",
-        "print(f\"Attempting to download from: {pdf_url}\")\n",
-        "response = requests.get(pdf_url)\n",
-        "pdf_content_bytes = response.content\n",
-        "\n",
-        "# 2. Base64 encode the downloaded content\n",
-        "encoded_content_bytes = base64.b64encode(pdf_content_bytes)\n",
-        "encoded_string = encoded_content_bytes.decode(\"utf-8\")\n",
-        "\n",
-        "print(\"Download and encoding complete.\")\n",
-        "\n",
-        "pdf_doc_base64_uri = f\"data:application/pdf;base64,{encoded_string}\"\n",
-        "\n",
-        "# print(pdf_doc_base64_uri)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Tn3sECpRqToj"
-      },
-      "outputs": [],
-      "source": [
-        "# Get the access token\n",
-        "process = subprocess.Popen(\n",
-        "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
-        ")\n",
-        "(access_token_bytes, err) = process.communicate()\n",
-        "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
-        "\n",
-        "OCR_MODEL = \"mistral-ocr-2505\"\n",
-        "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{OCR_MODEL}:rawPredict\"\n",
-        "data = {\n",
-        "    \"model\": OCR_MODEL,\n",
-        "    \"document\": {\"type\": \"document_url\", \"document_url\": pdf_doc_base64_uri},\n",
-        "}\n",
-        "headers = {\n",
-        "    \"Authorization\": f\"Bearer {access_token}\",\n",
-        "    \"Content-Type\": \"application/json\",\n",
-        "}\n",
-        "\n",
-        "# Make the POST request\n",
-        "response = requests.post(url, headers=headers, json=data)\n",
-        "\n",
-        "# Check status code and try to parse the response as JSON\n",
-        "if response.status_code == 200:\n",
-        "    try:\n",
-        "        response_dict = response.json()\n",
-        "        print(response_dict)\n",
-        "    except json.JSONDecodeError as e:\n",
-        "        print(\"Error decoding JSON:\", e)\n",
-        "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
-        "else:\n",
-        "    print(f\"Request failed with status code: {response.status_code}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "CmpLW-IEqToj"
-      },
-      "source": [
-        "To get more details on the options available when calling the OCR API, please refer to the [Mistral API documentation](https://docs.mistral.ai/api/#tag/ocr)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "da51562946ab"
-      },
-      "source": [
-        "## Using Mistral AI models in self-deploy mode\n",
-        "\n",
-        "The following models can be self-deployed on your own Google Cloud infrastructure:\n",
-        "\n",
-        "- `codestral-2501`\n",
-        "\n",
-        "Once the model has been procured and deployed, you can run inference on it by going through the following steps.\n",
-        "\n",
-        "- First, gather the required information element to build the URL of your deployed endpoint, namely:\n",
-        "  - Your Google Cloud Project ID\n",
-        "  - The name of the deployed model\n",
-        "  - The region where your model endpoint is deployed\n",
-        "  - Your model endpoint's ID\n",
-        "\n",
-        "  Most of these elements are referenced as environment variables in the cell below, which contains two functions:\n",
-        "\n",
-        "  - `get_access_token()` returns a credential object and extracts an access token to authenticate your API calls to the model endpoint,\n",
-        "  - `build_endpoint_url()` return your model endpoint's URL."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "82df0a0edf76"
-      },
-      "outputs": [],
-      "source": [
-        "import google.auth\n",
-        "import google.auth.credentials\n",
-        "import httpx\n",
-        "from google.auth.transport.requests import Request\n",
-        "\n",
-        "\n",
-        "def get_access_token() -> str:\n",
-        "    credentials, _ = google.auth.default(\n",
-        "        scopes=[\"https://www.googleapis.com/auth/cloud-platform\"]\n",
-        "    )\n",
-        "    credentials.refresh(Request())\n",
-        "    return credentials.token\n",
-        "\n",
-        "\n",
-        "def build_endpoint_url(\n",
-        "    project_id: str, region: str, endpoint_id: str, is_streamed: bool = False\n",
-        ") -> str:\n",
-        "    base_url = f\"https://{region}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{region}\"\n",
-        "    suffix = \"streamRawPredict\" if is_streamed else \"rawPredict\"\n",
-        "    endpoint_url = f\"{base_url}/endpoints/{endpoint_id}:{suffix}\"\n",
-        "    return endpoint_url"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "812ef74c57df"
-      },
-      "source": [
-        "- Next, run these functions to retrieve your model endpoint URL and the access token:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ba2c1a073d76"
-      },
-      "outputs": [],
-      "source": [
-        "project_id = \"\"  # Add your Google Cloud Project ID here\n",
-        "region = \"\"  # Add your Google Cloud Region here\n",
-        "endpoint_id = \"\"  # Add the Vertex endpoint ID of your deployed model here\n",
-        "model = \"codestral-2501-self-deploy\"\n",
-        "\n",
-        "url = build_endpoint_url(project_id=project_id, region=region, endpoint_id=endpoint_id)\n",
-        "token = get_access_token()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "a0bb2730f5e3"
-      },
-      "source": [
-        "- Finally, make the HTTP call to your model endpoint URL with the input of your choice. If your request runs successfully, you should retrieve a response containing the model's answer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "b104599c4d25"
-      },
-      "outputs": [],
-      "source": [
-        "is_streamed = False\n",
-        "user_message_content = \"Who is the best French painter? Answer in one short sentence\"\n",
-        "\n",
-        "headers = {\"Accept\": \"application/json\", \"Authorization\": f\"Bearer {token}\"}\n",
-        "payload = {\n",
-        "    \"model\": model,\n",
-        "    \"messages\": [{\"role\": \"user\", \"content\": user_message_content}],\n",
-        "    \"stream\": is_streamed,\n",
-        "}\n",
-        "url = build_endpoint_url(project_id=project_id, region=region, endpoint_id=endpoint_id)\n",
-        "\n",
-        "with httpx.Client() as client:\n",
-        "    resp = client.post(url=url, json=payload, headers=headers, timeout=None)\n",
-        "    print(resp.text)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "89e4f9bf981f"
-      },
-      "source": [
-        "From there you can tune your requests to match the capabilities of the regular serverless endpoints by streaming output tokens, leveraging tool use or performing FIM completion (for Codestral only), etc."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "mistralai_intro.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "9A9NkTRTfo2I"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IPprg6Oz0QDs"
+   },
+   "source": [
+    "# Getting Started with Mistral AI Models\n",
+    "<table align=\"left\">\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_intro.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fgenerative_ai%2Fmistralai_intro.ipynb\">\n",
+    "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">                                                                             \n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/notebooks/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/generative_ai/mistralai_intro.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_intro.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  \n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dFkhRcsaqToV"
+   },
+   "source": [
+    "NOTE: This notebook has been tested in the following environment:\n",
+    "\n",
+    "Python version = 3.10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8fK_rdvvx1iZ"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "### Mistral AI on Vertex AI\n",
+    "\n",
+    "Mistral AI models on Vertex AI offer fully managed and serverless models are offered as managed APIs. To use a Mistral AI model on Vertex AI, send a request directly to the Vertex AI API endpoint.\n",
+    "\n",
+    "You can stream your Mistral AI model responses to reduce the end-user latency perception. A streamed response uses server-sent events (SSE) to incrementally stream the response.\n",
+    "\n",
+    "Learn more about [Vertex AI](https://cloud.google.com/vertex-ai).\n",
+    "\n",
+    "### Available Mistral AI models\n",
+    "\n",
+    "*   ### Mistral Small 3.1 (25.03)\n",
+    "Mistral Small 3.1 (25.03) is the enhanced version of Mistral Small 3, featuring multimodal capabilities and an extended context length of up to 128k.\n",
+    "\n",
+    "*   ### Codestral (25.01)\n",
+    "A cutting-edge model specifically designed for code generation, including fill-in-the-middle and code completion.\n",
+    "\n",
+    "*   ### Mistral Large (24.11)\n",
+    "Mistral Large (24.11) is the latest version of the Mistral Large model now with improved reasoning and function calling capabilities.\n",
+    "\n",
+    "*   ### Mistral Nemo\n",
+    "Reasoning, world knowledge, and coding performance are state-of-the-art in its size category.\n",
+    "\n",
+    "\n",
+    "## Objective\n",
+    "\n",
+    "This notebook shows how to use **Vertex AI API** to call the Mistral AI models.\n",
+    "\n",
+    "For more information, see the [Use Mistral's](https://docs.mistral.ai/) documentation and [Mistral's models](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/mistral) on Google Cloud.\n",
+    "\n",
+    "- Mistral on Model Garden supports the same API calls as Mistral’s own API endpoints, except for the `safe_prompt` parameter that will return an error if specified in the input. So do not include `safe_prompt` in input requests.\n",
+    "- Documentation links\n",
+    "  - [Mistral APIs](https://docs.mistral.ai/api/)\n",
+    "  - [Chat Completion](https://docs.mistral.ai/api/#operation/createChatCompletion) operations supported by Mistral Large, Mistral Nemo and Codestral\n",
+    "  - [Fill-in-the-middle](https://docs.mistral.ai/api/#operation/createFIMCompletion) operations supported by Codestral"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HcJCV6Dw5usD"
+   },
+   "source": [
+    "## Vertex AI API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nwYvaaW25jYS"
+   },
+   "source": [
+    "## Get Started - Required first steps\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6a5bea26f60f"
+   },
+   "source": [
+    "### Authenticate your notebook environment (Colab only)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "c97be6a73155"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2fxZn4SAbxdl"
+   },
+   "source": [
+    "#### Select one of Mistral AI models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Y8X70FTSbx7U"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL = \"mistral-small-2503\"  # @param [\"mistral-small-2503\", \"codestral-2501\", \"mistral-large-2411\", \"mistral-nemo\"]\n",
+    "if MODEL == \"mistral-small-2503\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\"]\n",
+    "elif MODEL == \"mistral-large-2411\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\"]\n",
+    "elif MODEL == \"mistral-nemo\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"2407\"]\n",
+    "elif MODEL == \"codestral-2501\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bpuX3sKtexlK"
+   },
+   "source": [
+    "#### Select a location and a version from the dropdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dHl8xW45ex_O"
+   },
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "dropdown_loc = widgets.Dropdown(\n",
+    "    options=available_regions,\n",
+    "    description=\"Select a location:\",\n",
+    "    font_weight=\"bold\",\n",
+    "    style={\"description_width\": \"initial\"},\n",
+    ")\n",
+    "\n",
+    "dropdown_ver = widgets.Dropdown(\n",
+    "    options=available_versions,\n",
+    "    description=\"Select the model version (optional):\",\n",
+    "    font_weight=\"bold\",\n",
+    "    style={\"description_width\": \"initial\"},\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def dropdown_loc_eventhandler(change):\n",
+    "    global LOCATION\n",
+    "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
+    "        LOCATION = change.new\n",
+    "        print(\"Selected:\", change.new)\n",
+    "\n",
+    "\n",
+    "def dropdown_ver_eventhandler(change):\n",
+    "    global MODEL_VERSION\n",
+    "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
+    "        MODEL_VERSION = change.new\n",
+    "        print(\"Selected:\", change.new)\n",
+    "\n",
+    "\n",
+    "LOCATION = dropdown_loc.value\n",
+    "dropdown_loc.observe(dropdown_loc_eventhandler, names=\"value\")\n",
+    "display(dropdown_loc)\n",
+    "\n",
+    "MODEL_VERSION = dropdown_ver.value\n",
+    "dropdown_ver.observe(dropdown_ver_eventhandler, names=\"value\")\n",
+    "display(dropdown_ver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3q58icinBjoK"
+   },
+   "source": [
+    "#### Set Google Cloud project and model information\n",
+    "\n",
+    "To get started using Vertex AI, you must have an existing Google Cloud project and [enable the Vertex AI API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com). Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hltNx33t6cSZ"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "ENDPOINT = f\"https://{LOCATION}-aiplatform.googleapis.com\"\n",
+    "SELECTED_MODEL_VERSION = \"\" if MODEL_VERSION == \"latest\" else f\"@{MODEL_VERSION}\"\n",
+    "\n",
+    "if not PROJECT_ID or PROJECT_ID == \"[your-project-id]\":\n",
+    "    raise ValueError(\"Please set your PROJECT_ID\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4NAstKRFBt4N"
+   },
+   "source": [
+    "#### Import required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QZEFLE6a6bqy"
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import subprocess\n",
+    "\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vVVnOhvE_PA6"
+   },
+   "source": [
+    "### Sample Requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5ahw-uFjCAbo"
+   },
+   "source": [
+    "#### Text generation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "61107099357a"
+   },
+   "source": [
+    "##### Unary call\n",
+    "\n",
+    "Sends a POST request to the specified API endpoint to get a response from the model using the provided payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4zFz260B50oi"
+   },
+   "outputs": [],
+   "source": [
+    "PAYLOAD = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"messages\": [{\"role\": \"user\", \"content\": \"who is the best French painter?\"}],\n",
+    "    \"max_tokens\": 100,\n",
+    "    \"stream\": False,\n",
+    "}\n",
+    "\n",
+    "request = json.dumps(PAYLOAD)\n",
+    "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:rawPredict -d '{request}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tf56XLe1EZos"
+   },
+   "source": [
+    "With a pretty response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "L90Kdr-PEYr3"
+   },
+   "outputs": [],
+   "source": [
+    "# Get the access token\n",
+    "process = subprocess.Popen(\n",
+    "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
+    ")\n",
+    "(access_token_bytes, err) = process.communicate()\n",
+    "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
+    "\n",
+    "# Define query headers\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {access_token}\",\n",
+    "    \"Accept\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "# Replace with your actual values\n",
+    "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:rawPredict\"\n",
+    "data = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"messages\": [{\"role\": \"user\", \"content\": \"who is the best French painter?\"}],\n",
+    "    \"stream\": False,\n",
+    "}\n",
+    "\n",
+    "# Make the POST request\n",
+    "response = requests.post(url, headers=headers, json=data)\n",
+    "\n",
+    "# Check status code and try to parse the response as JSON\n",
+    "if response.status_code == 200:\n",
+    "    try:\n",
+    "        response_dict = response.json()\n",
+    "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        print(\"Error decoding JSON:\", e)\n",
+    "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
+    "else:\n",
+    "    print(f\"Request failed with status code: {response.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e6f52fae9379"
+   },
+   "source": [
+    "##### Streaming call\n",
+    "\n",
+    "Sends a POST request to the specified API endpoint to stream a response from the model using the provided payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "c99761dcd7da"
+   },
+   "outputs": [],
+   "source": [
+    "PAYLOAD = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"messages\": [{\"role\": \"user\", \"content\": \"who is the best French painter?\"}],\n",
+    "    \"max_tokens\": 100,\n",
+    "    \"stream\": True,\n",
+    "}\n",
+    "\n",
+    "request = json.dumps(PAYLOAD)\n",
+    "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:streamRawPredict -d '{request}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X6HolebUhShT"
+   },
+   "source": [
+    "#### Code generation\n",
+    "\n",
+    "Mistral Large, Mistral Nemo and Codestral support code generation with the Chat Completion operations covered above.\n",
+    "\n",
+    "With Codestral, you can also do Fill-in-the-middle operations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "deUZQwgSheEr"
+   },
+   "source": [
+    "##### Fill-in-the-middle (FIM)\n",
+    "With this feature, users can define the starting point of the code using a `prompt`, and the ending point of the code using an optional `suffix` and an optional `stop`.\n",
+    "\n",
+    "The Codestral model will then generate the code that fits in between, making it ideal for tasks that require a specific piece of code to be generated.\n",
+    "\n",
+    "More information on FIM:\n",
+    "- [Mistral API Documentation FIM](https://docs.mistral.ai/api/#operation/createFIMCompletion)\n",
+    "- [Mistral FIM Documentation](https://docs.mistral.ai/capabilities/code_generation/#fill-in-the-middle-endpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5JzsH7TmujqR"
+   },
+   "source": [
+    "Example 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0zXL4RrnhRLG"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL = \"codestral-2501\"  # use \"codestral\" for Codestral (24.05)\n",
+    "SELECTED_MODEL_VERSION = \"\"  # use \"@2405\" for Codestral (24.05)\n",
+    "\n",
+    "PAYLOAD = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"prompt\": \"def say_hello(name: str) -> str\",\n",
+    "    \"suffix\": \"return n_words\",\n",
+    "}\n",
+    "\n",
+    "request = json.dumps(PAYLOAD)\n",
+    "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:streamRawPredict -d '{request}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n6kMTcg5ulJD"
+   },
+   "source": [
+    "Example 2 with pretty response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ciJKueNfDman"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL = \"codestral-2501\"  # use \"codestral\" for Codestral (24.05)\n",
+    "SELECTED_MODEL_VERSION = \"\"  # use \"@2405\" for Codestral (24.05)\n",
+    "\n",
+    "# Get the access token\n",
+    "process = subprocess.Popen(\n",
+    "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
+    ")\n",
+    "(access_token_bytes, err) = process.communicate()\n",
+    "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
+    "\n",
+    "# Define query headers\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {access_token}\",\n",
+    "    \"Accept\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "# Replace with your actual values\n",
+    "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}{SELECTED_MODEL_VERSION}:rawPredict\"\n",
+    "data = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"prompt\": \"def f(\",\n",
+    "    \"suffix\": \"return a + b\",\n",
+    "    \"max_tokens\": 64,\n",
+    "    \"temperature\": 0,\n",
+    "}\n",
+    "\n",
+    "# Make the POST request\n",
+    "response = requests.post(url, headers=headers, json=data)\n",
+    "\n",
+    "# Check status code and try to parse the response as JSON\n",
+    "if response.status_code == 200:\n",
+    "    try:\n",
+    "        response_dict = response.json()\n",
+    "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        print(\"Error decoding JSON:\", e)\n",
+    "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
+    "else:\n",
+    "    print(f\"Request failed with status code: {response.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-G8kI3S_FUjM"
+   },
+   "source": [
+    "## Using Mistral AI's Vertex SDK for *Python*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pdzqqcJKOYHa"
+   },
+   "source": [
+    "## Get Started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_TGDKo-vFn5F"
+   },
+   "source": [
+    "### Install Mistral's Vertex SDK for Python and other required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2AdfzWYfFw3u"
+   },
+   "outputs": [],
+   "source": [
+    "! pip3 install -U -q 'mistralai[gcp]>=1.2.4'\n",
+    "! pip3 install -U -q httpx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mTbP9RNlF1nO"
+   },
+   "source": [
+    "### Restart runtime (Colab only)\n",
+    "\n",
+    "To use the newly installed packages, you must restart the runtime on Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "FCjYtEc8F437"
+   },
+   "outputs": [],
+   "source": [
+    "# Restart kernel after installs so that your environment can access the new packages\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    import IPython\n",
+    "\n",
+    "    app = IPython.Application.instance()\n",
+    "    app.kernel.do_shutdown(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Fgq8ZhyuF8wx"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "d3nepikRF_Gt"
+   },
+   "source": [
+    "### Authenticate your notebook environment (Colab only)\n",
+    "\n",
+    "Authenticate your environment on Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Z9EvH5iez_n_"
+   },
+   "outputs": [],
+   "source": [
+    "# Get the access token\n",
+    "import subprocess\n",
+    "\n",
+    "process = subprocess.Popen(\n",
+    "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
+    ")\n",
+    "(access_token_bytes, err) = process.communicate()\n",
+    "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
+    "\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {access_token}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-qgHPk0IGBZX"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7ICjT5ZNGF2c"
+   },
+   "source": [
+    "#### Select one of Mistral AI models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-oqhRyb5-g6I"
+   },
+   "source": [
+    "**Note**: New Mistral Models will have python SDK supported in the upcoming versions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NBRTMXhmGIlN"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL = \"mistral-small-2503\"  # @param [\"mistral-small-2503\", \"mistral-large\", \"mistral-nemo\", \"codestral-2501\"]\n",
+    "\n",
+    "if MODEL == \"mistral-small-2503\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\"]\n",
+    "elif MODEL == \"mistral-large\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\", \"2411\"]\n",
+    "elif MODEL == \"mistral-nemo\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\", \"2407\"]\n",
+    "elif MODEL == \"codestral-2501\":\n",
+    "    available_regions = [\"europe-west4\", \"us-central1\"]\n",
+    "    available_versions = [\"latest\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "227_bG2OGNec"
+   },
+   "source": [
+    "#### Select a location and a version from the dropdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uoP1c89sGP7k"
+   },
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "dropdown_loc = widgets.Dropdown(\n",
+    "    options=available_regions,\n",
+    "    description=\"Select a location:\",\n",
+    "    font_weight=\"bold\",\n",
+    "    style={\"description_width\": \"initial\"},\n",
+    ")\n",
+    "\n",
+    "dropdown_ver = widgets.Dropdown(\n",
+    "    options=available_versions,\n",
+    "    description=\"Select the model version (optional):\",\n",
+    "    font_weight=\"bold\",\n",
+    "    style={\"description_width\": \"initial\"},\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def dropdown_loc_eventhandler(change):\n",
+    "    global LOCATION\n",
+    "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
+    "        LOCATION = change.new\n",
+    "        print(\"Selected:\", change.new)\n",
+    "\n",
+    "\n",
+    "def dropdown_ver_eventhandler(change):\n",
+    "    global MODEL_VERSION\n",
+    "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
+    "        MODEL_VERSION = change.new\n",
+    "        print(\"Selected:\", change.new)\n",
+    "\n",
+    "\n",
+    "LOCATION = dropdown_loc.value\n",
+    "dropdown_loc.observe(dropdown_loc_eventhandler, names=\"value\")\n",
+    "display(dropdown_loc)\n",
+    "\n",
+    "MODEL_VERSION = dropdown_ver.value\n",
+    "dropdown_ver.observe(dropdown_ver_eventhandler, names=\"value\")\n",
+    "display(dropdown_ver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mghCnsVbK5YP"
+   },
+   "source": [
+    "#### Set Google Cloud project and model information\n",
+    "\n",
+    "To get started using Vertex AI, you must have an existing Google Cloud project and [enable the Vertex AI API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com). Learn more about [setting up a project and a development environment](https://cloud.google.com/vertex-ai/docs/start/cloud-environment)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NB-_kGiJLDcT"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "ENDPOINT = f\"https://{LOCATION}-aiplatform.googleapis.com\"\n",
+    "\n",
+    "if not PROJECT_ID or PROJECT_ID == \"[your-project-id]\":\n",
+    "    raise ValueError(\"Please set your PROJECT_ID\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yD9oKNOGMA18"
+   },
+   "source": [
+    "#### Import required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hgmj4wwLMYgd"
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pQnpW1WLO3uX"
+   },
+   "source": [
+    "### Sample Requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tH0QFYIXMZNZ"
+   },
+   "source": [
+    "#### Text generation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tm2rUyXtPgp2"
+   },
+   "source": [
+    "##### Unary call\n",
+    "\n",
+    "Initializes a client for Mistral AI's Vertex AI, sends a request to generate the content, and prints the response in a formatted JSON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cRqiGVUdMgXs"
+   },
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "from mistralai_gcp import MistralGoogleCloud\n",
+    "\n",
+    "client = MistralGoogleCloud(\n",
+    "    access_token=access_token, region=LOCATION, project_id=PROJECT_ID\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    resp = client.chat.complete(\n",
+    "        model=f\"{MODEL}\",\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": \"Who is the best French painter? Answer in one short sentence.\",\n",
+    "            }\n",
+    "        ],\n",
+    "    )\n",
+    "    print(resp.choices[0].message.content)\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"An error occurred: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EWkLsn5GQrqu"
+   },
+   "source": [
+    "##### Streaming call\n",
+    "\n",
+    "Initializes a client for Mistral AI's Vertex AI, sends a streaming request to generate the content, and continuously prints the received text as it is streamed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2uOfrmmRQ-rJ"
+   },
+   "outputs": [],
+   "source": [
+    "from mistralai_gcp import MistralGoogleCloud\n",
+    "\n",
+    "client = MistralGoogleCloud(\n",
+    "    access_token=access_token, region=LOCATION, project_id=PROJECT_ID\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    stream = client.chat.stream(\n",
+    "        model=f\"{MODEL}\",\n",
+    "        max_tokens=1024,\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": \"Who is the best French painter? Answer in one short sentence.\",\n",
+    "            }\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    for chunk in stream:\n",
+    "        print(chunk.data.choices[0].delta.content)\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"An error occurred: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PEZcdznmRxT6"
+   },
+   "source": [
+    "#### Code generation\n",
+    "\n",
+    "Mistral Large, Mistral Nemo and Codestral support code generation with the Chat Completion operations covered above.\n",
+    "\n",
+    "With Codestral, you can also do Fill-in-the-middle operations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BWl3pMDOXdEZ"
+   },
+   "source": [
+    "##### Fill-in-the-middle (FIM)\n",
+    "With this feature, users can define the starting point of the code using a `prompt`, and the ending point of the code using an optional `suffix` and an optional `stop`.\n",
+    "\n",
+    "The Codestral model will then generate the code that fits in between, making it ideal for tasks that require a specific piece of code to be generated.\n",
+    "\n",
+    "More information on FIM:\n",
+    "- [Mistral API Documentation FIM](https://docs.mistral.ai/api/#operation/createFIMCompletion)\n",
+    "- [Mistral FIM Documentation](https://docs.mistral.ai/capabilities/code_generation/#fill-in-the-middle-endpoint)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "o61l9pOsTUc-"
+   },
+   "outputs": [],
+   "source": [
+    "from mistralai_gcp import MistralGoogleCloud\n",
+    "\n",
+    "client = MistralGoogleCloud(\n",
+    "    access_token=access_token, region=LOCATION, project_id=PROJECT_ID\n",
+    ")\n",
+    "\n",
+    "MODEL = \"codestral-2501\"\n",
+    "MODEL_VERSION = \"2501\"\n",
+    "\n",
+    "try:\n",
+    "    resp = client.fim.complete(\n",
+    "        model=f\"{MODEL}\",\n",
+    "        prompt=\"def count_words_in_file(file_path: str) -> int\",\n",
+    "        suffix=\"return n_words\",\n",
+    "    )\n",
+    "\n",
+    "    print(resp.choices[0].message.content)\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"An error occurred: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qsJLkqyyztR_"
+   },
+   "source": [
+    "## Model Capabilities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TfmwOYBXxcQG"
+   },
+   "source": [
+    "### Function Calling with Mistral Large\n",
+    "\n",
+    "Function calling allows Mistral models to connect to external tools. By integrating Mistral models with external tools such as user defined functions or APIs, users can easily build applications catering to specific use cases and practical problems.\n",
+    "\n",
+    "This guide is the one Mistral provides [here](https://docs.mistral.ai/capabilities/function_calling/). We write two functions for tracking payment status and payment date. We can use these two tools to provide answers for payment-related queries."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nLmoam_z0OfN"
+   },
+   "source": [
+    "#### Step 1. User: specify tools\n",
+    "\n",
+    "Define sample data like this was stored in a sample database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Oak2cRcgx7VB"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Assuming we have the following data\n",
+    "data = {\n",
+    "    \"transaction_id\": [\"T1001\", \"T1002\", \"T1003\", \"T1004\", \"T1005\"],\n",
+    "    \"customer_id\": [\"C001\", \"C002\", \"C003\", \"C002\", \"C001\"],\n",
+    "    \"payment_amount\": [125.50, 89.99, 120.00, 54.30, 210.20],\n",
+    "    \"payment_date\": [\n",
+    "        \"2021-10-05\",\n",
+    "        \"2021-10-06\",\n",
+    "        \"2021-10-07\",\n",
+    "        \"2021-10-05\",\n",
+    "        \"2021-10-08\",\n",
+    "    ],\n",
+    "    \"payment_status\": [\"Paid\", \"Unpaid\", \"Paid\", \"Paid\", \"Pending\"],\n",
+    "}\n",
+    "\n",
+    "# Create DataFrame\n",
+    "df = pd.DataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cxb7_m9UxxmW"
+   },
+   "source": [
+    "Define the functions that will be used as tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pfOuDWlYxdvL"
+   },
+   "outputs": [],
+   "source": [
+    "def retrieve_payment_status(df: data, transaction_id: str) -> str:\n",
+    "    if transaction_id in df.transaction_id.values:\n",
+    "        return json.dumps(\n",
+    "            {\"status\": df[df.transaction_id == transaction_id].payment_status.item()}\n",
+    "        )\n",
+    "    return json.dumps({\"error\": \"transaction id not found.\"})\n",
+    "\n",
+    "\n",
+    "def retrieve_payment_date(df: data, transaction_id: str) -> str:\n",
+    "    if transaction_id in df.transaction_id.values:\n",
+    "        return json.dumps(\n",
+    "            {\"date\": df[df.transaction_id == transaction_id].payment_date.item()}\n",
+    "        )\n",
+    "    return json.dumps({\"error\": \"transaction id not found.\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "66OSfAKVyJnn"
+   },
+   "source": [
+    "Define the tools for those functions following the right JSON format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "o5xBTtIGxzRS"
+   },
+   "outputs": [],
+   "source": [
+    "tools = [\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"retrieve_payment_status\",\n",
+    "            \"description\": \"Get payment status of a transaction\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\n",
+    "                    \"transaction_id\": {\n",
+    "                        \"type\": \"string\",\n",
+    "                        \"description\": \"The transaction id.\",\n",
+    "                    }\n",
+    "                },\n",
+    "                \"required\": [\"transaction_id\"],\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"retrieve_payment_date\",\n",
+    "            \"description\": \"Get payment date of a transaction\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\n",
+    "                    \"transaction_id\": {\n",
+    "                        \"type\": \"string\",\n",
+    "                        \"description\": \"The transaction id.\",\n",
+    "                    }\n",
+    "                },\n",
+    "                \"required\": [\"transaction_id\"],\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9DCJP8hN2X-c"
+   },
+   "source": [
+    "#### Step 2. Model: Generate the right tool and arguments with Mistral Large"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "fmhX-3FDy1vS"
+   },
+   "outputs": [],
+   "source": [
+    "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}:rawPredict\"\n",
+    "data = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"messages\": [\n",
+    "        {\"role\": \"user\", \"content\": \"What is the status of my transaction T1001?\"}\n",
+    "    ],\n",
+    "    \"tools\": tools,\n",
+    "    \"tool_choice\": \"any\",\n",
+    "}\n",
+    "function_name = None\n",
+    "function_params = None\n",
+    "\n",
+    "# Make the POST request\n",
+    "response = requests.post(url, headers=headers, json=data)\n",
+    "\n",
+    "# Check status code and try to parse the response as JSON\n",
+    "if response.status_code == 200:\n",
+    "    try:\n",
+    "        response_dict = response.json()\n",
+    "        tool_call = response_dict[\"choices\"][0][\"message\"][\"tool_calls\"][0]\n",
+    "        function_name = tool_call[\"function\"][\"name\"]\n",
+    "        function_params = json.loads(tool_call[\"function\"][\"arguments\"])\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        print(\"Error decoding JSON:\", e)\n",
+    "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
+    "else:\n",
+    "    print(f\"Request failed with status code: {response.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EkG59Jsg1hnE"
+   },
+   "source": [
+    "#### Step 3. User: Extract the tool function name, the params and execute the tool function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rQHeV3Qz032W"
+   },
+   "outputs": [],
+   "source": [
+    "if function_name and function_params:\n",
+    "    print(\"\\nfunction_name: \", function_name, \"\\nfunction_params: \", function_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5-nOJR6hCpYz"
+   },
+   "source": [
+    "Map function names returned by Mistral model to the actual function object in the environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "W30ACckn2N_F"
+   },
+   "outputs": [],
+   "source": [
+    "import functools\n",
+    "\n",
+    "names_to_functions = {\n",
+    "    \"retrieve_payment_status\": functools.partial(retrieve_payment_status, df=df),\n",
+    "    \"retrieve_payment_date\": functools.partial(retrieve_payment_date, df=df),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "78S2e-TOCyQn"
+   },
+   "source": [
+    "Call the right function with the parameters suggested by Mistral's model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5Pk7XszE1nXI"
+   },
+   "outputs": [],
+   "source": [
+    "if function_name and function_params:\n",
+    "    function_result = names_to_functions[function_name](**function_params)\n",
+    "    function_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nbEuWr3M922W"
+   },
+   "source": [
+    "### JSON Output Mode\n",
+    "\n",
+    "You can force the response format to JSON by adding `\"response_format\": {\"type\": \"json_object\"}` in the JSON payload of the request\n",
+    "See Mistral's documentation on JSON mode\n",
+    "\n",
+    "*   See Mistral's [documentation](https://docs.mistral.ai/capabilities/json_mode/) on JSON mode\n",
+    "*   See Mistral's API [documentation](https://docs.mistral.ai/api/#operation/createChatCompletion)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Y-695Dyt-Q9V"
+   },
+   "outputs": [],
+   "source": [
+    "PAYLOAD = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"messages\": [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": \"What is the best French cheese? Return the product and produce location in JSON format\",\n",
+    "        }\n",
+    "    ],\n",
+    "    \"response_format\": {\"type\": \"json_object\"},\n",
+    "}\n",
+    "\n",
+    "request = json.dumps(PAYLOAD)\n",
+    "!curl -X POST -H \"Authorization: Bearer $(gcloud auth print-access-token)\" -H \"Content-Type: application/json\" {ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}:rawPredict -d '{request}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7DQlJjz7DXDu"
+   },
+   "source": [
+    "Pretty response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ky1TDqhc-bur"
+   },
+   "outputs": [],
+   "source": [
+    "# Get the access token\n",
+    "process = subprocess.Popen(\n",
+    "    \"gcloud auth print-access-token\", stdout=subprocess.PIPE, shell=True\n",
+    ")\n",
+    "(access_token_bytes, err) = process.communicate()\n",
+    "access_token = access_token_bytes.decode(\"utf-8\").strip()  # Strip newline\n",
+    "\n",
+    "# Replace with your actual values\n",
+    "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MODEL}:rawPredict\"\n",
+    "data = {\n",
+    "    \"model\": MODEL,\n",
+    "    \"messages\": [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": \"What is the best French cheese? Return the product and produce location in JSON format\",\n",
+    "        }\n",
+    "    ],\n",
+    "    \"response_format\": {\"type\": \"json_object\"},\n",
+    "}\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {access_token}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "# Make the POST request\n",
+    "response = requests.post(url, headers=headers, json=data)\n",
+    "\n",
+    "# Check status code and try to parse the response as JSON\n",
+    "if response.status_code == 200:\n",
+    "    try:\n",
+    "        response_dict = response.json()\n",
+    "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        print(\"Error decoding JSON:\", e)\n",
+    "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
+    "else:\n",
+    "    print(f\"Request failed with status code: {response.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JEbcSlVTqToe"
+   },
+   "source": [
+    "### Leveraging multimodal inputs (images and text)\n",
+    "\n",
+    "When using a multimodal model like `mistral-small-2503` it is possible to pass images as input in addition to text. To do so, you will need to encode the image in base64 and pass it inside an `image_url` content block:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "SRckVQXkqToe"
+   },
+   "outputs": [],
+   "source": [
+    "MM_MODEL = \"mistral-small-2503\"\n",
+    "url = f\"{ENDPOINT}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/mistralai/models/{MM_MODEL}:rawPredict\"\n",
+    "data = {\n",
+    "    \"model\": MM_MODEL,\n",
+    "    \"messages\": [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": [\n",
+    "                {\"type\": \"text\", \"text\": \"What is in this image ?\"},\n",
+    "                {\n",
+    "                    \"type\": \"image_url\",\n",
+    "                    \"image_url\": \"data:image/jpeg;base64,<your_base64_image>\",\n",
+    "                },\n",
+    "            ],\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "headers = {\n",
+    "    \"Authorization\": f\"Bearer {access_token}\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "}\n",
+    "\n",
+    "# Make the POST request\n",
+    "response = requests.post(url, headers=headers, json=data)\n",
+    "\n",
+    "# Check status code and try to parse the response as JSON\n",
+    "if response.status_code == 200:\n",
+    "    try:\n",
+    "        response_dict = response.json()\n",
+    "        print(response_dict[\"choices\"][0][\"message\"][\"content\"])\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        print(\"Error decoding JSON:\", e)\n",
+    "        print(\"Raw response:\", response.text)  # Print raw response if parsing fails\n",
+    "else:\n",
+    "    print(f\"Request failed with status code: {response.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "da51562946ab"
+   },
+   "source": [
+    "## Using Mistral AI models in self-deploy mode\n",
+    "\n",
+    "The following models can be self-deployed on your own Google Cloud infrastructure:\n",
+    "\n",
+    "- `codestral-2501`\n",
+    "\n",
+    "Once the model has been procured and deployed, you can run inference on it by going through the following steps.\n",
+    "\n",
+    "- First, gather the required information element to build the URL of your deployed endpoint, namely:\n",
+    "  - Your Google Cloud Project ID\n",
+    "  - The name of the deployed model\n",
+    "  - The region where your model endpoint is deployed\n",
+    "  - Your model endpoint's ID\n",
+    "\n",
+    "  Most of these elements are referenced as environment variables in the cell below, which contains two functions:\n",
+    "\n",
+    "  - `get_access_token()` returns a credential object and extracts an access token to authenticate your API calls to the model endpoint,\n",
+    "  - `build_endpoint_url()` return your model endpoint's URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "82df0a0edf76"
+   },
+   "outputs": [],
+   "source": [
+    "import google.auth\n",
+    "import google.auth.credentials\n",
+    "import httpx\n",
+    "from google.auth.transport.requests import Request\n",
+    "\n",
+    "\n",
+    "def get_access_token() -> str:\n",
+    "    credentials, _ = google.auth.default(\n",
+    "        scopes=[\"https://www.googleapis.com/auth/cloud-platform\"]\n",
+    "    )\n",
+    "    credentials.refresh(Request())\n",
+    "    return credentials.token\n",
+    "\n",
+    "\n",
+    "def build_endpoint_url(\n",
+    "    project_id: str, region: str, endpoint_id: str, is_streamed: bool = False\n",
+    ") -> str:\n",
+    "    base_url = f\"https://{region}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{region}\"\n",
+    "    suffix = \"streamRawPredict\" if is_streamed else \"rawPredict\"\n",
+    "    endpoint_url = f\"{base_url}/endpoints/{endpoint_id}:{suffix}\"\n",
+    "    return endpoint_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "812ef74c57df"
+   },
+   "source": [
+    "- Next, run these functions to retrieve your model endpoint URL and the access token:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ba2c1a073d76"
+   },
+   "outputs": [],
+   "source": [
+    "project_id = \"\"  # Add your Google Cloud Project ID here\n",
+    "region = \"\"  # Add your Google Cloud Region here\n",
+    "endpoint_id = \"\"  # Add the Vertex endpoint ID of your deployed model here\n",
+    "model = \"codestral-2501-self-deploy\"\n",
+    "\n",
+    "url = build_endpoint_url(project_id=project_id, region=region, endpoint_id=endpoint_id)\n",
+    "token = get_access_token()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a0bb2730f5e3"
+   },
+   "source": [
+    "- Finally, make the HTTP call to your model endpoint URL with the input of your choice. If your request runs successfully, you should retrieve a response containing the model's answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "b104599c4d25"
+   },
+   "outputs": [],
+   "source": [
+    "is_streamed = False\n",
+    "user_message_content = \"Who is the best French painter? Answer in one short sentence\"\n",
+    "\n",
+    "headers = {\"Accept\": \"application/json\", \"Authorization\": f\"Bearer {token}\"}\n",
+    "payload = {\n",
+    "    \"model\": model,\n",
+    "    \"messages\": [{\"role\": \"user\", \"content\": user_message_content}],\n",
+    "    \"stream\": is_streamed,\n",
+    "}\n",
+    "url = build_endpoint_url(project_id=project_id, region=region, endpoint_id=endpoint_id)\n",
+    "\n",
+    "with httpx.Client() as client:\n",
+    "    resp = client.post(url=url, json=payload, headers=headers, timeout=None)\n",
+    "    print(resp.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "89e4f9bf981f"
+   },
+   "source": [
+    "From there you can tune your requests to match the capabilities of the regular serverless endpoints by streaming output tokens, leveraging tool use or performing FIM completion (for Codestral only), etc."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "mistralai_intro.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/notebooks/official/generative_ai/mistralai_intro.ipynb
+++ b/notebooks/official/generative_ai/mistralai_intro.ipynb
@@ -1544,7 +1544,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/official/generative_ai/mistralai_ocr.ipynb
+++ b/notebooks/official/generative_ai/mistralai_ocr.ipynb
@@ -1,0 +1,632 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e636548d-0b00-456e-a288-cc73d7a630df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21e4cf90-5f1f-44c2-b020-91ecb003bb77",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Mistral AI OCR\n",
+    "<table align=\"left\">\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fgenerative_ai%2Fmistralai_ocr.ipynb\">\n",
+    "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">                                                                             \n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/notebooks/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  \n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a94cdb15-82cf-477f-9f31-3a31574bdf91",
+   "metadata": {},
+   "source": [
+    "NOTE: This notebook has been tested in the following environment:\n",
+    "\n",
+    "Python version = 3.10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4774e332-79af-48a5-b31a-17be51dd7caf",
+   "metadata": {},
+   "source": [
+    "## Objective\n",
+    "\n",
+    "Mistral OCR (25.05) is a model specialized in extracting text and images from documents. It is specifically built to preserve the structure of the document pages and automatically formats the extracted text in Markdown.\n",
+    "\n",
+    "The objective of this notebook is to provide a summary overview of the Mistral OCR (25.05) model's capabilities and how to leverage it using the Vertex AI platform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40d7a849-b291-4a09-8673-0f98989714bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U -q httpx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82aa1ec4-ca7a-424f-94d3-90e687d37152",
+   "metadata": {},
+   "source": [
+    "## Getting started\n",
+    "\n",
+    "Before proceeding further, fill in the following information:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2fcdc63-466c-4186-b9aa-3a77d11026b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"\"\n",
+    "REGION = \"\"\n",
+    "MODEL_NAME = \"mistral-ocr\"\n",
+    "MODEL_VERSION = \"2505\"\n",
+    "TEST_DOC_URL = \"https://arxiv.org/pdf/2410.07073\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a89e8159-46c6-4cf4-b8fd-acdb49ac1d1f",
+   "metadata": {},
+   "source": [
+    "As a developer, your first step is to authenticate your notebook environment. If you are using Google Colab to run it, the following cell should take care of the authentication, otherwise it will run the `gcloud` command to retrieve the access token needed to authenticate your API calls:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e27c2f-b324-458d-8526-163dc14f4bbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import subprocess\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "    auth.authenticate_user()\n",
+    "else:\n",
+    "    try:\n",
+    "        result = subprocess.run(\n",
+    "            [\"gcloud\", \"auth\", \"print-access-token\"],\n",
+    "            check=True,\n",
+    "            stdout=subprocess.PIPE,\n",
+    "            stderr=subprocess.PIPE,\n",
+    "            text=True\n",
+    "        )\n",
+    "        access_token = result.stdout.strip()\n",
+    "    except subprocess.CalledProcessError as e:\n",
+    "        print(f\"Error while running command: {e.stderr}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f8a5799-2806-47e2-b1ce-5d8dd3c58cdb",
+   "metadata": {},
+   "source": [
+    "## Calling the OCR model (HTTP)\n",
+    "\n",
+    "Start by defining a simple function that will help building the URL of your model endpoint:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eed6ee59-c4c0-4a02-aef5-3d28b049c285",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_endpoint_url(region: str, project_id: str, model_name: str, model_version: str) -> str:\n",
+    "    base_url = f\"https://{region}-aiplatform.googleapis.com/v1\"\n",
+    "    endpoint_url_segments = [\n",
+    "        base_url,\n",
+    "        f\"projects/{project_id}\",\n",
+    "        f\"locations/{region}\",\n",
+    "        \"publishers/mistralai\",\n",
+    "        f\"models/{model_name}-{model_version}\",\n",
+    "    ]\n",
+    "    specifier = \"rawPredict\" # Streaming is not supported\n",
+    "    endpoint_url = \"/\".join(endpoint_url_segments) + f\":{specifier}\"\n",
+    "    return endpoint_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "343096d0-bc42-45e1-8a34-a564867dd1ab",
+   "metadata": {},
+   "source": [
+    "You can now send your HTTP request to the model endpoint:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5b6ca1c-2839-4b84-a4bc-f799304dc9bd",
+   "metadata": {},
+   "source": [
+    "Calling the OCR model is done via a HTTP POST request where the document to be processed is passed in the payload as a base64-encoded string. The following cell defines another helper function that downloads a given PDF file from a URL and encodes it in base64. If you already have your own documents at hand you can easily modify it to only keep the encoding part.\n",
+    "\n",
+    "**Warning**: the larger the document, the bigger the payload and the longer the model will take to handle it. To avoid timeout issues it is advised to split the document into smaller chunks. The number and size of chunks will depend on the total volume of documents you wish to process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "851f2e12-a1bb-4e31-ac00-aa9b5993fe9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "\n",
+    "def download_pdf_and_base64_encode(pdf_url: str) -> str:\n",
+    "    resp = httpx.get(pdf_url)\n",
+    "    resp.raise_for_status()\n",
+    "    content_bytes = resp.content\n",
+    "    content_encoded_pdf = base64.b64encode(content_bytes).decode(\"utf-8\")\n",
+    "    return content_encoded_pdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4fa491f-4edc-401e-95a7-8afb52ece915",
+   "metadata": {},
+   "source": [
+    "You can now send the HTTP request to the model endpoint. Note that you can also optionally:\n",
+    "\n",
+    "- limit the number of scanned pages,\n",
+    "- retrieved any image detected by the model, in the form of base64-encoded strings.\n",
+    "\n",
+    "Check the detailed list of available options and values in the [Mistral AI API documentation](https://docs.mistral.ai/api/#tag/ocr)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddf75839-a55a-49f0-ad06-6771ba97ec87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import httpx\n",
+    "\n",
+    "# URL\n",
+    "url = build_endpoint_url(\n",
+    "    region=REGION,\n",
+    "    project_id=PROJECT_ID,\n",
+    "    model_name=MODEL_NAME,\n",
+    "    model_version=MODEL_VERSION\n",
+    ")\n",
+    "\n",
+    "# Headers\n",
+    "headers = {\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "    \"Accept\": \"application/json\"\n",
+    "}\n",
+    "if not \"google.colab\" in sys.modules:\n",
+    "    headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
+    "\n",
+    "# Payload\n",
+    "encoded_doc = download_pdf_and_base64_encode(TEST_DOC_URL)\n",
+    "payload = {\n",
+    "    \"model\": f\"{MODEL_NAME}-{MODEL_VERSION}\",\n",
+    "    \"document\": {\n",
+    "        \"type\": \"document_url\",\n",
+    "        \"document_url\": f\"data:application/pdf;base64,{encoded_doc}\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Request\n",
+    "model_resp = httpx.post(\n",
+    "    url=url,\n",
+    "    headers=headers,\n",
+    "    json=payload,\n",
+    "    timeout=None\n",
+    ")\n",
+    "\n",
+    "# Response\n",
+    "model_resp.raise_for_status()\n",
+    "if model_resp.status_code == 200:\n",
+    "    scanned_doc = model_resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e69f7c7b-a595-480b-8081-bc57e6ad2989",
+   "metadata": {},
+   "source": [
+    "## Parsing the results\n",
+    "\n",
+    "If your request was successful, the `scanned_doc` variable should contain:\n",
+    "\n",
+    "* `.pages` : a list of dicts containing, for each scanned page, the Markdown-formatted text detected.\n",
+    "* `.usage_info`: the total count of pages processed as well as the scanned document's size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d05f635-b89b-4ffd-9af0-02af9ea2acaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Beginning of the first page's content\n",
+    "\n",
+    "content_extract = scanned_doc[\"pages\"][0][\"markdown\"][:256]\n",
+    "print(content_extract)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb04cd2d-3c87-4bb3-8f20-87dd01a759c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content_info = scanned_doc[\"usage_info\"]\n",
+    "print(content_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17fa538d-de5b-4c52-be3b-6a935c0c509c",
+   "metadata": {},
+   "source": [
+    "## (Advanced) Combining OCR with a multimodal model\n",
+    "\n",
+    "In more elaborate scenarios, you may want to annotate the images of a document in addition to retrieving the document's text. This is made possible by adding a multimodal model such as `mistral-small-2503` to the mix and have it analyze the image extracted from the OCR operation, making the overall operation a two-step process which takes longer but yields more information on the document's content.\n",
+    "\n",
+    "To make the code more modular you can start by packaging the OCR call into a `call_ocr_model()` function that:\n",
+    "- downloads the document,\n",
+    "- converts it into a base64-encoded string,\n",
+    "- passes that string to the OCR model. We added a `pages` argument to optionally limit the number of pages processed, to shorten processing time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60870ff2-e749-4678-89e4-55912fdbbb95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Dict, Any, Optional\n",
+    "\n",
+    "def call_ocr_model(endpoint_url: str, \n",
+    "                   pdf_url: str,\n",
+    "                   with_image_outputs: bool = False,\n",
+    "                   pages: Optional[str]=None,\n",
+    "                   access_token: Optional[str]=None) -> Dict[str, Any]:\n",
+    "    headers = {\n",
+    "        \"Content-Type\": \"application/json\",\n",
+    "        \"Accept\": \"application/json\",\n",
+    "    }\n",
+    "    if access_token:\n",
+    "        headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
+    "    payload = {\n",
+    "        \"model\": f\"{MODEL_NAME}-{MODEL_VERSION}\",\n",
+    "        \"document\": {\n",
+    "            \"type\": \"document_url\",\n",
+    "            \"document_url\": f\"data:application/pdf;base64,{encoded_doc}\",\n",
+    "        },\n",
+    "        \"include_image_base64\": with_image_outputs,\n",
+    "    }\n",
+    "    if pages:\n",
+    "        payload[\"pages\"] = pages\n",
+    "    with httpx.Client() as client:\n",
+    "        ocr_resp = client.post(\n",
+    "            url=endpoint_url, headers=headers, json=payload, timeout=None\n",
+    "        )\n",
+    "        ocr_resp.raise_for_status()\n",
+    "        if ocr_resp.status_code == 200:\n",
+    "            return ocr_resp.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baea9c6b-0aa5-4c5e-a586-b07da6a29932",
+   "metadata": {},
+   "source": [
+    "To illustrate how the system works, you can scan the document pointed at by the `TEST_DOC_URL` URL as such:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "242a3c6d-ab85-4d40-99f6-cf2aadd77d34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scanned_doc = call_ocr_model(\n",
+    "    endpoint_url=url,\n",
+    "    pdf_url=TEST_DOC_URL,\n",
+    "    pages=\"1-10\",\n",
+    "    with_image_outputs=True,\n",
+    "    access_token=access_token\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6310be20-49bd-4ab7-8fdb-4b889ee07857",
+   "metadata": {},
+   "source": [
+    "Note that `with_image_outputs` is set to `True` because you will want to annotate the figures/images in the documents, so you need to retrieve their base64-encoded representation.\n",
+    "\n",
+    "The next step is to define how the multimodal model will be called to analyze the image content. To do so, you will query another Mistral model available on Vertex AI: `mistral-small-2503`, which can process both text and image inputs. This is a basic system message you can pass to it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68c2762e-76e4-4135-8204-be221f5eb211",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VLM_NAME = \"mistral-small\"\n",
+    "VLM_VERSION = \"2503\"\n",
+    "\n",
+    "ANNOTATION_SYSTEM_PROMPT = \"\"\"\n",
+    "Your mission is to provide a clear description to each image you will see.\n",
+    "Describe its features and key components.\n",
+    "Return your answer in a well-structured JSON object.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0467bcbc-01e5-4cc1-8afb-f16d385e2713",
+   "metadata": {},
+   "source": [
+    "To ensure that the image annotation will stick to a specific format, you will leverage another feature called _structured outputs_, which enforces strict schema rules when you require JSON output from the model. In practice, you can define your output structure with a Pydantic model, then later convert it into a JSON Schema dictionary when passing it to the API, here is an example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ef6c0a9-e1dd-438d-a14b-2dd416a8ec55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, Field\n",
+    "import json\n",
+    "\n",
+    "class AnnotatedImage(BaseModel):\n",
+    "    short_desc: str = Field(...,\n",
+    "                            description=\"A short one-sentence summary of the image\")\n",
+    "    long_desc: str = Field(...,\n",
+    "                           description=\"A longer detailed description of the image\")\n",
+    "\n",
+    "schema = AnnotatedImage.model_json_schema()\n",
+    "print(json.dumps(schema, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dbec360-8878-4fb4-bf15-8c0c43bcefcc",
+   "metadata": {},
+   "source": [
+    "You can read more about structured outputs in the [Mistral documentation](https://docs.mistral.ai/capabilities/structured-output/custom_structured_output).\n",
+    "\n",
+    "From there, you can write an `annotate_with_vlm_model()` function that will call the multimodal model and pass it a base64-encoded image to retrieve its description in a well-structured format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40428fe0-ac1d-4f5e-8219-94d98d5b3688",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def annotate_with_vlm_model(endpoint_url: str,\n",
+    "                            annotation_structure: BaseModel,\n",
+    "                            image_base64: str,\n",
+    "                            access_token:Optional[str]=None,\n",
+    "                            debug: bool = False) -> Dict[str,Any]:\n",
+    "    \n",
+    "    # Headers\n",
+    "    headers = {\n",
+    "        \"Content-Type\": \"application/json\",\n",
+    "        \"Accept\": \"application/json\",\n",
+    "    }\n",
+    "    if access_token: # Non-Colab environments only\n",
+    "        headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
+    "\n",
+    "    # JSON output schema\n",
+    "    annotation_schema = annotation_structure.model_json_schema()\n",
+    "    annotation_schema[\"additionalProperties\"] = False\n",
+    "    payload = {\n",
+    "        \"model\": f\"{VLM_NAME}-{VLM_VERSION}\",\n",
+    "        \"messages\": [\n",
+    "            {\n",
+    "                \"role\": \"system\",\n",
+    "                \"content\": ANNOTATION_SYSTEM_PROMPT\n",
+    "            },\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": [\n",
+    "                    {\n",
+    "                        \"type\": \"image_url\",\n",
+    "                        \"image_url\": image_base64\n",
+    "                    }\n",
+    "                ]\n",
+    "            }\n",
+    "        ],\n",
+    "        \"response_format\": {\n",
+    "            \"type\": \"json_schema\",\n",
+    "            \"json_schema\": {\n",
+    "                \"schema\": annotation_schema, \n",
+    "                \"name\": \"image_schema\", \n",
+    "                \"strict\": True\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "    # Request & response\n",
+    "    with httpx.Client() as client:\n",
+    "        vlm_resp = client.post(url=endpoint_url, headers=headers, json=payload, timeout=None)\n",
+    "        vlm_resp.raise_for_status()\n",
+    "        if vlm_resp.status_code == 200:\n",
+    "            vlm_out = vlm_resp.json()\n",
+    "            annotation = json.loads(vlm_out[\"choices\"][0][\"message\"][\"content\"])\n",
+    "        return annotation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e6d738d-440a-477b-a8d2-cc47272e16a2",
+   "metadata": {},
+   "source": [
+    "You can test your function on a page of the scanned document that contains one or more images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b881446-8bcc-4161-a579-7cbb31f57370",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "page_idx = 0\n",
+    "images_b64 = [item[\"image_base64\"] for item in scanned_doc[\"pages\"][page_idx][\"images\"]]\n",
+    "vlm_url = build_endpoint_url(\n",
+    "    model_name=VLM_NAME,\n",
+    "    model_version=VLM_VERSION,\n",
+    "    project_id=PROJECT_ID,\n",
+    "    region=REGION\n",
+    ")\n",
+    "annotations: List[Dict[str, Any]] = []\n",
+    "for imgb64 in images_b64:\n",
+    "    annotations.append(\n",
+    "        annotate_with_vlm_model(\n",
+    "            endpoint_url=vlm_url,\n",
+    "            annotation_structure=AnnotatedImage,\n",
+    "            image_base64=imgb64,\n",
+    "            access_token=access_token\n",
+    "        )\n",
+    "    )\n",
+    "print(f\"Page {page_idx}:\")\n",
+    "print(annotations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10976165-28df-48d1-ae15-b22e1dbc71a7",
+   "metadata": {},
+   "source": [
+    "Finally, in order to stict everything together, you can run the following code that will edit in-place the `scanned_doc` variable and add a `annotations` field where each detected image will have its description written:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "182f830a-8bda-45a4-a518-d55206352a28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for idx, page in enumerate(scanned_doc[\"pages\"]):\n",
+    "    annotations: List[Dict[str, Any]] = []\n",
+    "    for img in page[\"images\"]:\n",
+    "        annotations.append(\n",
+    "            {\n",
+    "                \"id\": img[\"id\"],\n",
+    "                \"annotation\": annotate_with_vlm_model(\n",
+    "                    endpoint_url=vlm_url,\n",
+    "                    annotation_structure=AnnotatedImage,\n",
+    "                    image_base64=img[\"image_base64\"],\n",
+    "                    access_token=access_token\n",
+    "                )\n",
+    "            }\n",
+    "        )\n",
+    "    scanned_doc[\"pages\"][idx][\"annotations\"] = annotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a494332d-bc00-4aaf-a373-1291951b77c4",
+   "metadata": {},
+   "source": [
+    "You can now retrieve both text and image descriptions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "435df5b9-9c53-4971-b3d9-68611ec81f82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "page_idx = 6\n",
+    "text = scanned_doc[\"pages\"][page_idx][\"markdown\"]\n",
+    "annotations = scanned_doc[\"pages\"][page_idx][\"annotations\"]\n",
+    "print(text)\n",
+    "print(80*\"_\")\n",
+    "print(annotations)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/official/generative_ai/mistralai_ocr.ipynb
+++ b/notebooks/official/generative_ai/mistralai_ocr.ipynb
@@ -1,632 +1,655 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e636548d-0b00-456e-a288-cc73d7a630df",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Copyright 2024 Google LLC\n",
-    "#\n",
-    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2eec5cc39a59"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2024 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "da28efe88436"
+      },
+      "source": [
+        "# Getting Started with Mistral AI OCR\n",
+        "<table align=\"left\">\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fgenerative_ai%2Fmistralai_ocr.ipynb\">\n",
+        "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td style=\"text-align: center\">                                                                             \n",
+        "    <a href=\"https://console.cloud.google.com/vertex-ai/notebooks/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
+        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  <td style=\"text-align: center\">\n",
+        "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
+        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
+        "    </a>\n",
+        "  </td>\n",
+        "  \n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ccc3e15e21c5"
+      },
+      "source": [
+        "NOTE: This notebook has been tested in the following environment:\n",
+        "\n",
+        "Python version = 3.10"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5e9bfd2d8658"
+      },
+      "source": [
+        "## Objective\n",
+        "\n",
+        "Mistral OCR (25.05) is a model specialized in extracting text and images from documents. It is specifically built to preserve the structure of the document pages and automatically formats the extracted text in Markdown.\n",
+        "\n",
+        "The objective of this notebook is to provide a summary overview of the Mistral OCR (25.05) model's capabilities and how to leverage it using the Vertex AI platform."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "200afb22a42b"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install -U -q httpx"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "563f89d0115e"
+      },
+      "source": [
+        "## Getting started\n",
+        "\n",
+        "Before proceeding further, fill in the following information:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "85932a54e4db"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_ID = \"\"\n",
+        "REGION = \"\"\n",
+        "MODEL_NAME = \"mistral-ocr\"\n",
+        "MODEL_VERSION = \"2505\"\n",
+        "TEST_DOC_URL = \"https://arxiv.org/pdf/2410.07073\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5544ad27e670"
+      },
+      "source": [
+        "As a developer, your first step is to authenticate your notebook environment. If you are using Google Colab to run it, the following cell should take care of the authentication, otherwise it will run the `gcloud` command to retrieve the access token needed to authenticate your API calls:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6e127418e326"
+      },
+      "outputs": [],
+      "source": [
+        "import subprocess\n",
+        "import sys\n",
+        "\n",
+        "if \"google.colab\" in sys.modules:\n",
+        "    from google.colab import auth\n",
+        "\n",
+        "    auth.authenticate_user()\n",
+        "else:\n",
+        "    try:\n",
+        "        result = subprocess.run(\n",
+        "            [\"gcloud\", \"auth\", \"print-access-token\"],\n",
+        "            check=True,\n",
+        "            stdout=subprocess.PIPE,\n",
+        "            stderr=subprocess.PIPE,\n",
+        "            text=True,\n",
+        "        )\n",
+        "        access_token = result.stdout.strip()\n",
+        "    except subprocess.CalledProcessError as e:\n",
+        "        print(f\"Error while running command: {e.stderr}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "a9206ed0b71c"
+      },
+      "source": [
+        "## Calling the OCR model (HTTP)\n",
+        "\n",
+        "Start by defining a simple function that will help building the URL of your model endpoint:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "70651e83cff5"
+      },
+      "outputs": [],
+      "source": [
+        "def build_endpoint_url(\n",
+        "    region: str, project_id: str, model_name: str, model_version: str\n",
+        ") -> str:\n",
+        "    base_url = f\"https://{region}-aiplatform.googleapis.com/v1\"\n",
+        "    endpoint_url_segments = [\n",
+        "        base_url,\n",
+        "        f\"projects/{project_id}\",\n",
+        "        f\"locations/{region}\",\n",
+        "        \"publishers/mistralai\",\n",
+        "        f\"models/{model_name}-{model_version}\",\n",
+        "    ]\n",
+        "    specifier = \"rawPredict\"  # Streaming is not supported\n",
+        "    endpoint_url = \"/\".join(endpoint_url_segments) + f\":{specifier}\"\n",
+        "    return endpoint_url"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ab383be0128c"
+      },
+      "source": [
+        "You can now send your HTTP request to the model endpoint:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cc3b5bd0e27a"
+      },
+      "source": [
+        "Calling the OCR model is done via a HTTP POST request where the document to be processed is passed in the payload as a base64-encoded string. The following cell defines another helper function that downloads a given PDF file from a URL and encodes it in base64. If you already have your own documents at hand you can easily modify it to only keep the encoding part.\n",
+        "\n",
+        "**Warning**: the larger the document, the bigger the payload and the longer the model will take to handle it. To avoid timeout issues it is advised to split the document into smaller chunks. The number and size of chunks will depend on the total volume of documents you wish to process."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "57561631be74"
+      },
+      "outputs": [],
+      "source": [
+        "import base64\n",
+        "\n",
+        "\n",
+        "def download_pdf_and_base64_encode(pdf_url: str) -> str:\n",
+        "    resp = httpx.get(pdf_url)\n",
+        "    resp.raise_for_status()\n",
+        "    content_bytes = resp.content\n",
+        "    content_encoded_pdf = base64.b64encode(content_bytes).decode(\"utf-8\")\n",
+        "    return content_encoded_pdf"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "87092165402d"
+      },
+      "source": [
+        "You can now send the HTTP request to the model endpoint. Note that you can also optionally:\n",
+        "\n",
+        "- limit the number of scanned pages,\n",
+        "- retrieved any image detected by the model, in the form of base64-encoded strings.\n",
+        "\n",
+        "Check the detailed list of available options and values in the [Mistral AI API documentation](https://docs.mistral.ai/api/#tag/ocr)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6685ffe363b7"
+      },
+      "outputs": [],
+      "source": [
+        "import httpx\n",
+        "\n",
+        "# URL\n",
+        "url = build_endpoint_url(\n",
+        "    region=REGION,\n",
+        "    project_id=PROJECT_ID,\n",
+        "    model_name=MODEL_NAME,\n",
+        "    model_version=MODEL_VERSION,\n",
+        ")\n",
+        "\n",
+        "# Headers\n",
+        "headers = {\"Content-Type\": \"application/json\", \"Accept\": \"application/json\"}\n",
+        "if \"google.colab\" not in sys.modules:\n",
+        "    headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
+        "\n",
+        "# Payload\n",
+        "encoded_doc = download_pdf_and_base64_encode(TEST_DOC_URL)\n",
+        "payload = {\n",
+        "    \"model\": f\"{MODEL_NAME}-{MODEL_VERSION}\",\n",
+        "    \"document\": {\n",
+        "        \"type\": \"document_url\",\n",
+        "        \"document_url\": f\"data:application/pdf;base64,{encoded_doc}\",\n",
+        "    },\n",
+        "}\n",
+        "\n",
+        "# Request\n",
+        "model_resp = httpx.post(url=url, headers=headers, json=payload, timeout=None)\n",
+        "\n",
+        "# Response\n",
+        "model_resp.raise_for_status()\n",
+        "if model_resp.status_code == 200:\n",
+        "    scanned_doc = model_resp.json()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1c23e104bb19"
+      },
+      "source": [
+        "## Parsing the results\n",
+        "\n",
+        "If your request was successful, the `scanned_doc` variable should contain:\n",
+        "\n",
+        "* `.pages` : a list of dicts containing, for each scanned page, the Markdown-formatted text detected.\n",
+        "* `.usage_info`: the total count of pages processed as well as the scanned document's size."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "8cfe8e16ddef"
+      },
+      "outputs": [],
+      "source": [
+        "# Beginning of the first page's content\n",
+        "\n",
+        "content_extract = scanned_doc[\"pages\"][0][\"markdown\"][:256]\n",
+        "print(content_extract)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "e475ab265ae4"
+      },
+      "outputs": [],
+      "source": [
+        "content_info = scanned_doc[\"usage_info\"]\n",
+        "print(content_info)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4d619af71b78"
+      },
+      "source": [
+        "## (Advanced) Combining OCR with a multimodal model\n",
+        "\n",
+        "In more elaborate scenarios, you may want to annotate the images of a document in addition to retrieving the document's text. This is made possible by adding a multimodal model such as `mistral-small-2503` to the mix and have it analyze the image extracted from the OCR operation, making the overall operation a two-step process which takes longer but yields more information on the document's content.\n",
+        "\n",
+        "To make the code more modular you can start by packaging the OCR call into a `call_ocr_model()` function that:\n",
+        "- downloads the document,\n",
+        "- converts it into a base64-encoded string,\n",
+        "- passes that string to the OCR model. We added a `pages` argument to optionally limit the number of pages processed, to shorten processing time."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "5290a17ed1ca"
+      },
+      "outputs": [],
+      "source": [
+        "from typing import Any, Dict, Optional\n",
+        "\n",
+        "\n",
+        "def call_ocr_model(\n",
+        "    endpoint_url: str,\n",
+        "    pdf_url: str,\n",
+        "    with_image_outputs: bool = False,\n",
+        "    pages: Optional[str] = None,\n",
+        "    access_token: Optional[str] = None,\n",
+        ") -> Dict[str, Any]:\n",
+        "    headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"Accept\": \"application/json\",\n",
+        "    }\n",
+        "    if access_token:\n",
+        "        headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
+        "    payload = {\n",
+        "        \"model\": f\"{MODEL_NAME}-{MODEL_VERSION}\",\n",
+        "        \"document\": {\n",
+        "            \"type\": \"document_url\",\n",
+        "            \"document_url\": f\"data:application/pdf;base64,{encoded_doc}\",\n",
+        "        },\n",
+        "        \"include_image_base64\": with_image_outputs,\n",
+        "    }\n",
+        "    if pages:\n",
+        "        payload[\"pages\"] = pages\n",
+        "    with httpx.Client() as client:\n",
+        "        ocr_resp = client.post(\n",
+        "            url=endpoint_url, headers=headers, json=payload, timeout=None\n",
+        "        )\n",
+        "        ocr_resp.raise_for_status()\n",
+        "        if ocr_resp.status_code == 200:\n",
+        "            return ocr_resp.json()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "b1b7b5c79a55"
+      },
+      "source": [
+        "To illustrate how the system works, you can scan the document pointed at by the `TEST_DOC_URL` URL as such:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "49138e10d101"
+      },
+      "outputs": [],
+      "source": [
+        "scanned_doc = call_ocr_model(\n",
+        "    endpoint_url=url,\n",
+        "    pdf_url=TEST_DOC_URL,\n",
+        "    pages=\"1-10\",\n",
+        "    with_image_outputs=True,\n",
+        "    access_token=access_token,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "a0e81cf53e9c"
+      },
+      "source": [
+        "Note that `with_image_outputs` is set to `True` because you will want to annotate the figures/images in the documents, so you need to retrieve their base64-encoded representation.\n",
+        "\n",
+        "The next step is to define how the multimodal model will be called to analyze the image content. To do so, you will query another Mistral model available on Vertex AI: `mistral-small-2503`, which can process both text and image inputs. This is a basic system message you can pass to it:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "46a275c654bc"
+      },
+      "outputs": [],
+      "source": [
+        "VLM_NAME = \"mistral-small\"\n",
+        "VLM_VERSION = \"2503\"\n",
+        "\n",
+        "ANNOTATION_SYSTEM_PROMPT = \"\"\"\n",
+        "Your mission is to provide a clear description to each image you will see.\n",
+        "Describe its features and key components.\n",
+        "Return your answer in a well-structured JSON object.\n",
+        "\"\"\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "287daf8c15ae"
+      },
+      "source": [
+        "To ensure that the image annotation will stick to a specific format, you will leverage another feature called _structured outputs_, which enforces strict schema rules when you require JSON output from the model. In practice, you can define your output structure with a Pydantic model, then later convert it into a JSON Schema dictionary when passing it to the API, here is an example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "25ae77088850"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "\n",
+        "from pydantic import BaseModel, Field\n",
+        "\n",
+        "\n",
+        "class AnnotatedImage(BaseModel):\n",
+        "    short_desc: str = Field(\n",
+        "        ..., description=\"A short one-sentence summary of the image\"\n",
+        "    )\n",
+        "    long_desc: str = Field(\n",
+        "        ..., description=\"A longer detailed description of the image\"\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "schema = AnnotatedImage.model_json_schema()\n",
+        "print(json.dumps(schema, indent=4))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4c7cec2f02ff"
+      },
+      "source": [
+        "You can read more about structured outputs in the [Mistral documentation](https://docs.mistral.ai/capabilities/structured-output/custom_structured_output).\n",
+        "\n",
+        "From there, you can write an `annotate_with_vlm_model()` function that will call the multimodal model and pass it a base64-encoded image to retrieve its description in a well-structured format:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2729970e01df"
+      },
+      "outputs": [],
+      "source": [
+        "def annotate_with_vlm_model(\n",
+        "    endpoint_url: str,\n",
+        "    annotation_structure: BaseModel,\n",
+        "    image_base64: str,\n",
+        "    access_token: Optional[str] = None,\n",
+        "    debug: bool = False,\n",
+        ") -> Dict[str, Any]:\n",
+        "\n",
+        "    # Headers\n",
+        "    headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"Accept\": \"application/json\",\n",
+        "    }\n",
+        "    if access_token:  # Non-Colab environments only\n",
+        "        headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
+        "\n",
+        "    # JSON output schema\n",
+        "    annotation_schema = annotation_structure.model_json_schema()\n",
+        "    annotation_schema[\"additionalProperties\"] = False\n",
+        "    payload = {\n",
+        "        \"model\": f\"{VLM_NAME}-{VLM_VERSION}\",\n",
+        "        \"messages\": [\n",
+        "            {\"role\": \"system\", \"content\": ANNOTATION_SYSTEM_PROMPT},\n",
+        "            {\n",
+        "                \"role\": \"user\",\n",
+        "                \"content\": [{\"type\": \"image_url\", \"image_url\": image_base64}],\n",
+        "            },\n",
+        "        ],\n",
+        "        \"response_format\": {\n",
+        "            \"type\": \"json_schema\",\n",
+        "            \"json_schema\": {\n",
+        "                \"schema\": annotation_schema,\n",
+        "                \"name\": \"image_schema\",\n",
+        "                \"strict\": True,\n",
+        "            },\n",
+        "        },\n",
+        "    }\n",
+        "\n",
+        "    # Request & response\n",
+        "    with httpx.Client() as client:\n",
+        "        vlm_resp = client.post(\n",
+        "            url=endpoint_url, headers=headers, json=payload, timeout=None\n",
+        "        )\n",
+        "        vlm_resp.raise_for_status()\n",
+        "        if vlm_resp.status_code == 200:\n",
+        "            vlm_out = vlm_resp.json()\n",
+        "            annotation = json.loads(vlm_out[\"choices\"][0][\"message\"][\"content\"])\n",
+        "        return annotation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eee496c724f1"
+      },
+      "source": [
+        "You can test your function on a page of the scanned document that contains one or more images:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cb5b24399943"
+      },
+      "outputs": [],
+      "source": [
+        "from typing import List\n",
+        "\n",
+        "page_idx = 0\n",
+        "images_b64 = [item[\"image_base64\"] for item in scanned_doc[\"pages\"][page_idx][\"images\"]]\n",
+        "vlm_url = build_endpoint_url(\n",
+        "    model_name=VLM_NAME, model_version=VLM_VERSION, project_id=PROJECT_ID, region=REGION\n",
+        ")\n",
+        "annotations: List[Dict[str, Any]] = []\n",
+        "for imgb64 in images_b64:\n",
+        "    annotations.append(\n",
+        "        annotate_with_vlm_model(\n",
+        "            endpoint_url=vlm_url,\n",
+        "            annotation_structure=AnnotatedImage,\n",
+        "            image_base64=imgb64,\n",
+        "            access_token=access_token,\n",
+        "        )\n",
+        "    )\n",
+        "print(f\"Page {page_idx}:\")\n",
+        "print(annotations)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8136937e22ce"
+      },
+      "source": [
+        "Finally, in order to stict everything together, you can run the following code that will edit in-place the `scanned_doc` variable and add a `annotations` field where each detected image will have its description written:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6b75a52c7b35"
+      },
+      "outputs": [],
+      "source": [
+        "for idx, page in enumerate(scanned_doc[\"pages\"]):\n",
+        "    annotations: List[Dict[str, Any]] = []\n",
+        "    for img in page[\"images\"]:\n",
+        "        annotations.append(\n",
+        "            {\n",
+        "                \"id\": img[\"id\"],\n",
+        "                \"annotation\": annotate_with_vlm_model(\n",
+        "                    endpoint_url=vlm_url,\n",
+        "                    annotation_structure=AnnotatedImage,\n",
+        "                    image_base64=img[\"image_base64\"],\n",
+        "                    access_token=access_token,\n",
+        "                ),\n",
+        "            }\n",
+        "        )\n",
+        "    scanned_doc[\"pages\"][idx][\"annotations\"] = annotations"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ae5bcfff22cc"
+      },
+      "source": [
+        "You can now retrieve both text and image descriptions:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "238a4eaef404"
+      },
+      "outputs": [],
+      "source": [
+        "page_idx = 6\n",
+        "text = scanned_doc[\"pages\"][page_idx][\"markdown\"]\n",
+        "annotations = scanned_doc[\"pages\"][page_idx][\"annotations\"]\n",
+        "print(text)\n",
+        "print(80 * \"_\")\n",
+        "print(annotations)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "mistralai_ocr.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "21e4cf90-5f1f-44c2-b020-91ecb003bb77",
-   "metadata": {},
-   "source": [
-    "# Getting Started with Mistral AI OCR\n",
-    "<table align=\"left\">\n",
-    "  <td style=\"text-align: center\">\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Open in Colab\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td style=\"text-align: center\">\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/colab/import/https:%2F%2Fraw.githubusercontent.com%2FGoogleCloudPlatform%2Fvertex-ai-samples%2Fmain%2Fnotebooks%2Fofficial%2Fgenerative_ai%2Fmistralai_ocr.ipynb\">\n",
-    "      <img width=\"32px\" src=\"https://cloud.google.com/ml-engine/images/colab-enterprise-logo-32px.png\" alt=\"Google Cloud Colab Enterprise logo\"><br> Open in Colab Enterprise\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td style=\"text-align: center\">                                                                             \n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/notebooks/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/vertex-ai-samples/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
-    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Workbench\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  <td style=\"text-align: center\">\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/mistralai_ocr.ipynb\">\n",
-    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
-    "    </a>\n",
-    "  </td>\n",
-    "  \n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a94cdb15-82cf-477f-9f31-3a31574bdf91",
-   "metadata": {},
-   "source": [
-    "NOTE: This notebook has been tested in the following environment:\n",
-    "\n",
-    "Python version = 3.10"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4774e332-79af-48a5-b31a-17be51dd7caf",
-   "metadata": {},
-   "source": [
-    "## Objective\n",
-    "\n",
-    "Mistral OCR (25.05) is a model specialized in extracting text and images from documents. It is specifically built to preserve the structure of the document pages and automatically formats the extracted text in Markdown.\n",
-    "\n",
-    "The objective of this notebook is to provide a summary overview of the Mistral OCR (25.05) model's capabilities and how to leverage it using the Vertex AI platform."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40d7a849-b291-4a09-8673-0f98989714bd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -U -q httpx"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "82aa1ec4-ca7a-424f-94d3-90e687d37152",
-   "metadata": {},
-   "source": [
-    "## Getting started\n",
-    "\n",
-    "Before proceeding further, fill in the following information:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e2fcdc63-466c-4186-b9aa-3a77d11026b4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = \"\"\n",
-    "REGION = \"\"\n",
-    "MODEL_NAME = \"mistral-ocr\"\n",
-    "MODEL_VERSION = \"2505\"\n",
-    "TEST_DOC_URL = \"https://arxiv.org/pdf/2410.07073\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a89e8159-46c6-4cf4-b8fd-acdb49ac1d1f",
-   "metadata": {},
-   "source": [
-    "As a developer, your first step is to authenticate your notebook environment. If you are using Google Colab to run it, the following cell should take care of the authentication, otherwise it will run the `gcloud` command to retrieve the access token needed to authenticate your API calls:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d4e27c2f-b324-458d-8526-163dc14f4bbb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "import subprocess\n",
-    "\n",
-    "if \"google.colab\" in sys.modules:\n",
-    "    from google.colab import auth\n",
-    "    auth.authenticate_user()\n",
-    "else:\n",
-    "    try:\n",
-    "        result = subprocess.run(\n",
-    "            [\"gcloud\", \"auth\", \"print-access-token\"],\n",
-    "            check=True,\n",
-    "            stdout=subprocess.PIPE,\n",
-    "            stderr=subprocess.PIPE,\n",
-    "            text=True\n",
-    "        )\n",
-    "        access_token = result.stdout.strip()\n",
-    "    except subprocess.CalledProcessError as e:\n",
-    "        print(f\"Error while running command: {e.stderr}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6f8a5799-2806-47e2-b1ce-5d8dd3c58cdb",
-   "metadata": {},
-   "source": [
-    "## Calling the OCR model (HTTP)\n",
-    "\n",
-    "Start by defining a simple function that will help building the URL of your model endpoint:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eed6ee59-c4c0-4a02-aef5-3d28b049c285",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def build_endpoint_url(region: str, project_id: str, model_name: str, model_version: str) -> str:\n",
-    "    base_url = f\"https://{region}-aiplatform.googleapis.com/v1\"\n",
-    "    endpoint_url_segments = [\n",
-    "        base_url,\n",
-    "        f\"projects/{project_id}\",\n",
-    "        f\"locations/{region}\",\n",
-    "        \"publishers/mistralai\",\n",
-    "        f\"models/{model_name}-{model_version}\",\n",
-    "    ]\n",
-    "    specifier = \"rawPredict\" # Streaming is not supported\n",
-    "    endpoint_url = \"/\".join(endpoint_url_segments) + f\":{specifier}\"\n",
-    "    return endpoint_url"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "343096d0-bc42-45e1-8a34-a564867dd1ab",
-   "metadata": {},
-   "source": [
-    "You can now send your HTTP request to the model endpoint:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b5b6ca1c-2839-4b84-a4bc-f799304dc9bd",
-   "metadata": {},
-   "source": [
-    "Calling the OCR model is done via a HTTP POST request where the document to be processed is passed in the payload as a base64-encoded string. The following cell defines another helper function that downloads a given PDF file from a URL and encodes it in base64. If you already have your own documents at hand you can easily modify it to only keep the encoding part.\n",
-    "\n",
-    "**Warning**: the larger the document, the bigger the payload and the longer the model will take to handle it. To avoid timeout issues it is advised to split the document into smaller chunks. The number and size of chunks will depend on the total volume of documents you wish to process."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "851f2e12-a1bb-4e31-ac00-aa9b5993fe9f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import base64\n",
-    "\n",
-    "def download_pdf_and_base64_encode(pdf_url: str) -> str:\n",
-    "    resp = httpx.get(pdf_url)\n",
-    "    resp.raise_for_status()\n",
-    "    content_bytes = resp.content\n",
-    "    content_encoded_pdf = base64.b64encode(content_bytes).decode(\"utf-8\")\n",
-    "    return content_encoded_pdf"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4fa491f-4edc-401e-95a7-8afb52ece915",
-   "metadata": {},
-   "source": [
-    "You can now send the HTTP request to the model endpoint. Note that you can also optionally:\n",
-    "\n",
-    "- limit the number of scanned pages,\n",
-    "- retrieved any image detected by the model, in the form of base64-encoded strings.\n",
-    "\n",
-    "Check the detailed list of available options and values in the [Mistral AI API documentation](https://docs.mistral.ai/api/#tag/ocr)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ddf75839-a55a-49f0-ad06-6771ba97ec87",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import httpx\n",
-    "\n",
-    "# URL\n",
-    "url = build_endpoint_url(\n",
-    "    region=REGION,\n",
-    "    project_id=PROJECT_ID,\n",
-    "    model_name=MODEL_NAME,\n",
-    "    model_version=MODEL_VERSION\n",
-    ")\n",
-    "\n",
-    "# Headers\n",
-    "headers = {\n",
-    "    \"Content-Type\": \"application/json\",\n",
-    "    \"Accept\": \"application/json\"\n",
-    "}\n",
-    "if not \"google.colab\" in sys.modules:\n",
-    "    headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
-    "\n",
-    "# Payload\n",
-    "encoded_doc = download_pdf_and_base64_encode(TEST_DOC_URL)\n",
-    "payload = {\n",
-    "    \"model\": f\"{MODEL_NAME}-{MODEL_VERSION}\",\n",
-    "    \"document\": {\n",
-    "        \"type\": \"document_url\",\n",
-    "        \"document_url\": f\"data:application/pdf;base64,{encoded_doc}\"\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "# Request\n",
-    "model_resp = httpx.post(\n",
-    "    url=url,\n",
-    "    headers=headers,\n",
-    "    json=payload,\n",
-    "    timeout=None\n",
-    ")\n",
-    "\n",
-    "# Response\n",
-    "model_resp.raise_for_status()\n",
-    "if model_resp.status_code == 200:\n",
-    "    scanned_doc = model_resp.json()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e69f7c7b-a595-480b-8081-bc57e6ad2989",
-   "metadata": {},
-   "source": [
-    "## Parsing the results\n",
-    "\n",
-    "If your request was successful, the `scanned_doc` variable should contain:\n",
-    "\n",
-    "* `.pages` : a list of dicts containing, for each scanned page, the Markdown-formatted text detected.\n",
-    "* `.usage_info`: the total count of pages processed as well as the scanned document's size."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d05f635-b89b-4ffd-9af0-02af9ea2acaa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Beginning of the first page's content\n",
-    "\n",
-    "content_extract = scanned_doc[\"pages\"][0][\"markdown\"][:256]\n",
-    "print(content_extract)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cb04cd2d-3c87-4bb3-8f20-87dd01a759c2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "content_info = scanned_doc[\"usage_info\"]\n",
-    "print(content_info)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17fa538d-de5b-4c52-be3b-6a935c0c509c",
-   "metadata": {},
-   "source": [
-    "## (Advanced) Combining OCR with a multimodal model\n",
-    "\n",
-    "In more elaborate scenarios, you may want to annotate the images of a document in addition to retrieving the document's text. This is made possible by adding a multimodal model such as `mistral-small-2503` to the mix and have it analyze the image extracted from the OCR operation, making the overall operation a two-step process which takes longer but yields more information on the document's content.\n",
-    "\n",
-    "To make the code more modular you can start by packaging the OCR call into a `call_ocr_model()` function that:\n",
-    "- downloads the document,\n",
-    "- converts it into a base64-encoded string,\n",
-    "- passes that string to the OCR model. We added a `pages` argument to optionally limit the number of pages processed, to shorten processing time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60870ff2-e749-4678-89e4-55912fdbbb95",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from typing import Dict, Any, Optional\n",
-    "\n",
-    "def call_ocr_model(endpoint_url: str, \n",
-    "                   pdf_url: str,\n",
-    "                   with_image_outputs: bool = False,\n",
-    "                   pages: Optional[str]=None,\n",
-    "                   access_token: Optional[str]=None) -> Dict[str, Any]:\n",
-    "    headers = {\n",
-    "        \"Content-Type\": \"application/json\",\n",
-    "        \"Accept\": \"application/json\",\n",
-    "    }\n",
-    "    if access_token:\n",
-    "        headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
-    "    payload = {\n",
-    "        \"model\": f\"{MODEL_NAME}-{MODEL_VERSION}\",\n",
-    "        \"document\": {\n",
-    "            \"type\": \"document_url\",\n",
-    "            \"document_url\": f\"data:application/pdf;base64,{encoded_doc}\",\n",
-    "        },\n",
-    "        \"include_image_base64\": with_image_outputs,\n",
-    "    }\n",
-    "    if pages:\n",
-    "        payload[\"pages\"] = pages\n",
-    "    with httpx.Client() as client:\n",
-    "        ocr_resp = client.post(\n",
-    "            url=endpoint_url, headers=headers, json=payload, timeout=None\n",
-    "        )\n",
-    "        ocr_resp.raise_for_status()\n",
-    "        if ocr_resp.status_code == 200:\n",
-    "            return ocr_resp.json()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "baea9c6b-0aa5-4c5e-a586-b07da6a29932",
-   "metadata": {},
-   "source": [
-    "To illustrate how the system works, you can scan the document pointed at by the `TEST_DOC_URL` URL as such:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "242a3c6d-ab85-4d40-99f6-cf2aadd77d34",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scanned_doc = call_ocr_model(\n",
-    "    endpoint_url=url,\n",
-    "    pdf_url=TEST_DOC_URL,\n",
-    "    pages=\"1-10\",\n",
-    "    with_image_outputs=True,\n",
-    "    access_token=access_token\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6310be20-49bd-4ab7-8fdb-4b889ee07857",
-   "metadata": {},
-   "source": [
-    "Note that `with_image_outputs` is set to `True` because you will want to annotate the figures/images in the documents, so you need to retrieve their base64-encoded representation.\n",
-    "\n",
-    "The next step is to define how the multimodal model will be called to analyze the image content. To do so, you will query another Mistral model available on Vertex AI: `mistral-small-2503`, which can process both text and image inputs. This is a basic system message you can pass to it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68c2762e-76e4-4135-8204-be221f5eb211",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "VLM_NAME = \"mistral-small\"\n",
-    "VLM_VERSION = \"2503\"\n",
-    "\n",
-    "ANNOTATION_SYSTEM_PROMPT = \"\"\"\n",
-    "Your mission is to provide a clear description to each image you will see.\n",
-    "Describe its features and key components.\n",
-    "Return your answer in a well-structured JSON object.\n",
-    "\"\"\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0467bcbc-01e5-4cc1-8afb-f16d385e2713",
-   "metadata": {},
-   "source": [
-    "To ensure that the image annotation will stick to a specific format, you will leverage another feature called _structured outputs_, which enforces strict schema rules when you require JSON output from the model. In practice, you can define your output structure with a Pydantic model, then later convert it into a JSON Schema dictionary when passing it to the API, here is an example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3ef6c0a9-e1dd-438d-a14b-2dd416a8ec55",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pydantic import BaseModel, Field\n",
-    "import json\n",
-    "\n",
-    "class AnnotatedImage(BaseModel):\n",
-    "    short_desc: str = Field(...,\n",
-    "                            description=\"A short one-sentence summary of the image\")\n",
-    "    long_desc: str = Field(...,\n",
-    "                           description=\"A longer detailed description of the image\")\n",
-    "\n",
-    "schema = AnnotatedImage.model_json_schema()\n",
-    "print(json.dumps(schema, indent=4))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4dbec360-8878-4fb4-bf15-8c0c43bcefcc",
-   "metadata": {},
-   "source": [
-    "You can read more about structured outputs in the [Mistral documentation](https://docs.mistral.ai/capabilities/structured-output/custom_structured_output).\n",
-    "\n",
-    "From there, you can write an `annotate_with_vlm_model()` function that will call the multimodal model and pass it a base64-encoded image to retrieve its description in a well-structured format:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40428fe0-ac1d-4f5e-8219-94d98d5b3688",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def annotate_with_vlm_model(endpoint_url: str,\n",
-    "                            annotation_structure: BaseModel,\n",
-    "                            image_base64: str,\n",
-    "                            access_token:Optional[str]=None,\n",
-    "                            debug: bool = False) -> Dict[str,Any]:\n",
-    "    \n",
-    "    # Headers\n",
-    "    headers = {\n",
-    "        \"Content-Type\": \"application/json\",\n",
-    "        \"Accept\": \"application/json\",\n",
-    "    }\n",
-    "    if access_token: # Non-Colab environments only\n",
-    "        headers[\"Authorization\"] = f\"Bearer {access_token}\"\n",
-    "\n",
-    "    # JSON output schema\n",
-    "    annotation_schema = annotation_structure.model_json_schema()\n",
-    "    annotation_schema[\"additionalProperties\"] = False\n",
-    "    payload = {\n",
-    "        \"model\": f\"{VLM_NAME}-{VLM_VERSION}\",\n",
-    "        \"messages\": [\n",
-    "            {\n",
-    "                \"role\": \"system\",\n",
-    "                \"content\": ANNOTATION_SYSTEM_PROMPT\n",
-    "            },\n",
-    "            {\n",
-    "                \"role\": \"user\",\n",
-    "                \"content\": [\n",
-    "                    {\n",
-    "                        \"type\": \"image_url\",\n",
-    "                        \"image_url\": image_base64\n",
-    "                    }\n",
-    "                ]\n",
-    "            }\n",
-    "        ],\n",
-    "        \"response_format\": {\n",
-    "            \"type\": \"json_schema\",\n",
-    "            \"json_schema\": {\n",
-    "                \"schema\": annotation_schema, \n",
-    "                \"name\": \"image_schema\", \n",
-    "                \"strict\": True\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "\n",
-    "    # Request & response\n",
-    "    with httpx.Client() as client:\n",
-    "        vlm_resp = client.post(url=endpoint_url, headers=headers, json=payload, timeout=None)\n",
-    "        vlm_resp.raise_for_status()\n",
-    "        if vlm_resp.status_code == 200:\n",
-    "            vlm_out = vlm_resp.json()\n",
-    "            annotation = json.loads(vlm_out[\"choices\"][0][\"message\"][\"content\"])\n",
-    "        return annotation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4e6d738d-440a-477b-a8d2-cc47272e16a2",
-   "metadata": {},
-   "source": [
-    "You can test your function on a page of the scanned document that contains one or more images:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3b881446-8bcc-4161-a579-7cbb31f57370",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from typing import List\n",
-    "\n",
-    "page_idx = 0\n",
-    "images_b64 = [item[\"image_base64\"] for item in scanned_doc[\"pages\"][page_idx][\"images\"]]\n",
-    "vlm_url = build_endpoint_url(\n",
-    "    model_name=VLM_NAME,\n",
-    "    model_version=VLM_VERSION,\n",
-    "    project_id=PROJECT_ID,\n",
-    "    region=REGION\n",
-    ")\n",
-    "annotations: List[Dict[str, Any]] = []\n",
-    "for imgb64 in images_b64:\n",
-    "    annotations.append(\n",
-    "        annotate_with_vlm_model(\n",
-    "            endpoint_url=vlm_url,\n",
-    "            annotation_structure=AnnotatedImage,\n",
-    "            image_base64=imgb64,\n",
-    "            access_token=access_token\n",
-    "        )\n",
-    "    )\n",
-    "print(f\"Page {page_idx}:\")\n",
-    "print(annotations)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10976165-28df-48d1-ae15-b22e1dbc71a7",
-   "metadata": {},
-   "source": [
-    "Finally, in order to stict everything together, you can run the following code that will edit in-place the `scanned_doc` variable and add a `annotations` field where each detected image will have its description written:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "182f830a-8bda-45a4-a518-d55206352a28",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for idx, page in enumerate(scanned_doc[\"pages\"]):\n",
-    "    annotations: List[Dict[str, Any]] = []\n",
-    "    for img in page[\"images\"]:\n",
-    "        annotations.append(\n",
-    "            {\n",
-    "                \"id\": img[\"id\"],\n",
-    "                \"annotation\": annotate_with_vlm_model(\n",
-    "                    endpoint_url=vlm_url,\n",
-    "                    annotation_structure=AnnotatedImage,\n",
-    "                    image_base64=img[\"image_base64\"],\n",
-    "                    access_token=access_token\n",
-    "                )\n",
-    "            }\n",
-    "        )\n",
-    "    scanned_doc[\"pages\"][idx][\"annotations\"] = annotations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a494332d-bc00-4aaf-a373-1291951b77c4",
-   "metadata": {},
-   "source": [
-    "You can now retrieve both text and image descriptions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "435df5b9-9c53-4971-b3d9-68611ec81f82",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "page_idx = 6\n",
-    "text = scanned_doc[\"pages\"][page_idx][\"markdown\"]\n",
-    "annotations = scanned_doc[\"pages\"][page_idx][\"annotations\"]\n",
-    "print(text)\n",
-    "print(80*\"_\")\n",
-    "print(annotations)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
<br>
This PR adds a new notebook with usage examples for the Mistral OCR 2505 model. It ports the previous code samples from the existing generic notebook to a dedicated new notebook.
<br><br><br>

- [x] Use the [notebook template](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/notebook_template.ipynb) as a starting point.
- [x] Follow the style and grammar rules outlined in the above notebook template.
- [x] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [x] Passes all the required automated checks. You can locally test for formatting and linting with these [instructions](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/CONTRIBUTING.md#code-quality-checks).
- [x] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.

<br>


