### PR TITLE
fix: correct a typo in error message

### DIFF
--- a/notebooks/official/generative_ai/text_embedding_new_api.ipynb
+++ b/notebooks/official/generative_ai/text_embedding_new_api.ipynb
@@ -348,7 +348,7 @@
         "    \"gemini-embedding-001\",\n",
         "    \"text-multilingual-embedding-002\",\n",
         "]:\n",
-        "    raise ValueError(f\"OUTPUT_DIMENTIONALITY cannot be specified for model '{MODEL}'.\")\n",
+        "    raise ValueError(f\"OUTPUT_DIMENSIONALITY cannot be specified for model '{MODEL}'.\")\n",
         "if TASK in [\"QUESTION_ANSWERING\", \"FACT_VERIFICATION\"] and MODEL not in [\n",
         "    \"text-embedding-005\",\n",
         "    \"text-embedding-004\",\n",


### PR DESCRIPTION
Correct a typo in error message

OUTPUT_DIMENTIONALITY > OUTPUT_DIMENSIONALITY