### PR TITLE
feat: Add Google Analytics to the docs GitHub Pages site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,5 @@
+# Jekyll configuration for the GitHub Pages site published from this folder.
+#
+# This site uses the GitHub Pages default theme (jekyll-theme-primer), whose
+# layout emits the gtag.js snippet on every page when `google_analytics` is set.
+google_analytics: G-XXXXXXXXXX


### PR DESCRIPTION
Enables Google Analytics on the Pages site published from `docs/` (https://googlecloudplatform.github.io/vertex-ai-samples/).

One new file. The Pages default theme (`jekyll-theme-primer`) already emits the gtag.js snippet when `site.google_analytics` is set, and nothing when it isn't — this just sets that key. No new dependencies, no change to current rendering.

**Draft:** `G-XXXXXXXXXX` is a placeholder pending the real Measurement ID.
